### PR TITLE
feat(registry): improve search and setup flows

### DIFF
--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -18,7 +18,7 @@ from api.deps import (
     get_effective_agent_permission,
     require_role,
 )
-from api.sanitize import escape_like
+from api.search import keyword_search
 from models.agent import (
     Agent,
     AgentStatus,
@@ -231,9 +231,13 @@ async def list_agents(
 
     base_filter = (AgentVersion.status == AgentStatus.approved) & (Agent.deleted_at.is_(None))
     search_filter = None
+    search_rank = None
     if search:
-        safe = escape_like(search)
-        search_filter = Agent.name.ilike(f"%{safe}%") | AgentVersion.description.ilike(f"%{safe}%")
+        search_filter, search_rank = keyword_search(
+            search,
+            [Agent.name, AgentVersion.description, AgentVersion.model_name],
+            name_field=Agent.name,
+        )
 
     # Org-scoping: when the caller belongs to an org, show agents owned by that org
     # or agents with no org set (legacy/bulk-created agents)
@@ -257,7 +261,10 @@ async def list_agents(
         stmt = stmt.where(search_filter)
     if org_filter is not None:
         stmt = stmt.where(org_filter)
-    result = await db.execute(stmt.order_by(Agent.created_at.desc()).offset(offset).limit(limit))
+    order_by = [Agent.created_at.desc()]
+    if search_rank is not None:
+        order_by.insert(0, search_rank.desc())
+    result = await db.execute(stmt.order_by(*order_by).offset(offset).limit(limit))
     agents = result.scalars().all()
 
     # Batch-fetch average ratings

--- a/observal-server/api/routes/agent/install.py
+++ b/observal-server/api/routes/agent/install.py
@@ -152,6 +152,7 @@ async def install_agent(
         sandbox_listings_map = {row.id: row for row in sandbox_rows}
 
     archived_warnings = []
+    setup_warnings = []
     for item_type, rows in (
         ("MCP", mcp_listings_map.values()),
         ("skill", skill_listings_map.values()),
@@ -162,6 +163,8 @@ async def install_agent(
         for row in rows:
             if row.status == ListingStatus.archived:
                 archived_warnings.append(archived_install_warning(item_type, row.name))
+            if item_type == "MCP" and row.setup_instructions:
+                setup_warnings.append(f"MCP '{row.name}' requires local setup before use:\n{row.setup_instructions}")
 
     # Resolve all component names for rules file content
     name_map = await _resolve_component_names(agent.components, db)
@@ -226,7 +229,7 @@ async def install_agent(
         metadata={"harness": req.harness},
     )
 
-    warnings = archived_warnings + snippet.pop("_warnings", [])
+    warnings = archived_warnings + setup_warnings + snippet.pop("_warnings", [])
     return AgentInstallResponse(
         agent_id=resolved_agent_id, harness=req.harness, config_snippet=snippet, warnings=warnings
     )

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -27,7 +27,7 @@ from api.deps import (
 )
 from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
-from api.sanitize import escape_like
+from api.search import keyword_search
 from models.hook import HookDownload, HookListing, HookVersion
 from models.mcp import ListingStatus
 from models.user import User, UserRole
@@ -119,12 +119,21 @@ async def list_hooks(
         stmt = stmt.where(HookVersion.event == event)
     if scope:
         stmt = stmt.where(HookVersion.scope == scope)
+    search_rank = None
     if search:
-        safe = escape_like(search)
-        stmt = stmt.where(HookListing.name.ilike(f"%{safe}%") | HookVersion.description.ilike(f"%{safe}%"))
+        search_filter, search_rank = keyword_search(
+            search,
+            [HookListing.name, HookVersion.description, HookVersion.event, HookVersion.scope, HookVersion.handler_type],
+            name_field=HookListing.name,
+        )
+        if search_filter is not None:
+            stmt = stmt.where(search_filter)
     stmt = apply_visibility_filter(stmt, HookListing, current_user)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
-    result = await db.execute(stmt.order_by(HookListing.created_at.desc()).limit(limit).offset(offset))
+    order_by = [HookListing.created_at.desc()]
+    if search_rank is not None:
+        order_by.insert(0, search_rank.desc())
+    result = await db.execute(stmt.order_by(*order_by).limit(limit).offset(offset))
     listings = [HookListingSummary.model_validate(r) for r in result.scalars().all()]
     response.headers["X-Total-Count"] = str(total or 0)
     return listings

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -27,7 +27,7 @@ from api.deps import (
 )
 from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
-from api.sanitize import escape_like
+from api.search import keyword_search
 from database import async_session
 from models.mcp import ListingStatus, McpDownload, McpListing, McpValidationResult, McpVersion
 from models.user import User, UserRole
@@ -204,12 +204,27 @@ async def list_mcps(
     )
     if category:
         stmt = stmt.where(McpListing.category == category)
+    search_rank = None
     if search:
-        safe = escape_like(search)
-        stmt = stmt.where(McpListing.name.ilike(f"%{safe}%") | McpVersion.description.ilike(f"%{safe}%"))
+        search_filter, search_rank = keyword_search(
+            search,
+            [
+                McpListing.name,
+                McpListing.category,
+                McpVersion.description,
+                McpVersion.framework,
+                McpVersion.setup_instructions,
+            ],
+            name_field=McpListing.name,
+        )
+        if search_filter is not None:
+            stmt = stmt.where(search_filter)
     stmt = apply_visibility_filter(stmt, McpListing, current_user)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
-    result = await db.execute(stmt.order_by(McpListing.created_at.desc()).limit(limit).offset(offset))
+    order_by = [McpListing.created_at.desc()]
+    if search_rank is not None:
+        order_by.insert(0, search_rank.desc())
+    result = await db.execute(stmt.order_by(*order_by).limit(limit).offset(offset))
     listings = [McpListingSummary.model_validate(r) for r in result.scalars().all()]
     response.headers["X-Total-Count"] = str(total or 0)
     return listings

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -290,6 +290,10 @@ async def install_mcp(
     warnings = []
     if listing.status == ListingStatus.archived:
         warnings.append(archived_install_warning("MCP", listing.name))
+    if listing.setup_instructions:
+        warnings.append(
+            f"MCP '{listing.name}' requires local setup before use:\n{listing.setup_instructions}"
+        )
 
     db.add(McpDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
     latest_version = getattr(listing, "latest_version", None)

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -291,9 +291,7 @@ async def install_mcp(
     if listing.status == ListingStatus.archived:
         warnings.append(archived_install_warning("MCP", listing.name))
     if listing.setup_instructions:
-        warnings.append(
-            f"MCP '{listing.name}' requires local setup before use:\n{listing.setup_instructions}"
-        )
+        warnings.append(f"MCP '{listing.name}' requires local setup before use:\n{listing.setup_instructions}")
 
     db.add(McpDownload(listing_id=listing.id, user_id=current_user.id, harness=req.harness))
     latest_version = getattr(listing, "latest_version", None)

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -27,7 +27,7 @@ from api.deps import (
 )
 from api.routes._component_archive import archive_listing, unarchive_listing
 from api.routes.component_versions import create_version_router
-from api.sanitize import escape_like
+from api.search import keyword_search
 from models.mcp import ListingStatus
 from models.prompt import PromptDownload, PromptListing, PromptVersion
 from models.user import User, UserRole
@@ -107,12 +107,21 @@ async def list_prompts(
     )
     if category:
         stmt = stmt.where(PromptVersion.category == category)
+    search_rank = None
     if search:
-        safe = escape_like(search)
-        stmt = stmt.where(PromptListing.name.ilike(f"%{safe}%") | PromptVersion.description.ilike(f"%{safe}%"))
+        search_filter, search_rank = keyword_search(
+            search,
+            [PromptListing.name, PromptVersion.description, PromptVersion.category, PromptVersion.template],
+            name_field=PromptListing.name,
+        )
+        if search_filter is not None:
+            stmt = stmt.where(search_filter)
     stmt = apply_visibility_filter(stmt, PromptListing, current_user)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
-    result = await db.execute(stmt.order_by(PromptListing.created_at.desc()).limit(limit).offset(offset))
+    order_by = [PromptListing.created_at.desc()]
+    if search_rank is not None:
+        order_by.insert(0, search_rank.desc())
+    result = await db.execute(stmt.order_by(*order_by).limit(limit).offset(offset))
     listings = [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
     response.headers["X-Total-Count"] = str(total or 0)
     return listings

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -26,7 +26,7 @@ from api.deps import (
 )
 from api.routes._component_archive import archive_listing, unarchive_listing
 from api.routes.component_versions import create_version_router
-from api.sanitize import escape_like
+from api.search import keyword_search
 from models.mcp import ListingStatus
 from models.sandbox import SandboxDownload, SandboxListing, SandboxVersion
 from models.user import User, UserRole
@@ -107,12 +107,27 @@ async def list_sandboxes(
     )
     if runtime_type:
         stmt = stmt.where(SandboxVersion.runtime_type == runtime_type)
+    search_rank = None
     if search:
-        safe = escape_like(search)
-        stmt = stmt.where(SandboxListing.name.ilike(f"%{safe}%") | SandboxVersion.description.ilike(f"%{safe}%"))
+        search_filter, search_rank = keyword_search(
+            search,
+            [
+                SandboxListing.name,
+                SandboxVersion.description,
+                SandboxVersion.runtime_type,
+                SandboxVersion.image,
+                SandboxVersion.network_policy,
+            ],
+            name_field=SandboxListing.name,
+        )
+        if search_filter is not None:
+            stmt = stmt.where(search_filter)
     stmt = apply_visibility_filter(stmt, SandboxListing, current_user)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
-    result = await db.execute(stmt.order_by(SandboxListing.created_at.desc()).limit(limit).offset(offset))
+    order_by = [SandboxListing.created_at.desc()]
+    if search_rank is not None:
+        order_by.insert(0, search_rank.desc())
+    result = await db.execute(stmt.order_by(*order_by).limit(limit).offset(offset))
     listings = [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
     response.headers["X-Total-Count"] = str(total or 0)
     return listings

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi_cache.decorator import cache
 from loguru import logger as optic
-from sqlalchemy import func, select
+from sqlalchemy import String, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import services.dynamic_settings as ds
@@ -194,15 +194,16 @@ async def list_skills(
     )
     if task_type:
         stmt = stmt.where(SkillVersion.task_type == task_type)
+    target_agents_text = cast(SkillVersion.target_agents, String)
     if target_agent:
-        target_filter, _ = keyword_search(target_agent, [SkillVersion.target_agents.cast(str)])
+        target_filter, _ = keyword_search(target_agent, [target_agents_text])
         if target_filter is not None:
             stmt = stmt.where(target_filter)
     search_rank = None
     if search:
         search_filter, search_rank = keyword_search(
             search,
-            [SkillListing.name, SkillVersion.description, SkillVersion.task_type, SkillVersion.target_agents.cast(str)],
+            [SkillListing.name, SkillVersion.description, SkillVersion.task_type, target_agents_text],
             name_field=SkillListing.name,
         )
         if search_filter is not None:

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -28,7 +28,7 @@ from api.deps import (
 )
 from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
-from api.sanitize import escape_like
+from api.search import keyword_search
 from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing, SkillVersion
 from models.user import User, UserRole
@@ -195,13 +195,24 @@ async def list_skills(
     if task_type:
         stmt = stmt.where(SkillVersion.task_type == task_type)
     if target_agent:
-        stmt = stmt.where(SkillVersion.target_agents.cast(str).ilike(f"%{escape_like(target_agent)}%"))
+        target_filter, _ = keyword_search(target_agent, [SkillVersion.target_agents.cast(str)])
+        if target_filter is not None:
+            stmt = stmt.where(target_filter)
+    search_rank = None
     if search:
-        safe = escape_like(search)
-        stmt = stmt.where(SkillListing.name.ilike(f"%{safe}%") | SkillVersion.description.ilike(f"%{safe}%"))
+        search_filter, search_rank = keyword_search(
+            search,
+            [SkillListing.name, SkillVersion.description, SkillVersion.task_type, SkillVersion.target_agents.cast(str)],
+            name_field=SkillListing.name,
+        )
+        if search_filter is not None:
+            stmt = stmt.where(search_filter)
     stmt = apply_visibility_filter(stmt, SkillListing, current_user)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
-    result = await db.execute(stmt.order_by(SkillListing.created_at.desc()).limit(limit).offset(offset))
+    order_by = [SkillListing.created_at.desc()]
+    if search_rank is not None:
+        order_by.insert(0, search_rank.desc())
+    result = await db.execute(stmt.order_by(*order_by).limit(limit).offset(offset))
     listings = [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
     response.headers["X-Total-Count"] = str(total or 0)
     return listings

--- a/observal-server/api/search.py
+++ b/observal-server/api/search.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+"""Small keyword search helpers for registry list endpoints."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import case, literal, or_
+
+from api.sanitize import escape_like
+
+_KEEP_TINY = {"ai", "go", "js", "ts", "ui", "ux"}
+_STOP_WORDS = {
+    "about",
+    "agent",
+    "all",
+    "and",
+    "any",
+    "are",
+    "component",
+    "components",
+    "could",
+    "find",
+    "for",
+    "from",
+    "good",
+    "help",
+    "helps",
+    "install",
+    "into",
+    "make",
+    "mcp",
+    "me",
+    "need",
+    "please",
+    "registry",
+    "server",
+    "skill",
+    "skills",
+    "setup",
+    "that",
+    "the",
+    "this",
+    "what",
+    "when",
+    "with",
+    "would",
+    "you",
+}
+
+
+def keyword_tokens(query: str | None) -> list[str]:
+    """Tokenize a natural-ish query into useful search words."""
+    if not query:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in re.findall(r"[a-z0-9][a-z0-9_-]*", query.lower()):
+        token = raw.strip("-_")
+        if token.endswith("s") and len(token) > 4 and not token.endswith("ss"):
+            token = token[:-1]
+        if (len(token) < 3 and token not in _KEEP_TINY) or token in _STOP_WORDS:
+            continue
+        if token not in seen:
+            out.append(token)
+            seen.add(token)
+    return out
+
+
+def keyword_search(query: str | None, fields: Sequence[Any], *, name_field: Any | None = None) -> tuple[Any | None, Any | None]:
+    """Return ``(where_clause, rank_expr)`` for token OR search.
+
+    The rank is intentionally simple: phrase/name hits first, then token hits.
+    """
+    tokens = keyword_tokens(query)
+    if not tokens:
+        return None, None
+
+    phrase = " ".join(tokens)
+    terms = [phrase, *[t for t in tokens if t != phrase]]
+    clauses = [field.ilike(f"%{escape_like(term)}%") for term in terms for field in fields]
+    rank = literal(0)
+
+    if name_field is not None:
+        rank += case((name_field.ilike(f"%{escape_like(phrase)}%"), 100), else_=0)
+    for field in fields:
+        rank += case((field.ilike(f"%{escape_like(phrase)}%"), 40), else_=0)
+    for token in tokens:
+        if name_field is not None:
+            rank += case((name_field.ilike(f"%{escape_like(token)}%"), 12), else_=0)
+        for field in fields:
+            rank += case((field.ilike(f"%{escape_like(token)}%"), 4), else_=0)
+
+    return or_(*clauses), rank

--- a/observal-server/api/search.py
+++ b/observal-server/api/search.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Small keyword search helpers for registry list endpoints."""
@@ -5,8 +6,10 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 from sqlalchemy import case, literal, or_
 

--- a/observal-server/api/search.py
+++ b/observal-server/api/search.py
@@ -73,7 +73,9 @@ def keyword_tokens(query: str | None) -> list[str]:
     return out
 
 
-def keyword_search(query: str | None, fields: Sequence[Any], *, name_field: Any | None = None) -> tuple[Any | None, Any | None]:
+def keyword_search(
+    query: str | None, fields: Sequence[Any], *, name_field: Any | None = None
+) -> tuple[Any | None, Any | None]:
     """Return ``(where_clause, rank_expr)`` for token OR search.
 
     The rank is intentionally simple: phrase/name hits first, then token hits.

--- a/observal-server/services/mcp_validator.py
+++ b/observal-server/services/mcp_validator.py
@@ -17,6 +17,7 @@ from git import Repo
 from loguru import logger as optic
 from observal_shared.mcp_analysis import (
     analyze_python_entry,
+    detect_container_image,
     detect_docker_image,
     detect_env_vars,
     detect_non_python_mcp,
@@ -37,6 +38,7 @@ _is_filtered_env_var = is_filtered_env_var
 _is_test_file = is_test_file
 _detect_env_vars = detect_env_vars
 _detect_docker_image = detect_docker_image
+_detect_container_image = detect_container_image
 _infer_command_args = infer_command_args
 _detect_non_python_mcp = detect_non_python_mcp
 _extract_repo_name = extract_repo_name
@@ -101,6 +103,14 @@ async def _async_clone(clone_url: str, dest: str, depth: int = 1) -> None:
     )
 
 
+def _apply_container_detection(listing: McpListing, tmp_dir: str) -> None:
+    image, _suggested, setup_commands = detect_container_image(Path(tmp_dir), listing.git_url or "", listing.name)
+    if image and not listing.docker_image:
+        listing.docker_image = image
+    if setup_commands and not listing.setup_instructions:
+        listing.setup_instructions = "\n".join(setup_commands)
+
+
 async def run_validation(listing: McpListing, db: AsyncSession):
     optic.trace("running MCP validation for listing {}", listing.id)
     await db.execute(delete(McpValidationResult).where(McpValidationResult.listing_id == listing.id))
@@ -158,9 +168,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
     if entry_point:
         listing.mcp_validated = True
         listing.framework = "python-mcp"
-        docker_image, _ = detect_docker_image(Path(tmp_dir), listing.git_url or "")
-        if docker_image and not listing.docker_image:
-            listing.docker_image = docker_image
+        _apply_container_detection(listing, tmp_dir)
         cmd, cmd_args = infer_command_args(listing.framework, listing.docker_image, listing.name)
         if cmd and not listing.command:
             listing.command = cmd
@@ -184,9 +192,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
     if non_python_framework:
         listing.mcp_validated = True
         listing.framework = non_python_framework
-        docker_image, _ = detect_docker_image(Path(tmp_dir), listing.git_url or "")
-        if docker_image and not listing.docker_image:
-            listing.docker_image = docker_image
+        _apply_container_detection(listing, tmp_dir)
         cmd, cmd_args = infer_command_args(listing.framework, listing.docker_image, listing.name)
         if cmd and not listing.command:
             listing.command = cmd
@@ -207,9 +213,7 @@ async def _clone_and_inspect(listing: McpListing, db: AsyncSession, tmp_dir: str
 
     # No known framework detected - still mark as validated but note unknown framework
     listing.mcp_validated = True
-    docker_image, _ = detect_docker_image(Path(tmp_dir), listing.git_url or "")
-    if docker_image and not listing.docker_image:
-        listing.docker_image = docker_image
+    _apply_container_detection(listing, tmp_dir)
     cmd, cmd_args = infer_command_args(listing.framework, listing.docker_image, listing.name)
     if cmd and not listing.command:
         listing.command = cmd
@@ -377,7 +381,7 @@ async def analyze_repo(git_url: str) -> dict:
             # Try non-Python detection; return repo name as fallback
             non_python = detect_non_python_mcp(tmp_dir)
             name = extract_repo_name(git_url, tmp_dir)
-            docker_image, docker_suggested = detect_docker_image(Path(tmp_dir), git_url)
+            docker_image, docker_suggested, setup_commands = detect_container_image(Path(tmp_dir), git_url, name)
             cmd, cmd_args = infer_command_args(non_python, docker_image, name)
             base: dict = {
                 "name": name,
@@ -391,6 +395,8 @@ async def analyze_repo(git_url: str) -> dict:
             if docker_image:
                 base["docker_image"] = docker_image
                 base["docker_image_suggested"] = docker_suggested
+            if setup_commands:
+                base["setup_instructions"] = "\n".join(setup_commands)
             if cmd:
                 base["command"] = cmd
                 base["args"] = cmd_args
@@ -399,7 +405,7 @@ async def analyze_repo(git_url: str) -> dict:
         tree = ast.parse(entry_point.read_text(errors="ignore"))
         server_name, server_desc, tools, issues = analyze_python_entry(tree, git_url, tmp_dir)
         relative_entry = str(entry_point.relative_to(tmp_dir))
-        docker_image, docker_suggested = detect_docker_image(Path(tmp_dir), git_url)
+        docker_image, docker_suggested, setup_commands = detect_container_image(Path(tmp_dir), git_url, server_name)
         cmd, cmd_args = infer_command_args("python", docker_image, server_name, relative_entry)
         result: dict = {
             "name": server_name,
@@ -412,6 +418,8 @@ async def analyze_repo(git_url: str) -> dict:
         if docker_image:
             result["docker_image"] = docker_image
             result["docker_image_suggested"] = docker_suggested
+        if setup_commands:
+            result["setup_instructions"] = "\n".join(setup_commands)
         if cmd:
             result["command"] = cmd
             result["args"] = cmd_args

--- a/observal_cli/analyzer.py
+++ b/observal_cli/analyzer.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from loguru import logger as optic
 from observal_shared.mcp_analysis import (
     analyze_python_entry,
+    detect_container_image,
     detect_docker_image,
     detect_env_vars,
     detect_non_python_mcp,
@@ -28,6 +29,7 @@ _is_filtered_env_var = is_filtered_env_var
 _is_test_file = is_test_file
 _detect_env_vars = detect_env_vars
 _detect_docker_image = detect_docker_image
+_detect_container_image = detect_container_image
 _infer_command_args = infer_command_args
 _detect_non_python_mcp = detect_non_python_mcp
 _extract_repo_name = extract_repo_name
@@ -64,7 +66,7 @@ def _clone_repo(git_url: str, dest: str) -> str | None:
 def _non_python_result(git_url: str, tmp_dir: str, env_vars: list[dict]) -> dict:
     non_python = detect_non_python_mcp(tmp_dir)
     name = extract_repo_name(git_url, tmp_dir)
-    docker_image, docker_suggested = detect_docker_image(Path(tmp_dir), git_url)
+    docker_image, docker_suggested, setup_commands = detect_container_image(Path(tmp_dir), git_url, name)
     cmd, cmd_args = infer_command_args(non_python, docker_image, name)
     result: dict = {
         "name": name,
@@ -78,6 +80,8 @@ def _non_python_result(git_url: str, tmp_dir: str, env_vars: list[dict]) -> dict
     if docker_image:
         result["docker_image"] = docker_image
         result["docker_image_suggested"] = docker_suggested
+    if setup_commands:
+        result["setup_instructions"] = "\n".join(setup_commands)
     if cmd:
         result["command"] = cmd
         result["args"] = cmd_args
@@ -103,7 +107,7 @@ def analyze_local(git_url: str) -> dict:
         tree = ast.parse(entry_point.read_text(errors="ignore"))
         server_name, server_desc, tools, issues = analyze_python_entry(tree, git_url, tmp_dir)
         relative_entry = str(entry_point.relative_to(tmp_dir))
-        docker_image, docker_suggested = detect_docker_image(Path(tmp_dir), git_url)
+        docker_image, docker_suggested, setup_commands = detect_container_image(Path(tmp_dir), git_url, server_name)
         cmd, cmd_args = infer_command_args("python", docker_image, server_name, relative_entry)
 
         result: dict = {
@@ -118,6 +122,8 @@ def analyze_local(git_url: str) -> dict:
         if docker_image:
             result["docker_image"] = docker_image
             result["docker_image_suggested"] = docker_suggested
+        if setup_commands:
+            result["setup_instructions"] = "\n".join(setup_commands)
         if cmd:
             result["command"] = cmd
             result["args"] = cmd_args

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -772,6 +772,13 @@ def agent_unarchive(
 def agent_init(
     directory: str = typer.Option(".", "--dir", "-d", help="Directory to scaffold in"),
     beta: bool = typer.Option(False, "--beta", help="Start at version 0.1.0 (beta)"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Agent name"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Version"),
+    description: str | None = typer.Option(None, "--description", help="Description"),
+    model_name: str | None = typer.Option(None, "--model", "-m", help="Model name"),
+    prompt: str | None = typer.Option(None, "--prompt", "-p", help="System prompt text"),
+    prompt_file: str | None = typer.Option(None, "--prompt-file", help="Read system prompt from a file"),
+    supported_harnesses: list[str] | None = typer.Option(None, "--harness", help="Supported harness (repeatable)"),
 ):
     """Scaffold an observal-agent.yaml definition file.
 
@@ -792,7 +799,27 @@ def agent_init(
         rprint("[yellow]Aborted.[/yellow]")
         raise typer.Exit(code=1)
 
-    raw_name = text_input("Agent name")
+    default_version = "0.1.0" if beta else "1.0.0"
+    flag_mode = any(x is not None for x in (name, version, description, model_name, prompt, prompt_file, supported_harnesses))
+    if flag_mode:
+        if not name or not description or not (prompt or prompt_file):
+            rprint("[red]Error:[/red] --name, --description, and --prompt or --prompt-file are required")
+            raise typer.Exit(1)
+        raw_name = name
+        prompt_text = prompt or Path(prompt_file).read_text(encoding="utf-8")
+        harnesses = supported_harnesses or list(VALID_HARNESSES)
+        bad_harnesses = [h for h in harnesses if h not in VALID_HARNESSES]
+        if bad_harnesses:
+            rprint(f"[red]Error:[/red] Invalid harness: {bad_harnesses[0]}")
+            raise typer.Exit(1)
+    else:
+        raw_name = text_input("Agent name")
+        version = text_input("Version", default=default_version)
+        description = text_input("Description")
+        model_name = text_input("Model name", default="claude-sonnet-4")
+        prompt_text = text_input("System prompt")
+        harnesses = list(VALID_HARNESSES)
+
     name = _slugify(raw_name)
     if name != raw_name:
         rprint(f"  [dim]→ Slugified to:[/dim] [bold]{name}[/bold]")
@@ -801,24 +828,19 @@ def agent_init(
         rprint(f"[red]Error:[/red] {err}")
         raise typer.Exit(1)
 
-    default_version = "0.1.0" if beta else "1.0.0"
-    version = text_input("Version", default=default_version)
-    description = text_input("Description")
     owner = config.load().get("username", "") or "unknown"
-    model_name = text_input("Model name", default="claude-sonnet-4")
-    prompt_text = text_input("System prompt")
 
     data = {
         "name": name,
-        "version": version,
+        "version": version or default_version,
         "description": description,
         "owner": owner,
-        "model_name": model_name,
+        "model_name": model_name or "claude-sonnet-4",
         # Optional per-harness model overrides, e.g. {"kiro": "claude-haiku-4-5"}.
         # Leave empty to use model_name everywhere that accepts a model choice.
         "models_by_harness": {},
         "prompt": prompt_text,
-        "supported_harnesses": list(VALID_HARNESSES),
+        "supported_harnesses": harnesses,
         "components": [],
     }
 

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -800,7 +800,9 @@ def agent_init(
         raise typer.Exit(code=1)
 
     default_version = "0.1.0" if beta else "1.0.0"
-    flag_mode = any(x is not None for x in (name, version, description, model_name, prompt, prompt_file, supported_harnesses))
+    flag_mode = any(
+        x is not None for x in (name, version, description, model_name, prompt, prompt_file, supported_harnesses)
+    )
     if flag_mode:
         if not name or not description or not (prompt or prompt_file):
             rprint("[red]Error:[/red] --name, --description, and --prompt or --prompt-file are required")

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -15,7 +15,13 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client, config
-from observal_cli.constants import VALID_HOOK_EVENTS, VALID_HOOK_EXECUTION_MODES, VALID_HOOK_HANDLER_TYPES
+from observal_cli.constants import (
+    VALID_HARNESSES,
+    VALID_HOOK_EVENTS,
+    VALID_HOOK_EXECUTION_MODES,
+    VALID_HOOK_HANDLER_TYPES,
+    VALID_HOOK_SCOPES,
+)
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
 
@@ -59,6 +65,17 @@ def hook_submit(
     source_ref: str | None = typer.Option(None, "--source-ref", help="Branch/tag to track (default: main)"),
     source_path: str | None = typer.Option(None, "--source-path", help="Directory within repo containing hook files"),
     requires: list[str] | None = typer.Option(None, "--requires", help="Install prerequisites (repeatable)"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Hook name"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Version (default: 1.0.0)"),
+    description: str | None = typer.Option(None, "--description", "-d", help="Short description"),
+    event: str | None = typer.Option(None, "--event", "-e", help="Hook event"),
+    handler_type: str | None = typer.Option(None, "--handler-type", help="command or http"),
+    handler_command: str | None = typer.Option(None, "--handler-command", help="Command handler"),
+    handler_url: str | None = typer.Option(None, "--handler-url", help="HTTP handler URL"),
+    timeout: int | None = typer.Option(None, "--timeout", help="Timeout seconds"),
+    execution_mode: str | None = typer.Option(None, "--execution-mode", help="async, sync, or blocking"),
+    scope: str | None = typer.Option(None, "--scope", help="agent, session, or global"),
+    supported_harnesses: list[str] | None = typer.Option(None, "--harness", help="Supported harness (repeatable)"),
 ):
     """Submit a new hook for review.
 
@@ -108,45 +125,106 @@ def hook_submit(
             script_content = script_path.read_text()
             script_filename = script_path.name
 
-        # Prompt for essential fields
-        name = text_input("Hook name")
-        version = text_input("Version", default="1.0.0")
-        description = text_input("Description")
-        owner = config.load().get("username", "")
-        event = select_one("Event", VALID_HOOK_EVENTS)
-        handler_type = select_one("Handler type", VALID_HOOK_HANDLER_TYPES)
-
-        # Build handler_config
-        if script_filename and handler_type == "command":
-            # Auto-populate command from script filename
-            timeout = int(text_input("Timeout (seconds)", default="10"))
-            handler_config = {"command": script_filename, "timeout": timeout}
-            rprint(f"[dim]Command auto-set to '{script_filename}' from --script[/dim]")
-        elif handler_type == "command":
-            command = text_input("Command")
-            timeout = int(text_input("Timeout (seconds)", default="10"))
-            handler_config = {"command": command, "timeout": timeout}
+        flag_mode = any(
+            x is not None
+            for x in (
+                name,
+                version,
+                description,
+                event,
+                handler_type,
+                handler_command,
+                handler_url,
+                timeout,
+                execution_mode,
+                scope,
+                supported_harnesses,
+            )
+        )
+        if flag_mode:
+            _handler_type = handler_type or ("http" if handler_url else "command")
+            _execution_mode = execution_mode or "async"
+            _scope = scope or "agent"
+            for value, choices, label in (
+                (event, VALID_HOOK_EVENTS, "event"),
+                (_handler_type, VALID_HOOK_HANDLER_TYPES, "handler type"),
+                (_execution_mode, VALID_HOOK_EXECUTION_MODES, "execution mode"),
+                (_scope, VALID_HOOK_SCOPES, "scope"),
+            ):
+                if value and value not in choices:
+                    rprint(f"[red]Error:[/red] Invalid {label}: {value}")
+                    raise typer.Exit(1)
+            bad_harnesses = [h for h in supported_harnesses or [] if h not in VALID_HARNESSES]
+            if bad_harnesses:
+                rprint(f"[red]Error:[/red] Invalid harness: {bad_harnesses[0]}")
+                raise typer.Exit(1)
+            if not (name and description and event):
+                rprint("[red]Error:[/red] --name, --description, and --event are required without prompts")
+                raise typer.Exit(1)
+            if _handler_type == "http":
+                if not handler_url:
+                    rprint("[red]Error:[/red] --handler-url is required for http hooks")
+                    raise typer.Exit(1)
+                handler_config = {"url": handler_url, "timeout": timeout or 10}
+            else:
+                command = handler_command or script_filename
+                if not command:
+                    rprint("[red]Error:[/red] --handler-command or --script is required for command hooks")
+                    raise typer.Exit(1)
+                handler_config = {"command": command, "timeout": timeout or 10}
+            _validate_timeout(_execution_mode, handler_config)
+            payload: dict = {
+                "name": name,
+                "version": version or "1.0.0",
+                "description": description,
+                "owner": config.load().get("username", ""),
+                "event": event,
+                "handler_type": _handler_type,
+                "handler_config": handler_config,
+                "execution_mode": _execution_mode,
+                "scope": _scope,
+                "supported_harnesses": supported_harnesses or [],
+            }
         else:
-            # HTTP handler
-            url = text_input("Hook URL")
-            timeout = int(text_input("Timeout (seconds)", default="10"))
-            handler_config = {"url": url, "timeout": timeout}
+            # Prompt for essential fields
+            name = text_input("Hook name")
+            version = text_input("Version", default="1.0.0")
+            description = text_input("Description")
+            owner = config.load().get("username", "")
+            event = select_one("Event", VALID_HOOK_EVENTS)
+            handler_type = select_one("Handler type", VALID_HOOK_HANDLER_TYPES)
 
-        execution_mode = select_one("Execution mode", VALID_HOOK_EXECUTION_MODES)
+            # Build handler_config
+            if script_filename and handler_type == "command":
+                # Auto-populate command from script filename
+                timeout = int(text_input("Timeout (seconds)", default="10"))
+                handler_config = {"command": script_filename, "timeout": timeout}
+                rprint(f"[dim]Command auto-set to '{script_filename}' from --script[/dim]")
+            elif handler_type == "command":
+                command = text_input("Command")
+                timeout = int(text_input("Timeout (seconds)", default="10"))
+                handler_config = {"command": command, "timeout": timeout}
+            else:
+                # HTTP handler
+                url = text_input("Hook URL")
+                timeout = int(text_input("Timeout (seconds)", default="10"))
+                handler_config = {"url": url, "timeout": timeout}
 
-        # Validate timeout before sending
-        _validate_timeout(execution_mode, handler_config)
+            execution_mode = select_one("Execution mode", VALID_HOOK_EXECUTION_MODES)
 
-        payload: dict = {
-            "name": name,
-            "version": version,
-            "description": description,
-            "owner": owner,
-            "event": event,
-            "handler_type": handler_type,
-            "handler_config": handler_config,
-            "execution_mode": execution_mode,
-        }
+            # Validate timeout before sending
+            _validate_timeout(execution_mode, handler_config)
+
+            payload = {
+                "name": name,
+                "version": version,
+                "description": description,
+                "owner": owner,
+                "event": event,
+                "handler_type": handler_type,
+                "handler_config": handler_config,
+                "execution_mode": execution_mode,
+            }
 
         # Add optional script/source fields
         if script_content:

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -626,6 +626,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
     detected_args = prefill.get("args")
     detected_docker_image = prefill.get("docker_image")
     detected_docker_suggested = prefill.get("docker_image_suggested", False)
+    detected_setup = prefill.get("setup_instructions", "")
 
     rprint("\n[bold]--- Analysis Results ---[/bold]")
 
@@ -651,6 +652,8 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
             for ev in detected_env_vars:
                 ev_name = ev.get("name", ev) if isinstance(ev, dict) else ev
                 rprint(f"    [cyan]*[/cyan] {ev_name}")
+        if detected_setup:
+            rprint(f"  Setup:        [dim]{detected_setup.splitlines()[0]}[/dim]")
         if not detected_name and not tools:
             rprint("  [dim]No MCP metadata detected. You will need to fill in all fields manually.[/dim]")
 
@@ -723,7 +726,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
         _category = category or "general"
         if not _framework:
             _framework = "python"
-        _setup = ""
+        _setup = detected_setup
         _changelog = "Initial release"
         # Detect $VAR patterns in args and merge into env vars
         dollar_vars = _extract_dollar_vars(_args or [], {})
@@ -819,7 +822,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
 
         _category = category or select_one("Category", VALID_MCP_CATEGORIES, default="general")
 
-        _setup = text_input("Setup instructions (optional, press Enter to skip)", default="")
+        _setup = text_input("Setup instructions (optional, press Enter to skip)", default=detected_setup)
         _changelog = text_input("Changelog", default="Initial release")
 
         # Detect $VAR patterns in final args and merge into detected env vars
@@ -873,6 +876,7 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
             "command": prefill.get("command"),
             "args": prefill.get("args"),
             "docker_image": prefill.get("docker_image"),
+            "setup_instructions": prefill.get("setup_instructions"),
         }
 
     endpoint = "/api/v1/mcps/draft" if draft else "/api/v1/mcps/submit"

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1171,8 +1171,13 @@ def _install_impl(
         rprint(f"\n[dim]Add to:[/dim] [bold]{config_path}[/bold]")
         rprint(f"[dim]Or pipe:[/dim] observal install {mcp_id} --harness {ide} --raw > {config_path}")
 
-    for warning in result.get("warnings") or []:
+    warnings = result.get("warnings") or []
+    for warning in warnings:
         rprint(f"\n[yellow]Warning:[/yellow] {warning}")
+
+    setup = listing.get("setup_instructions")
+    if setup and not any(setup in warning for warning in warnings):
+        rprint(f"\n[yellow]Setup required before use:[/yellow]\n{setup}")
 
     # Warn about any empty env vars the user skipped
     missing = [k for k, v in env_values.items() if not v or v.startswith("<")]

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -509,6 +509,14 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
 
         # Extract dollar-sign input variables before preview
         dollar_vars = parsed.pop("_dollar_vars_detected", None)
+        git_analysis: dict = {}
+        if git_url:
+            with spinner("Checking git repo for local OCI setup..."):
+                git_analysis = analyze_local(git_url)
+            if git_analysis.get("setup_instructions"):
+                rprint("[green]✓[/green] Found local OCI setup instructions from git repo.")
+            elif git_analysis.get("error"):
+                rprint(f"[yellow]Git analysis skipped:[/yellow] {git_analysis['error']}")
 
         rprint("\n[bold]Config preview:[/bold]")
         console.print_json(json.dumps(_build_config_preview(_name, parsed), indent=2))
@@ -556,6 +564,12 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
             "supported_harnesses": supported_harnesses,
             "environment_variables": parsed.get("environment_variables", []),
         }
+        if git_url:
+            submit_payload["git_url"] = git_url
+        if git_analysis.get("setup_instructions"):
+            submit_payload["setup_instructions"] = git_analysis["setup_instructions"]
+        if git_analysis.get("docker_image") and not parsed.get("docker_image"):
+            submit_payload["docker_image"] = git_analysis["docker_image"]
         if parsed.get("command"):
             submit_payload["command"] = parsed["command"]
         if parsed.get("args") is not None:
@@ -572,6 +586,16 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
             submit_payload["framework"] = parsed["framework"]
         if parsed.get("docker_image"):
             submit_payload["docker_image"] = parsed["docker_image"]
+        if git_analysis and not git_analysis.get("error"):
+            submit_payload["client_analysis"] = {
+                "tools": git_analysis.get("tools", []),
+                "issues": git_analysis.get("issues", []),
+                "framework": git_analysis.get("framework", ""),
+                "entry_point": git_analysis.get("entry_point", ""),
+                "command": git_analysis.get("command"),
+                "args": git_analysis.get("args"),
+                "docker_image": git_analysis.get("docker_image"),
+            }
 
         endpoint = "/api/v1/mcps/draft" if draft else "/api/v1/mcps/submit"
         label = "Saving draft..." if draft else "Submitting..."
@@ -1177,20 +1201,20 @@ def _delete_impl(mcp_id, yes):
 
 @mcp_app.command()
 def submit(
-    git_url: str = typer.Option(None, "--git", "-g", help="Analyze a git repository instead of pasting config"),
+    git_url: str = typer.Option(None, "--git", "-g", help="Optional git repo for local OCI setup detection"),
     name: str = typer.Option(None, "--name", "-n", help="Skip name prompt"),
     category: str = typer.Option(None, "--category", "-c", help="Skip category prompt"),
-    yes: bool = typer.Option(False, "--yes", "-y", help="Accept defaults from repo analysis"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Accept JSON-derived defaults"),
     config: bool = typer.Option(False, "--config", hidden=True, help="(deprecated) JSON paste is now the default"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (MCP ID)"),
 ):
     """Submit an MCP server to the registry.
 
-    By default, opens an interactive JSON paste prompt where you provide
-    the same config format used in your harness (e.g. mcpServers block). Use
-    --git to analyze a git repository instead, which auto-detects tools,
-    env vars, and startup commands.
+    Opens a JSON paste prompt where you provide the same config format used
+    in your harness (e.g. mcpServers block). Optionally pass --git so Observal
+    clones the repo and detects local OCI setup instructions for Dockerfile,
+    Containerfile, or compose build MCPs.
 
     Only submit servers you created or are the point-of-contact for.
     Submissions go into a pending review queue unless saved as a draft.
@@ -1203,11 +1227,11 @@ def submit(
         # Interactive JSON paste (default)
         observal registry mcp submit
 
-        # Analyze a git repo with all defaults accepted
+        # Paste JSON and attach a git repo for local OCI setup hints
         observal registry mcp submit --git https://github.com/org/mcp-server --yes
 
         # Submit with name and category pre-filled
-        observal registry mcp submit --git https://github.com/org/server -n my-server -c ai
+        observal registry mcp submit --git https://github.com/org/server -n my-server -c developer-tools
 
         # Save as draft for later editing
         observal registry mcp submit --draft
@@ -1231,9 +1255,7 @@ def submit(
     if config:
         rprint("[dim]Note: --config is now the default. You can just run `observal mcp submit`.[/dim]")
     rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
-    # Default is JSON paste (direct_config=True), unless --git is provided
-    direct_config = not git_url
-    _submit_impl(git_url, name, category, yes, direct_config, draft=draft)
+    _submit_impl(git_url, name, category, yes, direct_config=True, draft=draft)
 
 
 @mcp_app.command(name="list")

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -32,6 +32,11 @@ def prompt_submit(
     from_file: str | None = typer.Option(
         None, "--from-file", "-f", help="Create from JSON file or read template from file"
     ),
+    name: str | None = typer.Option(None, "--name", "-n", help="Prompt name"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Version (default: 1.0.0)"),
+    description: str | None = typer.Option(None, "--description", "-d", help="Short description"),
+    category: str | None = typer.Option(None, "--category", "-c", help="Prompt category"),
+    template: str | None = typer.Option(None, "--template", "-t", help="Template body"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (prompt ID)"),
 ):
@@ -62,6 +67,7 @@ def prompt_submit(
         rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
         return
 
+    flag_mode = any(x is not None for x in (name, version, description, category, template))
     if from_file:
         with open(from_file) as f:
             content = f.read()
@@ -70,14 +76,33 @@ def prompt_submit(
             if not payload.get("owner"):
                 payload["owner"] = config.load().get("username", "")
         except _json.JSONDecodeError:
-            payload = {
-                "name": text_input("Prompt name"),
-                "version": text_input("Version", default="1.0.0"),
-                "description": text_input("Description"),
-                "owner": config.load().get("username", ""),
-                "category": select_one("Category", VALID_PROMPT_CATEGORIES),
-                "template": content,
-            }
+            if flag_mode:
+                payload = {
+                    "name": name,
+                    "version": version or "1.0.0",
+                    "description": description,
+                    "owner": config.load().get("username", ""),
+                    "category": category or "general",
+                    "template": template or content,
+                }
+            else:
+                payload = {
+                    "name": text_input("Prompt name"),
+                    "version": text_input("Version", default="1.0.0"),
+                    "description": text_input("Description"),
+                    "owner": config.load().get("username", ""),
+                    "category": select_one("Category", VALID_PROMPT_CATEGORIES),
+                    "template": content,
+                }
+    elif flag_mode:
+        payload = {
+            "name": name,
+            "version": version or "1.0.0",
+            "description": description,
+            "owner": config.load().get("username", ""),
+            "category": category or "general",
+            "template": template,
+        }
     else:
         payload = {
             "name": text_input("Prompt name"),
@@ -87,6 +112,13 @@ def prompt_submit(
             "category": select_one("Category", VALID_PROMPT_CATEGORIES),
             "template": text_input("Template"),
         }
+    if flag_mode:
+        if not (payload.get("name") and payload.get("description") and payload.get("template")):
+            rprint("[red]Error:[/red] --name, --description, and --template or --from-file are required")
+            raise typer.Exit(1)
+        if payload.get("category") not in VALID_PROMPT_CATEGORIES:
+            rprint(f"[red]Error:[/red] Invalid category: {payload.get('category')}")
+            raise typer.Exit(1)
 
     if draft:
         with spinner("Saving draft..."):

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -15,7 +15,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client, config
-from observal_cli.constants import VALID_SANDBOX_RUNTIME_TYPES
+from observal_cli.constants import VALID_HARNESSES, VALID_SANDBOX_NETWORK_POLICIES, VALID_SANDBOX_RUNTIME_TYPES
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
 
@@ -29,6 +29,18 @@ def register_sandbox(app: typer.Typer):
 @sandbox_app.command(name="submit")
 def sandbox_submit(
     from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Sandbox name"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Version (default: 1.0.0)"),
+    description: str | None = typer.Option(None, "--description", "-d", help="Short description"),
+    runtime_type: str | None = typer.Option(None, "--runtime-type", "-r", help="Runtime type"),
+    image: str | None = typer.Option(None, "--image", "-i", help="Container image"),
+    resource_limits: str | None = typer.Option(None, "--resource-limits", help="Resource limits JSON"),
+    network_policy: str | None = typer.Option(None, "--network-policy", help="Network policy"),
+    entrypoint: str | None = typer.Option(None, "--entrypoint", help="Default entrypoint"),
+    supported_harnesses: list[str] | None = typer.Option(None, "--harness", help="Supported harness (repeatable)"),
+    source_url: str | None = typer.Option(None, "--source-url", help="Source repository URL"),
+    source_ref: str | None = typer.Option(None, "--source-ref", help="Source branch/tag"),
+    sandbox_path: str | None = typer.Option(None, "--sandbox-path", help="Path in source repo"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (sandbox ID)"),
 ):
@@ -59,6 +71,23 @@ def sandbox_submit(
         rprint(f"[green]✓ Draft submitted for review![/green] ID: [bold]{result['id']}[/bold]")
         return
 
+    flag_mode = any(
+        x is not None
+        for x in (
+            name,
+            version,
+            description,
+            runtime_type,
+            image,
+            resource_limits,
+            network_policy,
+            entrypoint,
+            supported_harnesses,
+            source_url,
+            source_ref,
+            sandbox_path,
+        )
+    )
     if from_file:
         try:
             with open(from_file) as f:
@@ -71,6 +100,31 @@ def sandbox_submit(
             raise typer.Exit(code=1)
         if not payload.get("owner"):
             payload["owner"] = config.load().get("username", "")
+    elif flag_mode:
+        try:
+            limits = _json.loads(resource_limits or "{}")
+        except _json.JSONDecodeError as e:
+            rprint(f"[red]Invalid --resource-limits JSON:[/red] {e}")
+            raise typer.Exit(1)
+        payload = {
+            "name": name,
+            "version": version or "1.0.0",
+            "description": description,
+            "owner": config.load().get("username", ""),
+            "runtime_type": runtime_type,
+            "image": image,
+            "resource_limits": limits,
+            "network_policy": network_policy or "none",
+            "supported_harnesses": supported_harnesses or [],
+        }
+        if entrypoint:
+            payload["entrypoint"] = entrypoint
+        if source_url:
+            payload["source_url"] = source_url
+        if source_ref:
+            payload["source_ref"] = source_ref
+        if sandbox_path:
+            payload["sandbox_path"] = sandbox_path
     else:
         payload = {
             "name": text_input("Sandbox name"),
@@ -81,6 +135,20 @@ def sandbox_submit(
             "image": text_input("Image"),
             "resource_limits": _json.loads(text_input("Resource limits (JSON)")),
         }
+    if flag_mode:
+        if not (payload.get("name") and payload.get("description") and payload.get("runtime_type") and payload.get("image")):
+            rprint("[red]Error:[/red] --name, --description, --runtime-type, and --image are required")
+            raise typer.Exit(1)
+        if payload.get("runtime_type") not in VALID_SANDBOX_RUNTIME_TYPES:
+            rprint(f"[red]Error:[/red] Invalid runtime type: {payload.get('runtime_type')}")
+            raise typer.Exit(1)
+        if payload.get("network_policy") not in VALID_SANDBOX_NETWORK_POLICIES:
+            rprint(f"[red]Error:[/red] Invalid network policy: {payload.get('network_policy')}")
+            raise typer.Exit(1)
+        bad_harnesses = [h for h in payload.get("supported_harnesses", []) if h not in VALID_HARNESSES]
+        if bad_harnesses:
+            rprint(f"[red]Error:[/red] Invalid harness: {bad_harnesses[0]}")
+            raise typer.Exit(1)
 
     if draft:
         with spinner("Saving draft..."):

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -136,7 +136,9 @@ def sandbox_submit(
             "resource_limits": _json.loads(text_input("Resource limits (JSON)")),
         }
     if flag_mode:
-        if not (payload.get("name") and payload.get("description") and payload.get("runtime_type") and payload.get("image")):
+        if not (
+            payload.get("name") and payload.get("description") and payload.get("runtime_type") and payload.get("image")
+        ):
             rprint("[red]Error:[/red] --name, --description, --runtime-type, and --image are required")
             raise typer.Exit(1)
         if payload.get("runtime_type") not in VALID_SANDBOX_RUNTIME_TYPES:

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -76,6 +76,14 @@ def skill_submit(
     git_ref: str | None = typer.Option(None, "--git-ref", help="Branch or tag (default: main)"),
     script: str | None = typer.Option(None, "--script", help="Path to script file (registry_direct mode)"),
     delivery_mode: str | None = typer.Option(None, "--delivery-mode", help="Delivery: git_fetch or registry_direct"),
+    name: str | None = typer.Option(None, "--name", "-n", help="Skill name"),
+    version: str | None = typer.Option(None, "--version", "-v", help="Version (default: 1.0.0)"),
+    description: str | None = typer.Option(None, "--description", "-d", help="Short description"),
+    task_type: str | None = typer.Option(None, "--task-type", "-t", help="Task type"),
+    target_agent: list[str] | None = typer.Option(None, "--target-agent", help="Target agent (repeatable)"),
+    skill_path: str | None = typer.Option(None, "--skill-path", help="Skill path in repo"),
+    slash_command: str | None = typer.Option(None, "--slash-command", help="Slash command name"),
+    supported_harnesses: list[str] | None = typer.Option(None, "--harness", help="Supported harness (repeatable)"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (skill ID)"),
 ):
@@ -168,22 +176,49 @@ def skill_submit(
             "registry_direct" if (skill_md_content and not git_url) else "git_fetch"
         )
 
-        agents_input = text_input("Target agents (comma-separated)", default="")
-        payload = {
-            "name": text_input("Skill name", default=prefill.get("name", "")),
-            "version": text_input("Version", default="1.0.0"),
-            "description": text_input("Description", default=prefill.get("description", "")),
-            "owner": config.load().get("username", ""),
-            "task_type": select_one("Task type", VALID_SKILL_TASK_TYPES),
-            "target_agents": [a.strip() for a in agents_input.split(",") if a.strip()],
-            "delivery_mode": effective_delivery_mode,
-        }
+        flag_mode = any(
+            x is not None
+            for x in (name, version, description, task_type, skill_path, slash_command, supported_harnesses)
+        ) or bool(target_agent)
+        if flag_mode:
+            _name = name or prefill.get("name", "")
+            _description = description or prefill.get("description", "")
+            if not _name or not _description:
+                rprint("[red]Error:[/red] --name and --description are required without interactive prompts")
+                raise typer.Exit(1)
+            payload = {
+                "name": _name,
+                "version": version or "1.0.0",
+                "description": _description,
+                "owner": config.load().get("username", ""),
+                "task_type": task_type or "general",
+                "target_agents": target_agent or [],
+                "delivery_mode": effective_delivery_mode,
+                "supported_harnesses": supported_harnesses or [],
+            }
+            if payload["task_type"] not in VALID_SKILL_TASK_TYPES:
+                rprint(f"[red]Error:[/red] Invalid task type: {payload['task_type']}")
+                raise typer.Exit(1)
+        else:
+            agents_input = text_input("Target agents (comma-separated)", default="")
+            payload = {
+                "name": text_input("Skill name", default=prefill.get("name", "")),
+                "version": text_input("Version", default="1.0.0"),
+                "description": text_input("Description", default=prefill.get("description", "")),
+                "owner": config.load().get("username", ""),
+                "task_type": select_one("Task type", VALID_SKILL_TASK_TYPES),
+                "target_agents": [a.strip() for a in agents_input.split(",") if a.strip()],
+                "delivery_mode": effective_delivery_mode,
+            }
         if effective_delivery_mode == "git_fetch":
+            if flag_mode and not git_url:
+                rprint("[red]Error:[/red] --git-url is required for git_fetch skills")
+                raise typer.Exit(1)
             payload["git_url"] = git_url or text_input("Git URL")
-            payload["skill_path"] = text_input("Skill path in repo", default="/")
-            payload["git_ref"] = git_ref or text_input("Git ref (branch/tag)", default="main")
-        if prefill.get("slash_command"):
-            payload["slash_command"] = prefill["slash_command"]
+            payload["skill_path"] = skill_path or ("/" if flag_mode else text_input("Skill path in repo", default="/"))
+            payload["git_ref"] = git_ref or ("main" if flag_mode else text_input("Git ref (branch/tag)", default="main"))
+        if slash_command or prefill.get("slash_command"):
+            payload["slash_command"] = slash_command or prefill["slash_command"]
         if skill_md_content:
             payload["skill_md_content"] = skill_md_content
         if script_content:

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -216,7 +216,9 @@ def skill_submit(
                 raise typer.Exit(1)
             payload["git_url"] = git_url or text_input("Git URL")
             payload["skill_path"] = skill_path or ("/" if flag_mode else text_input("Skill path in repo", default="/"))
-            payload["git_ref"] = git_ref or ("main" if flag_mode else text_input("Git ref (branch/tag)", default="main"))
+            payload["git_ref"] = git_ref or (
+                "main" if flag_mode else text_input("Git ref (branch/tag)", default="main")
+            )
         if slash_command or prefill.get("slash_command"):
             payload["slash_command"] = slash_command or prefill["slash_command"]
         if skill_md_content:

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -93,12 +93,15 @@ Goes through review queue. Use for "new version", "bump", or "release".
 
 ## Procedure: Author Agent Locally
 
-1. Scaffold (interactive):
+1. Scaffold with flags (no YAML hand-writing):
    ```bash
-   observal agent init --dir ./my-agent
+   observal agent init --dir ./my-agent --name AGENT_NAME --description 'Short description' --prompt 'System prompt' --model claude-sonnet-4 --harness kiro --harness claude-code
    ```
-2. Add components (second arg is UUID, find with `observal registry mcp show NAME --output json`):
+   Use `--prompt-file ./PROMPT.md` for long prompts. Omit flags only when the user wants the wizard.
+2. Find components, then add by UUID:
    ```bash
+   observal registry mcp list --search 'github docker' --output json
+   observal registry skill list --search 'frontend design' --output json
    observal agent add mcp COMPONENT_UUID --dir ./my-agent
    observal agent add skill COMPONENT_UUID --dir ./my-agent
    ```
@@ -132,6 +135,7 @@ observal agent unarchive AGENT_NAME --yes
 
 ```bash
 observal agent list --output json
+observal agent list --search 'incident resolution' --output json
 observal agent list --search keyword --output json
 observal agent list --page 2 --limit 20 --output json
 observal agent my --output json

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -22,8 +22,11 @@ owner: observal
 
 ## Procedure: Browse Registry
 
+Use natural-language keywords with `--search`; do not require exact whole-query matches.
+
 ```bash
 observal registry mcp list --category developer-tools --output json
+observal registry skill list --search 'frontend design' --output json
 observal registry skill list --task-type code-review --output json
 observal registry hook list --event UserPromptSubmit --output json
 observal registry prompt list --category coding --output json
@@ -53,7 +56,7 @@ After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--intera
 observal registry mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
 ```
 
-Without `--git`, opens interactive JSON paste (accepts harness config block, named config, bare config, or HTTP transport JSON). Press Enter on empty line to submit.
+`--git` clones locally and detects Python/TS/Go MCPs, env vars, Docker/OCI images, Dockerfile/Containerfile, and compose `build:`. If a local image must be built, follow the returned setup instructions (for example `docker build -t name:latest .`). Without `--git`, paste JSON config.
 
 ### Skill
 
@@ -61,14 +64,13 @@ There are two delivery modes for skills:
 
 **Git-based** (server validates SKILL.md from repo, recommended for open-source):
 ```bash
-observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main
+observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main --name my-skill --description 'What it does' --task-type general
 ```
 
 **Registry direct** (inline SKILL.md + optional script, no git repo needed):
 ```bash
-observal registry skill submit --skill-md ./SKILL.md --delivery-mode registry_direct
-observal registry skill submit --skill-md ./SKILL.md --script ./run.sh --delivery-mode registry_direct
-observal registry skill submit --skill-md ./SKILL.md --script ./scripts/lint.sh --script ./scripts/test.sh --delivery-mode registry_direct
+observal registry skill submit --skill-md ./SKILL.md --delivery-mode registry_direct --name my-skill --description 'What it does' --task-type general --harness claude-code
+observal registry skill submit --skill-md ./SKILL.md --script ./run.sh --delivery-mode registry_direct --name my-skill --description 'What it does' --task-type general
 ```
 
 On install, registry_direct skills write `<skill-name>/SKILL.md` and `<skill-name>/scripts/<filename>` into the harness skills directory.
@@ -80,16 +82,11 @@ On install, registry_direct skills write `<skill-name>/SKILL.md` and `<skill-nam
 ### Hook
 
 ```bash
-observal registry hook submit --from-file hook.json
-observal registry hook submit   # interactive
-```
-
-**With a script (inline or file):**
-```bash
+observal registry hook submit --name guard --description 'Guard prompts' --event UserPromptSubmit --handler-command './guard.sh' --execution-mode sync --timeout 10 --scope agent --harness claude-code
 observal registry hook submit --from-file hook.json --script ./pre-commit.sh
 ```
 
-Optional: `--script 'code'`, `--source-url URL --source-ref main`, `--requires dep1 --requires dep2`. Timeout caps: blocking 30s, sync 10s, async 60s.
+Optional: `--source-url URL --source-ref main`, `--requires dep1 --requires dep2`. Timeout caps: blocking 30s, sync 10s, async 60s.
 
 **Hook events:** `Start`, `Stop`, `UserPromptSubmit`, `SubagentComplete`, `ToolResult`, `Error`
 **Execution modes:** `blocking` (waits for completion), `sync` (waits, shorter timeout), `async` (fire and forget)
@@ -98,12 +95,14 @@ Optional: `--script 'code'`, `--source-url URL --source-ref main`, `--requires d
 ### Prompt
 
 ```bash
+observal registry prompt submit --name frontend-brief --description 'Frontend design brief' --category general --template 'Design {{component}} accessibly'
 observal registry prompt submit --from-file prompt.json
 ```
 
 ### Sandbox
 
 ```bash
+observal registry sandbox submit --name node-runner --description 'Node sandbox' --runtime-type docker --image node:22-alpine --resource-limits '{"memory_mb":512}' --network-policy none --entrypoint node --harness claude-code
 observal registry sandbox submit --from-file sandbox.json
 ```
 

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -59,7 +59,7 @@ observal registry mcp submit --name my-mcp --category developer-tools --yes
 observal registry mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
 ```
 
-The command still expects pasted JSON. If a local image must be built, follow the returned setup instructions, for example `docker build -t name:latest .`.
+The command still expects pasted JSON. If a local image must be built, follow the returned setup instructions, for example `docker build -t name:latest .`. Manual installs also print these setup instructions before the MCP can be used.
 
 ### Skill
 

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -14,7 +14,7 @@ owner: observal
 
 1. **EXECUTE commands**: run them in your shell. Set timeout to 60 seconds.
 2. **Pass `--output json`** on list/show commands.
-3. **Pass `--yes`** on destructive commands (`archive`, `unarchive`, `delete`, `submit --git`).
+3. **Pass `--yes`** on destructive commands (`archive`, `unarchive`, `delete`) and MCP JSON submit when defaults are acceptable.
 4. **When in doubt about a flag, run `<command> --help` first.**
 5. **`--from-file` does NOT exist on `mcp submit`**: that flag is on `mcp edit`.
 
@@ -50,13 +50,16 @@ After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--intera
 
 ## Procedure: Submit Component
 
-### MCP (from git, recommended)
+### MCP
+
+Paste the MCP JSON config. Optionally include `--git` so Observal clones the repo and detects local OCI setup for Dockerfile, Containerfile, or compose `build:`.
 
 ```bash
+observal registry mcp submit --name my-mcp --category developer-tools --yes
 observal registry mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
 ```
 
-`--git` clones locally and detects Python/TS/Go MCPs, env vars, Docker/OCI images, Dockerfile/Containerfile, and compose `build:`. If a local image must be built, follow the returned setup instructions (for example `docker build -t name:latest .`). Without `--git`, paste JSON config.
+The command still expects pasted JSON. If a local image must be built, follow the returned setup instructions, for example `docker build -t name:latest .`.
 
 ### Skill
 
@@ -198,7 +201,7 @@ observal registry hook co-authors remove <id-or-name> <user-uuid>
 
 | Error | Fix |
 |-------|-----|
-| `--from-file` not on `mcp submit` | Use `--git`, `--draft`, or interactive paste |
+| `--from-file` not on `mcp submit` | Paste JSON, optionally with `--git`, or use `--draft` |
 | `412 Edit lock held` | Wait a few minutes, retry |
 | Hook `timeout` | Caps: blocking 30s, sync 10s, async 60s |
 

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -26,9 +26,21 @@ owner: observal
 
 ---
 
+## Procedure: Natural-Language Registry Search
+
+For requests like "find me an agent for incident resolution" or "what skill helps design good frontends", extract the useful keywords and search JSON first.
+
+```bash
+observal agent list --search 'incident resolution' --output json
+observal registry skill list --search 'frontend design' --output json
+observal registry mcp list --search 'github docker' --output json
+```
+
+Summarize the top matches by name, description, and why they fit. If no results, retry with fewer keywords.
+
 ## Procedure: Pull Agent
 
-Install an agent's full config (rules, MCP servers, hooks, skills) into a local harness.
+Install an agent's full config (rules, MCP servers, hooks, skills, sandboxes, prompts) into a local harness.
 
 ```bash
 observal agent pull AGENT_NAME --harness kiro --no-prompt --dir .
@@ -50,7 +62,13 @@ observal agent pull AGENT_NAME --harness kiro --no-prompt --dir .
 
 **Version pinning:** When `--version` is specified, the exact content from that version is installed. The lockfile (`~/.observal/lockfile.json`) records the pin. If another agent depends on the same component at a different version, a warning is displayed.
 
-If the user did not specify an harness, ask which one before running.
+If the user did not specify an harness, ask which one before running. After install, check local files:
+
+```bash
+observal scan --harness kiro
+```
+
+`scan` verifies MCPs, skills, hooks, and agents. Prompts/sandboxes are injected into rules/MCP config; use the pull output/lockfile for membership.
 
 ---
 

--- a/observal_cli/tests/test_cmd_agent_init_flags.py
+++ b/observal_cli/tests/test_cmd_agent_init_flags.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from __future__ import annotations

--- a/observal_cli/tests/test_cmd_agent_init_flags.py
+++ b/observal_cli/tests/test_cmd_agent_init_flags.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import yaml
+from typer.testing import CliRunner
+
+from observal_cli.main import app
+
+runner = CliRunner()
+
+
+def test_agent_init_flags_write_yaml(tmp_path):
+    target = tmp_path / "agent"
+
+    with patch("observal_cli.config.load", return_value={"username": "me"}):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "init",
+                "--dir",
+                str(target),
+                "--name",
+                "Incident Helper",
+                "--version",
+                "1.2.3",
+                "--description",
+                "Resolves incidents",
+                "--model",
+                "claude-sonnet-4",
+                "--prompt",
+                "Handle incident response.",
+                "--harness",
+                "kiro",
+                "--harness",
+                "claude-code",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    data = yaml.safe_load((target / "observal-agent.yaml").read_text())
+    assert data["name"] == "incident-helper"
+    assert data["version"] == "1.2.3"
+    assert data["prompt"] == "Handle incident response."
+    assert data["supported_harnesses"] == ["kiro", "claude-code"]
+
+
+def test_agent_init_prompt_file(tmp_path):
+    target = tmp_path / "agent"
+    prompt = tmp_path / "PROMPT.md"
+    prompt.write_text("Design good frontends.", encoding="utf-8")
+
+    with patch("observal_cli.config.load", return_value={"username": "me"}):
+        result = runner.invoke(
+            app,
+            [
+                "agent",
+                "init",
+                "--dir",
+                str(target),
+                "--name",
+                "frontend-agent",
+                "--description",
+                "Frontend design",
+                "--prompt-file",
+                str(prompt),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    data = yaml.safe_load((target / "observal-agent.yaml").read_text())
+    assert data["prompt"] == "Design good frontends."

--- a/observal_cli/tests/test_cmd_component_submit_flags.py
+++ b/observal_cli/tests/test_cmd_component_submit_flags.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from __future__ import annotations

--- a/observal_cli/tests/test_cmd_component_submit_flags.py
+++ b/observal_cli/tests/test_cmd_component_submit_flags.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from observal_cli.main import app
+
+runner = CliRunner()
+
+
+def test_skill_submit_flags_post_payload(tmp_path):
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text("---\nname: frontend-helper\ndescription: Helps frontends\n---\n\nUse design systems.\n")
+
+    with (
+        patch("observal_cli.config.load", return_value={"username": "me"}),
+        patch("observal_cli.client.post", return_value={"id": "skill-1", "validated": True}) as post,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "registry",
+                "skill",
+                "submit",
+                "--skill-md",
+                str(skill_md),
+                "--delivery-mode",
+                "registry_direct",
+                "--name",
+                "frontend-helper",
+                "--description",
+                "Helps frontends",
+                "--task-type",
+                "general",
+                "--target-agent",
+                "designer",
+                "--harness",
+                "claude-code",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert post.call_args[0][0] == "/api/v1/skills/submit"
+    payload = post.call_args[0][1]
+    assert payload["name"] == "frontend-helper"
+    assert payload["target_agents"] == ["designer"]
+    assert payload["supported_harnesses"] == ["claude-code"]
+    assert payload["delivery_mode"] == "registry_direct"
+
+
+def test_hook_submit_flags_post_payload():
+    with (
+        patch("observal_cli.config.load", return_value={"username": "me"}),
+        patch("observal_cli.client.post", return_value={"id": "hook-1"}) as post,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "registry",
+                "hook",
+                "submit",
+                "--name",
+                "guard",
+                "--description",
+                "Guard files",
+                "--event",
+                "UserPromptSubmit",
+                "--handler-command",
+                "./guard.sh",
+                "--timeout",
+                "5",
+                "--execution-mode",
+                "sync",
+                "--scope",
+                "agent",
+                "--harness",
+                "kiro",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = post.call_args[0][1]
+    assert payload["handler_type"] == "command"
+    assert payload["handler_config"] == {"command": "./guard.sh", "timeout": 5}
+    assert payload["execution_mode"] == "sync"
+    assert payload["supported_harnesses"] == ["kiro"]
+
+
+def test_prompt_submit_flags_post_payload():
+    with (
+        patch("observal_cli.config.load", return_value={"username": "me"}),
+        patch("observal_cli.client.post", return_value={"id": "prompt-1"}) as post,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "registry",
+                "prompt",
+                "submit",
+                "--name",
+                "frontend-brief",
+                "--description",
+                "Frontend design brief",
+                "--category",
+                "general",
+                "--template",
+                "Design {{component}} accessibly",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = post.call_args[0][1]
+    assert payload["name"] == "frontend-brief"
+    assert payload["template"] == "Design {{component}} accessibly"
+
+
+def test_sandbox_submit_flags_post_payload():
+    with (
+        patch("observal_cli.config.load", return_value={"username": "me"}),
+        patch("observal_cli.client.post", return_value={"id": "sandbox-1"}) as post,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "registry",
+                "sandbox",
+                "submit",
+                "--name",
+                "node-runner",
+                "--description",
+                "Node sandbox",
+                "--runtime-type",
+                "docker",
+                "--image",
+                "node:22-alpine",
+                "--resource-limits",
+                '{"memory_mb": 512}',
+                "--network-policy",
+                "none",
+                "--entrypoint",
+                "node",
+                "--harness",
+                "claude-code",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = post.call_args[0][1]
+    assert payload["image"] == "node:22-alpine"
+    assert payload["resource_limits"] == {"memory_mb": 512}
+    assert payload["entrypoint"] == "node"
+    assert payload["supported_harnesses"] == ["claude-code"]

--- a/observal_cli/tests/test_cmd_mcp_submit_json_git.py
+++ b/observal_cli/tests/test_cmd_mcp_submit_json_git.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from observal_cli.main import app
+
+runner = CliRunner()
+
+
+def test_mcp_submit_git_keeps_json_paste_required():
+    config = {
+        "mcpServers": {
+            "local-mcp": {
+                "command": "docker",
+                "args": ["run", "-i", "--rm", "local-mcp:latest"],
+            }
+        }
+    }
+
+    with (
+        patch("observal_cli.config.load", return_value={"username": "me"}),
+        patch(
+            "observal_cli.cmd_mcp.analyze_local",
+            return_value={
+                "name": "local-mcp",
+                "version": "0.1.0",
+                "tools": [],
+                "docker_image": "local-mcp:latest",
+                "setup_instructions": "docker build -t local-mcp:latest .",
+            },
+        ),
+        patch("observal_cli.client.post", return_value={"id": "mcp-1", "status": "pending"}) as post,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "registry",
+                "mcp",
+                "submit",
+                "--git",
+                "https://github.com/org/local-mcp",
+                "--name",
+                "local-mcp",
+                "--category",
+                "developer-tools",
+                "--yes",
+            ],
+            input=json.dumps(config) + "\n\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = post.call_args[0][1]
+    assert payload["git_url"] == "https://github.com/org/local-mcp"
+    assert payload["command"] == "docker"
+    assert payload["setup_instructions"] == "docker build -t local-mcp:latest ."

--- a/packages/observal-shared/observal_shared/mcp_analysis.py
+++ b/packages/observal-shared/observal_shared/mcp_analysis.py
@@ -206,6 +206,23 @@ def _safe_image_name(value: str) -> str:
     return name or "mcp-server"
 
 
+def _github_image(git_url: str) -> tuple[str | None, bool]:
+    safe_name = re.compile(r"^[a-zA-Z0-9._-]+$")
+    try:
+        parts = urlparse(git_url)
+        if parts.hostname != "github.com":
+            return (None, False)
+        path = parts.path.strip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        owner_repo = path.split("/")
+        if len(owner_repo) >= 2 and safe_name.match(owner_repo[0]) and safe_name.match(owner_repo[1]):
+            return (f"ghcr.io/{owner_repo[0]}/{owner_repo[1]}", True)
+    except Exception:
+        pass
+    return (None, False)
+
+
 def _repo_image_name(git_url: str, fallback: str | None = None) -> str:
     try:
         path = urlparse(git_url).path.strip("/")
@@ -272,23 +289,16 @@ def detect_container_image(root: Path, git_url: str, name: str | None = None) ->
         if (root / dockerfile).exists():
             tag = f"{repo_name}:latest"
             return (tag, True, [_docker_build_command(tag, ".", dockerfile)])
-    safe_name = re.compile(r"^[a-zA-Z0-9._-]+$")
-    try:
-        parts = urlparse(git_url)
-        if parts.hostname == "github.com":
-            path = parts.path.strip("/")
-            if path.endswith(".git"):
-                path = path[:-4]
-            owner_repo = path.split("/")
-            if len(owner_repo) >= 2 and safe_name.match(owner_repo[0]) and safe_name.match(owner_repo[1]):
-                return (f"ghcr.io/{owner_repo[0]}/{owner_repo[1]}", True, [])
-    except Exception:
-        pass
+    image, suggested = _github_image(git_url)
+    if image:
+        return (image, suggested, [])
     return (None, False, [])
 
 
 def detect_docker_image(root: Path, git_url: str) -> tuple[str | None, bool]:
-    image, suggested, _setup = detect_container_image(root, git_url)
+    image, suggested, setup = detect_container_image(root, git_url)
+    if setup:
+        return _github_image(git_url)
     return (image, suggested)
 
 

--- a/packages/observal-shared/observal_shared/mcp_analysis.py
+++ b/packages/observal-shared/observal_shared/mcp_analysis.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import ast
 import json
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from urllib.parse import urlparse
 
 PYTHON_MCP_PATTERN = re.compile(
@@ -201,20 +201,62 @@ def detect_env_vars(tmp_dir: str) -> list[dict]:
     return [{"name": key, "description": value, "required": True} for key, value in sorted(found.items())]
 
 
-def detect_docker_image(root: Path, git_url: str) -> tuple[str | None, bool]:
+def _safe_image_name(value: str) -> str:
+    name = re.sub(r"[^a-z0-9_.-]+", "-", value.lower()).strip(".-")
+    return name or "mcp-server"
+
+
+def _repo_image_name(git_url: str, fallback: str | None = None) -> str:
+    try:
+        path = urlparse(git_url).path.strip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        if path:
+            return _safe_image_name(path.replace("/", "-"))
+    except Exception:
+        pass
+    return _safe_image_name(fallback or "mcp-server")
+
+
+def _docker_build_command(tag: str, context: str = ".", dockerfile: str | None = None) -> str:
+    context = context or "."
+    parts = ["docker", "build", "-t", tag]
+    if dockerfile:
+        dockerfile_path = str(PurePosixPath(context) / dockerfile) if not dockerfile.startswith("/") else dockerfile
+        parts.extend(["-f", dockerfile_path])
+    parts.append(context)
+    return " ".join(parts)
+
+
+def detect_container_image(root: Path, git_url: str, name: str | None = None) -> tuple[str | None, bool, list[str]]:
+    """Detect a runnable OCI image and any local setup commands.
+
+    ``suggested`` is true when the image tag is inferred and may need building.
+    """
+    repo_name = _repo_image_name(git_url, name)
     for compose_name in ("docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"):
         compose_file = root / compose_name
-        if compose_file.exists():
-            try:
-                import yaml
+        if not compose_file.exists():
+            continue
+        try:
+            import yaml
 
-                data = yaml.safe_load(compose_file.read_text(errors="ignore"))
-                for service in (data.get("services") or {}).values():
-                    image = service.get("image")
-                    if image and isinstance(image, str):
-                        return (image, False)
-            except Exception:
-                pass
+            data = yaml.safe_load(compose_file.read_text(errors="ignore")) or {}
+            services = data.get("services") or {}
+            for service in services.values():
+                image = service.get("image") if isinstance(service, dict) else None
+                if image and isinstance(image, str):
+                    return (image, False, [])
+            for service_name, service in services.items():
+                if not isinstance(service, dict) or not service.get("build"):
+                    continue
+                build = service["build"]
+                context = build if isinstance(build, str) else build.get("context", ".")
+                dockerfile = None if isinstance(build, str) else build.get("dockerfile")
+                tag = service.get("image") or f"{repo_name}-{_safe_image_name(str(service_name))}:latest"
+                return (tag, True, [_docker_build_command(tag, str(context or "."), dockerfile)])
+        except Exception:
+            pass
     for readme_name in ("README.md", "README.rst", "README.txt", "README"):
         readme = root / readme_name
         if not readme.exists():
@@ -222,10 +264,14 @@ def detect_docker_image(root: Path, git_url: str) -> tuple[str | None, bool]:
         try:
             match = _DOCKER_IMAGE_PATTERN.search(readme.read_text(errors="ignore"))
             if match:
-                return (match.group(1), False)
+                return (match.group(1), False, [])
         except Exception:
             pass
         break
+    for dockerfile in ("Dockerfile", "Containerfile"):
+        if (root / dockerfile).exists():
+            tag = f"{repo_name}:latest"
+            return (tag, True, [_docker_build_command(tag, ".", dockerfile)])
     safe_name = re.compile(r"^[a-zA-Z0-9._-]+$")
     try:
         parts = urlparse(git_url)
@@ -235,10 +281,15 @@ def detect_docker_image(root: Path, git_url: str) -> tuple[str | None, bool]:
                 path = path[:-4]
             owner_repo = path.split("/")
             if len(owner_repo) >= 2 and safe_name.match(owner_repo[0]) and safe_name.match(owner_repo[1]):
-                return (f"ghcr.io/{owner_repo[0]}/{owner_repo[1]}", True)
+                return (f"ghcr.io/{owner_repo[0]}/{owner_repo[1]}", True, [])
     except Exception:
         pass
-    return (None, False)
+    return (None, False, [])
+
+
+def detect_docker_image(root: Path, git_url: str) -> tuple[str | None, bool]:
+    image, suggested, _setup = detect_container_image(root, git_url)
+    return (image, suggested)
 
 
 def infer_command_args(

--- a/tests/test_mcp_analysis_containers.py
+++ b/tests/test_mcp_analysis_containers.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from observal_shared.mcp_analysis import detect_container_image, detect_docker_image
+
+
+def test_dockerfile_repo_gets_local_build_setup(tmp_path):
+    (tmp_path / "Dockerfile").write_text("FROM python:3.12-slim\n", encoding="utf-8")
+
+    image, suggested, setup = detect_container_image(tmp_path, "https://github.com/acme/local-mcp")
+
+    assert image == "acme-local-mcp:latest"
+    assert suggested is True
+    assert setup == ["docker build -t acme-local-mcp:latest -f Dockerfile ."]
+    assert detect_docker_image(tmp_path, "https://github.com/acme/local-mcp") == (image, suggested)
+
+
+def test_compose_build_service_gets_local_image_tag(tmp_path):
+    (tmp_path / "compose.yml").write_text(
+        """
+services:
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile.mcp
+""".strip(),
+        encoding="utf-8",
+    )
+
+    image, suggested, setup = detect_container_image(tmp_path, "https://github.com/acme/local-mcp")
+
+    assert image == "acme-local-mcp-server:latest"
+    assert suggested is True
+    assert setup == ["docker build -t acme-local-mcp-server:latest -f server/Dockerfile.mcp ./server"]
+
+
+def test_compose_declared_image_needs_no_local_setup(tmp_path):
+    (tmp_path / "docker-compose.yml").write_text(
+        """
+services:
+  mcp:
+    image: ghcr.io/acme/local-mcp:1.2.3
+""".strip(),
+        encoding="utf-8",
+    )
+
+    image, suggested, setup = detect_container_image(tmp_path, "https://github.com/acme/local-mcp")
+
+    assert image == "ghcr.io/acme/local-mcp:1.2.3"
+    assert suggested is False
+    assert setup == []

--- a/tests/test_mcp_analysis_containers.py
+++ b/tests/test_mcp_analysis_containers.py
@@ -1,6 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-from observal_shared.mcp_analysis import detect_container_image, detect_docker_image
+from observal_shared.mcp_analysis import detect_container_image
 
 
 def test_dockerfile_repo_gets_local_build_setup(tmp_path):
@@ -11,7 +12,6 @@ def test_dockerfile_repo_gets_local_build_setup(tmp_path):
     assert image == "acme-local-mcp:latest"
     assert suggested is True
     assert setup == ["docker build -t acme-local-mcp:latest -f Dockerfile ."]
-    assert detect_docker_image(tmp_path, "https://github.com/acme/local-mcp") == (image, suggested)
 
 
 def test_compose_build_service_gets_local_image_tag(tmp_path):

--- a/tests/test_registry_keyword_search.py
+++ b/tests/test_registry_keyword_search.py
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 from sqlalchemy import Column, MetaData, String, Table, create_engine, insert, select

--- a/tests/test_registry_keyword_search.py
+++ b/tests/test_registry_keyword_search.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from sqlalchemy import Column, MetaData, String, Table, create_engine, insert, select
+
+from api.search import keyword_search
+
+
+def _rows_for(query: str, descriptions: list[str]) -> list[str]:
+    engine = create_engine("sqlite:///:memory:")
+    meta = MetaData()
+    items = Table("items", meta, Column("name", String), Column("description", String))
+    meta.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(insert(items), [{"name": f"item-{i}", "description": d} for i, d in enumerate(descriptions)])
+        where, rank = keyword_search(query, [items.c.name, items.c.description], name_field=items.c.name)
+        assert where is not None and rank is not None
+        return [r.description for r in conn.execute(select(items).where(where).order_by(rank.desc())).all()]
+
+
+def test_incident_resolution_matches_incident_response_description():
+    rows = _rows_for(
+        "incident resolution",
+        ["On-call incident response and debugging", "Frontend component builder"],
+    )
+
+    assert rows == ["On-call incident response and debugging"]
+
+
+def test_frontend_design_matches_related_skill_description_without_phrase():
+    rows = _rows_for(
+        "frontend design",
+        ["Build accessible frontend components from design systems", "On-call incident response"],
+    )
+
+    assert rows == ["Build accessible frontend components from design systems"]

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -496,19 +496,18 @@ export function SubmitComponentDialog({
 		if (!name) return "Name is required";
 		if (!description) return "Description is required";
 
-		if (type === "mcps" && !gitUrl && !command && !mcpUrl) {
+		if (type === "mcps") {
 			if (mcpMode === "json" && !jsonParsed && !isEditMode) {
 				return "Paste a valid server config JSON";
 			}
 			if (mcpMode === "json" && !jsonParsed && isEditMode) {
-				// Edit mode: existing fields from editItem are still valid
 				const d = editItem as Record<string, unknown> | null;
-				if (!d?.command && !d?.url && !d?.git_url) {
+				if (!d?.command && !d?.url) {
 					return "Paste a new server config JSON to update";
 				}
 			}
-			if (mcpMode === "manual") {
-				return "At least one of Git URL, Command, or Server URL is required";
+			if (mcpMode === "manual" && !command && !mcpUrl) {
+				return "Command or Server URL is required";
 			}
 		}
 		if (type === "prompts" && !template) {
@@ -650,6 +649,23 @@ export function SubmitComponentDialog({
 							{mcpMode === "json" && (
 								<>
 									<div className="space-y-1.5">
+										<Label htmlFor="mcp-git-url-json">
+											Git URL for local OCI setup (optional)
+										</Label>
+										<Input
+											id="mcp-git-url-json"
+											value={gitUrl}
+											onChange={(e) => setGitUrl(e.target.value)}
+											placeholder="https://github.com/user/mcp-server"
+										/>
+										<p className="text-xs text-muted-foreground">
+											Observal still needs pasted MCP JSON. The git repo is only
+											used to detect Dockerfile, Containerfile, or compose build
+											setup instructions.
+										</p>
+									</div>
+
+									<div className="space-y-1.5">
 										<div className="flex items-center justify-between gap-3">
 											<Label htmlFor="mcp-json">
 												{isEditMode
@@ -700,7 +716,7 @@ export function SubmitComponentDialog({
 										onClick={() => setMcpMode("manual")}
 										className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
 									>
-										Switch to manual entry
+										Advanced: enter command or URL manually
 									</button>
 								</>
 							)}
@@ -769,10 +785,9 @@ export function SubmitComponentDialog({
 										/>
 									</div>
 
-									{!gitUrl && !command && !mcpUrl && (
+									{!command && !mcpUrl && (
 										<p className="text-xs text-destructive">
-											At least one of Git URL, Command, or Server URL is
-											required for submission.
+											Command or Server URL is required for manual submission.
 										</p>
 									)}
 


### PR DESCRIPTION
## Purpose / Description
Improve Observal registry discovery and setup flows so users can ask for agents or skills with natural keywords, pull agents with non-interactive setup values, and submit component definitions without being forced into prompts.

## Fixes
No linked issue.

## Approach
- Added shared keyword tokenization and ranking for registry list endpoints.
- Applied ranked search to agents, MCPs, skills, hooks, prompts, and sandboxes.
- Extended MCP git analysis to infer local OCI container setup from Dockerfile, Containerfile, and compose build services.
- Added flag-only submit paths for skills, hooks, prompts, and sandboxes.
- Added flag-only agent init scaffolding.
- Updated bundled Observal skills to route natural search requests and prefer flag-first setup flows.

## How Has This Been Tested?
<img width="1562" height="1039" alt="image" src="https://github.com/user-attachments/assets/2dd04c32-4183-4647-958a-ea302f2e2fc0" />


## Learning (optional, can help others)
Reused the existing MCP repository analyzer instead of adding a new parser or service. The existing clone and analysis path already handled most git based MCP submissions, so this change only adds the missing local container heuristics.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


## AI Assistance
Generative AI tooling was used to co-author this PR.

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
