### PR TITLE
fix(users): show locked super admin roles

### DIFF
--- a/web/src/pages/admin/users.tsx
+++ b/web/src/pages/admin/users.tsx
@@ -41,15 +41,23 @@ function useAssignableRoles(): Role[] {
 function RoleSelect({ userId, currentRole }: { userId: string; currentRole: string }) {
   const mutation = useUpdateUserRole();
   const assignable = useAssignableRoles();
+  const currentRoleOption = {
+    value: currentRole,
+    label: ROLE_LABELS[currentRole as Role] ?? currentRole,
+  };
+  const canEdit = assignable.includes(currentRole as Role);
+  const options = canEdit
+    ? assignable.map((r) => ({ value: r, label: ROLE_LABELS[r] }))
+    : [currentRoleOption];
 
   return (
     <PickerSelect
       value={currentRole}
       onValueChange={(value) => mutation.mutate({ id: userId, role: value })}
-      disabled={mutation.isPending}
+      disabled={!canEdit || mutation.isPending}
       className="w-[140px]"
       inputClassName="h-7 text-xs"
-      options={assignable.map((r) => ({ value: r, label: ROLE_LABELS[r] }))}
+      options={options}
     />
   );
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
Admins who cannot assign the `super_admin` role saw super admin users as an empty role selector. This makes the users table show `Super Admin` and disables the picker when the current admin cannot edit that role.

## Fixes
None.

## Approach
* Keep the current role as the only option when it is outside the signed in admin's assignable roles.
* Disable the picker for uneditable roles so the existing disabled styling greys it out.
* Preserve the existing editable role picker for roles the admin is allowed to assign.

## How Has This Been Tested?

<img width="1303" height="192" alt="image" src="https://github.com/user-attachments/assets/343883d6-612a-4dda-9ed6-dc5d5ec6a2df" />

## Learning (optional, can help others)
The existing `ROLE_LABELS` and `PickerSelect` behavior already covered the display and disabled states. The fix only needed to include the current uneditable role in the picker options.

## Checklist
_Please, go through these checks before submitting the PR._

* [x] You have a descriptive commit message with a short title (first line, max 50 chars).
* [ ] You have commented your code, particularly in hard-to-understand areas. 
* [x] You have performed a self-review of your own code.
* [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). 

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

* [x] Yes(Please Specify the tool): Pi coding agent
* [x] Was the generated code manually reviewed and tested?
