### PR TITLE
chore: update org namespace references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -13,7 +13,7 @@ body:
     id: contact
     attributes:
       label: Checked for duplicates?
-      description: Quickly search our [issues](https://github.com/BlazeUp-AI/Observal/issues) to see if a similar issue exists
+      description: Quickly search our [issues](https://github.com/Observal/Observal/issues) to see if a similar issue exists
       options:
         - label: This issue is not a duplicate
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,5 +5,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Github Discussions
-    url: https://github.com/BlazeUp-AI/Observal/discussions
+    url: https://github.com/Observal/Observal/discussions
     about: Post on the forums for questions, support and feature requests!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
     attributes:
       value: |
         **Have a quick idea or want to gauge interest first?**
-        Consider starting a conversation in our [GitHub Discussions](https://github.com/BlazeUp-AI/Observal/discussions) before filing a formal feature request.
+        Consider starting a conversation in our [GitHub Discussions](https://github.com/Observal/Observal/discussions) before filing a formal feature request.
 
   - type: textarea
     id: problem

--- a/.github/vex/observal.vex.json
+++ b/.github/vex/observal.vex.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://github.com/BlazeUp-AI/Observal/blob/main/.github/vex/observal.vex.json",
+  "@id": "https://github.com/Observal/Observal/blob/main/.github/vex/observal.vex.json",
   "author": "Observal Security <contact@observal.io>",
   "timestamp": "2026-05-31T00:00:00Z",
   "version": 1,

--- a/.github/workflows/badge-ghcr-pulls.yml
+++ b/.github/workflows/badge-ghcr-pulls.yml
@@ -36,7 +36,7 @@ jobs:
           import os, re, urllib.request
 
           def scrape_count(package):
-              url = f"https://github.com/orgs/BlazeUp-AI/packages/container/package/{package}"
+              url = f"https://github.com/orgs/Observal/packages/container/package/{package}"
               req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
               with urllib.request.urlopen(req) as resp:
                   html = resp.read().decode()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.repository == 'BlazeUp-AI/Observal'
+    if: github.repository == 'Observal/Observal'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/blazeup-ai/observal
+  IMAGE_PREFIX: ghcr.io/observal/observal
 
 jobs:
   # ── Preflight: detect release commit and create tag ────────
   preflight:
     name: Preflight checks
-    if: github.repository == 'BlazeUp-AI/Observal'
+    if: github.repository == 'Observal/Observal'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -64,7 +64,7 @@ jobs:
         run: uv run --no-project scripts/check_vulnerabilities.py sbom-python.cdx.json sbom-node.cdx.json
 
       - name: Ensure labels exist
-        if: github.repository == 'BlazeUp-AI/Observal'
+        if: github.repository == 'Observal/Observal'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -72,7 +72,7 @@ jobs:
           gh label create "automated" --color "0E8A16" --description "Created by CI automation" 2>/dev/null || true
 
       - name: Post vulnerability summary
-        if: github.repository == 'BlazeUp-AI/Observal' && hashFiles('vulnerability-report.md') != ''
+        if: github.repository == 'Observal/Observal' && hashFiles('vulnerability-report.md') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -104,7 +104,7 @@ jobs:
 
       # ── Attach to release ────────────────────────────────────
       - name: Attach SBOMs to release
-        if: github.event_name == 'release' && github.repository == 'BlazeUp-AI/Observal'
+        if: github.event_name == 'release' && github.repository == 'Observal/Observal'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Apoorv Garg <apoorvgarg.21@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# Updates the BlazeUp-AI/homebrew-observal tap after every published release.
+# Updates the Observal/homebrew-observal tap after every published release.
 #
 # Fires when a GitHub release is published (the release.yml workflow flips a
 # draft to published as its final step). Downloads the just-published binaries
@@ -78,13 +78,13 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: BlazeUp-AI
+          owner: Observal
           repositories: homebrew-observal
 
       - name: Checkout homebrew-observal
         uses: actions/checkout@v6
         with:
-          repository: BlazeUp-AI/homebrew-observal
+          repository: Observal/homebrew-observal
           token: ${{ steps.app-token.outputs.token }}
           path: homebrew-observal
 
@@ -123,7 +123,7 @@ jobs:
               return f'{url_line}\n{sha_indent}sha256 "{new_sha}"'
 
           text = re.sub(
-              r'(url "https://github\.com/BlazeUp-AI/Observal/releases/download/v[^"]+")\n(\s*)sha256 "[0-9a-f]{64}"',
+              r'(url "https://github\.com/Observal/Observal/releases/download/v[^"]+")\n(\s*)sha256 "[0-9a-f]{64}"',
               replace_sha,
               text,
           )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) and [AI Policy](AI_POLICY.
 ```bash
 git clone https://github.com/YOUR-USERNAME/Observal.git
 cd Observal
-git remote add upstream https://github.com/BlazeUp-AI/Observal.git
+git remote add upstream https://github.com/Observal/Observal.git
 ```
 
 ### Running Locally
@@ -94,7 +94,7 @@ Set `NEXT_PUBLIC_API_URL=http://localhost` in `web/.env.local` if the backend is
 
 ## Finding Work
 
-Check [open issues](https://github.com/BlazeUp-AI/Observal/issues) before starting. Look for **good first issue** if you are new.
+Check [open issues](https://github.com/Observal/Observal/issues) before starting. Look for **good first issue** if you are new.
 
 For larger changes, open an issue or discuss in **#contributing** on Discord before writing code.
 
@@ -195,7 +195,7 @@ Keep PRs focused on a single concern. Smaller PRs are easier to review and faste
 
 ### Bugs
 
-Search [existing issues](https://github.com/BlazeUp-AI/Observal/issues) first. Include:
+Search [existing issues](https://github.com/Observal/Observal/issues) first. Include:
 
 - Steps to reproduce
 - Expected vs actual behaviour

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/python-3.11+-3776ab?style=flat-square&logo=python&logoColor=white" alt="Python">
   <a href="https://pypi.org/project/observal-cli/"><img src="https://img.shields.io/pypi/v/observal-cli?style=flat-square&logo=pypi&logoColor=white&label=pypi" alt="PyPI version"></a>
-  <a href="https://codecov.io/gh/BlazeUp-AI/Observal"><img src="https://img.shields.io/codecov/c/github/BlazeUp-AI/Observal?style=flat-square&logo=codecov" alt="Coverage"></a>
-  <a href="https://github.com/BlazeUp-AI/Observal/graphs/contributors"><img src="https://img.shields.io/github/contributors/BlazeUp-AI/Observal?style=flat-square&logo=github" alt="Contributors"></a>
+  <a href="https://codecov.io/gh/Observal/Observal"><img src="https://img.shields.io/codecov/c/github/Observal/Observal?style=flat-square&logo=codecov" alt="Coverage"></a>
+  <a href="https://github.com/Observal/Observal/graphs/contributors"><img src="https://img.shields.io/github/contributors/Observal/Observal?style=flat-square&logo=github" alt="Contributors"></a>
   <a href="https://discord.observal.io"><img src="https://img.shields.io/badge/discord-chat-5865f2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://github.com/orgs/BlazeUp-AI/packages?repo_name=Observal"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Haz3-jolt/b28aba6d0efebb0b430d43c8068feb91/raw/ghcr-pulls.json&style=flat-square" alt="GHCR pulls"></a>
+  <a href="https://github.com/orgs/Observal/packages?repo_name=Observal"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Haz3-jolt/b28aba6d0efebb0b430d43c8068feb91/raw/ghcr-pulls.json&style=flat-square" alt="GHCR pulls"></a>
 </p>
 
 > If you find Observal useful, please consider giving it a star. It helps others discover the project and keeps development going.
@@ -80,7 +80,7 @@ Observal has two parts: a **server** (API + web UI + databases) you self-host, a
 **One-line install** (requires Docker Engine ≥ 24.0 with Compose v2):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install-server.sh | bash
 ```
 
 This downloads a Docker Compose package, runs guided setup (domain, secrets, ports), pulls container images from GHCR, and starts the full stack (API, web UI, PostgreSQL, ClickHouse, Redis, worker, load balancer, Prometheus, Grafana).
@@ -88,7 +88,7 @@ This downloads a Docker Compose package, runs guided setup (domain, secrets, por
 **From source** (for contributors):
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git && cd Observal
+git clone https://github.com/Observal/Observal.git && cd Observal
 cp .env.example .env
 make up
 ```
@@ -98,7 +98,7 @@ make up
 **Standalone binary** (no Python required):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash
 ```
 
 **Python** (3.11+):
@@ -229,7 +229,7 @@ The server and CLI are the same package for all editions. Enterprise features ac
 
 ```bash
 # Pass the key during server install
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash -s -- --license-key YOUR_KEY
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install-server.sh | bash -s -- --license-key YOUR_KEY
 
 # Or add it later to your .env
 echo 'OBSERVAL_LICENSE_KEY=your.key' >> .env
@@ -270,7 +270,7 @@ See [AGENTS.md](AGENTS.md) for internal codebase context.
 
 ## Community
 
-[GitHub Discussions](https://github.com/BlazeUp-AI/Observal/discussions) for questions and ideas. [Discord](https://discord.observal.io) for chat. Open Issues for confirmed bugs.
+[GitHub Discussions](https://github.com/Observal/Observal/discussions) for questions and ideas. [Discord](https://discord.observal.io) for chat. Open Issues for confirmed bugs.
 
 ## Reporting Issues
 
@@ -290,15 +290,15 @@ Logs are written to `~/.observal/logs/dev.log` and include structured context fo
 
 ## Security
 
-Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://github.com/BlazeUp-AI/Observal/security/advisories) or email contact@blazeup.app. Do not open a public issue. See [SECURITY.md](SECURITY.md).
+Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://github.com/Observal/Observal/security/advisories) or email contact@blazeup.app. Do not open a public issue. See [SECURITY.md](SECURITY.md).
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=BlazeUp-AI%2FObserval&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=Observal%2FObserval&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=BlazeUp-AI/Observal&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=BlazeUp-AI/Observal&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=BlazeUp-AI/Observal&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Observal/Observal&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Observal/Observal&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Observal/Observal&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@
 
 If you discover a security vulnerability in Observal, please report it responsibly through one of these channels:
 
-1. **GitHub Private Vulnerability Reporting** (preferred): Go to the [Security Advisories](https://github.com/BlazeUp-AI/Observal/security/advisories) page and click "Report a vulnerability".
+1. **GitHub Private Vulnerability Reporting** (preferred): Go to the [Security Advisories](https://github.com/Observal/Observal/security/advisories) page and click "Report a vulnerability".
 2. **Email**: Send details to **contact@blazeup.app**.
 
 ### What to Include

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,7 +27,7 @@ Everything you need to get Observal running locally for development or self-host
 ## 1. Clone and configure
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal
 cp .env.example .env
 ```
@@ -106,7 +106,7 @@ uv tool install observal-cli
 **Via Homebrew** (macOS Apple Silicon, Linux x64/arm64):
 
 ```bash
-brew install BlazeUp-AI/observal/observal-cli
+brew install Observal/observal/observal-cli
 ```
 
 Verify: `observal --version`

--- a/cliff.toml
+++ b/cliff.toml
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.\n
 """
 body = """
 {%- macro remote_url() -%}
-  https://github.com/BlazeUp-AI/Observal
+  https://github.com/Observal/Observal
 {%- endmacro -%}
 
 {% if version -%}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.api
-    image: ghcr.io/blazeup-ai/observal-api:latest
+    image: ghcr.io/observal/observal-api:latest
     command: ["/app/entrypoint.sh"]
     env_file:
       - ../.env
@@ -40,7 +40,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.api
-    image: ghcr.io/blazeup-ai/observal-api:latest
+    image: ghcr.io/observal/observal-api:latest
     command:
       [
         "/app/.venv/bin/python",
@@ -181,7 +181,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.api
-    image: ghcr.io/blazeup-ai/observal-api:latest
+    image: ghcr.io/observal/observal-api:latest
     command:
       [
         "/app/.venv/bin/python",
@@ -213,7 +213,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.web
-    image: ghcr.io/blazeup-ai/observal-web:latest
+    image: ghcr.io/observal/observal-web:latest
     ports:
       - "${WEB_HOST_PORT:-3000}:3000"
     depends_on:

--- a/docker/server-package/docker-compose.yml
+++ b/docker/server-package/docker-compose.yml
@@ -7,7 +7,7 @@
 
 services:
   observal-init:
-    image: ghcr.io/blazeup-ai/observal-api:${OBSERVAL_VERSION:-latest}
+    image: ghcr.io/observal/observal-api:${OBSERVAL_VERSION:-latest}
     command: ["/app/entrypoint.sh"]
     env_file:
       - ./.env
@@ -30,7 +30,7 @@ services:
       - observal-net
 
   observal-api:
-    image: ghcr.io/blazeup-ai/observal-api:${OBSERVAL_VERSION:-latest}
+    image: ghcr.io/observal/observal-api:${OBSERVAL_VERSION:-latest}
     command: ["/app/.venv/bin/python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
     env_file:
       - ./.env
@@ -139,7 +139,7 @@ services:
       - observal-net
 
   observal-worker:
-    image: ghcr.io/blazeup-ai/observal-api:${OBSERVAL_VERSION:-latest}
+    image: ghcr.io/observal/observal-api:${OBSERVAL_VERSION:-latest}
     command: ["/app/.venv/bin/python", "-c", "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)"]
     env_file:
       - ./.env
@@ -163,7 +163,7 @@ services:
       - observal-net
 
   observal-web:
-    image: ghcr.io/blazeup-ai/observal-web:${OBSERVAL_VERSION:-latest}
+    image: ghcr.io/observal/observal-web:${OBSERVAL_VERSION:-latest}
     ports:
       - "${WEB_HOST_PORT:-3000}:3000"
     depends_on:

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -159,7 +159,7 @@ cd Observal
 3. Add the upstream remote so you can pull in changes from the main repo:
 
 ```bash
-git remote add upstream https://github.com/BlazeUp-AI/Observal.git
+git remote add upstream https://github.com/Observal/Observal.git
 ```
 
 4. Verify your remotes:
@@ -168,8 +168,8 @@ git remote add upstream https://github.com/BlazeUp-AI/Observal.git
 git remote -v
 # origin    git@github.com:YOUR-USERNAME/Observal.git (fetch)
 # origin    git@github.com:YOUR-USERNAME/Observal.git (push)
-# upstream  https://github.com/BlazeUp-AI/Observal.git (fetch)
-# upstream  https://github.com/BlazeUp-AI/Observal.git (push)
+# upstream  https://github.com/Observal/Observal.git (fetch)
+# upstream  https://github.com/Observal/Observal.git (push)
 ```
 
 ---
@@ -387,7 +387,7 @@ git push origin feature/my-feature --force-with-lease
     ```bash
     git push origin feature/my-feature
     ```
-3. GitHub will show a banner on your fork offering to open a PR. Click it, or go to the [Observal repository](https://github.com/BlazeUp-AI/Observal) directly.
+3. GitHub will show a banner on your fork offering to open a PR. Click it, or go to the [Observal repository](https://github.com/Observal/Observal) directly.
 4. Fill in the PR template completely. PRs that do not follow the template will be closed.
 5. Link the related issue if one exists (`Fixes #123` in the PR body closes it automatically on merge).
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -185,7 +185,7 @@ observal server upgrade --skip-backup --force
 2. Verifies the Docker image exists on GHCR
 3. Acquires an upgrade lock (prevents concurrent upgrades)
 4. Creates a database backup (unless `--skip-backup`)
-5. Pulls new images: `ghcr.io/blazeup-ai/observal-{api,web}:<version>`
+5. Pulls new images: `ghcr.io/observal/observal-{api,web}:<version>`
 6. Updates `.env` with the new version
 7. Recreates containers via `docker compose up -d`
 8. Runs health checks for up to 120 seconds

--- a/docs/e2e-test-checklist.md
+++ b/docs/e2e-test-checklist.md
@@ -29,7 +29,7 @@
 - [ ] `make rebuild-clean`
 - [ ] Install the CLI from source:
   ```bash
-  git clone https://github.com/BlazeUp-AI/Observal.git
+  git clone https://github.com/Observal/Observal.git
   cd Observal
   uv tool install --editable .
   ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ The server runs as a Docker Compose stack (API, web UI, PostgreSQL, ClickHouse, 
 **One-line install:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install-server.sh | bash
 ```
 
 This downloads a config package, runs guided setup (domain, secrets, ports), pulls container images from GHCR, and starts the full stack.
@@ -25,7 +25,7 @@ This downloads a config package, runs guided setup (domain, secrets, ports), pul
 **From source** (for contributors):
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git && cd Observal
+git clone https://github.com/Observal/Observal.git && cd Observal
 cp .env.example .env
 make up
 ```
@@ -41,7 +41,7 @@ The CLI is what you use to log in, instrument harness configs, pull agents, and 
 The standalone binary is the simplest way to install. No Python required.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash
 ```
 
 This downloads the latest release binary for your platform and places it on your `PATH`. The binary is the same for all editions; enterprise features activate at runtime when a valid license key is present.
@@ -49,7 +49,7 @@ This downloads the latest release binary for your platform and places it on your
 To save a license key during install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash -s -- --license-key YOUR_KEY
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash -s -- --license-key YOUR_KEY
 ```
 
 This validates the Ed25519-signed key, installs the CLI, and writes the key to `~/.observal/config.json`. If the key is invalid or expired, the installer exits with an error.
@@ -101,7 +101,7 @@ uv tool install 'observal-cli[sandbox]'
 ## Install from source (for contributors)
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal
 uv tool install --editable .
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,7 +20,7 @@ By the end of this guide you will have:
 ## 1. Install the CLI
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash
 ```
 
 No Python required. For alternative install methods, see [Installation](installation.md).
@@ -31,7 +31,7 @@ No Python required. For alternative install methods, see [Installation](installa
 ## 2. Start the server
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal
 cp .env.example .env
 

--- a/docs/self-hosting/aws-terraform.md
+++ b/docs/self-hosting/aws-terraform.md
@@ -43,7 +43,7 @@ ClickHouse runs on EC2 because AWS does not offer a managed ClickHouse service. 
 ## Quickstart
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal/infra/terraform/aws
 
 # 1. Authenticate to AWS (any of these works)

--- a/docs/self-hosting/docker-compose.md
+++ b/docs/self-hosting/docker-compose.md
@@ -10,7 +10,7 @@ Step-by-step bring-up of the Observal stack. End state: the core services are he
 ## 1. Clone and configure
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal
 cp .env.example .env
 ```
@@ -77,7 +77,7 @@ For local dev, `http://localhost` is fine. For production, put a TLS-terminating
 Log in with the CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash   # if you haven't already
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash   # if you haven't already
 observal auth login              # Email: super@demo.example, Password: super-changeme
 ```
 

--- a/docs/self-hosting/gcp-terraform.md
+++ b/docs/self-hosting/gcp-terraform.md
@@ -50,7 +50,7 @@ gcloud services enable \
 ## Quickstart
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal/infra/terraform/gcp
 
 # 1. Authenticate

--- a/docs/self-hosting/okta-setup.md
+++ b/docs/self-hosting/okta-setup.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # Okta SSO Setup for Observal (Managed Customer Instance)
 
-Step-by-step runbook for BlazeUp operators setting up **Okta OIDC** for a **new Observal instance** deployed for another company (managed solution). Follow every step in order; each step assumes the previous one is complete.
+Step-by-step runbook for Observal operators setting up **Okta OIDC** for a **new Observal instance** deployed for another company (managed solution). Follow every step in order; each step assumes the previous one is complete.
 
 This guide matches how Observal’s server is implemented today:
 

--- a/docs/self-hosting/production-deploy.md
+++ b/docs/self-hosting/production-deploy.md
@@ -75,7 +75,7 @@ flowchart TB
 **Quick start:**
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal/infra/terraform/aws
 
 # Configure

--- a/docs/self-hosting/releasing.md
+++ b/docs/self-hosting/releasing.md
@@ -7,7 +7,7 @@ How to cut a release of Observal. This is for maintainers with push access.
 
 ## Prerequisites
 
-- A fork of `BlazeUp-AI/Observal` with `origin` pointing to your fork and `upstream` pointing to the org repo
+- A fork of `Observal/Observal` with `origin` pointing to your fork and `upstream` pointing to the org repo
 - GitHub CLI (`gh`) installed and authenticated
 - `git-cliff` installed (`cargo install git-cliff`) or `uvx` available as a fallback
 
@@ -39,7 +39,7 @@ These jobs run in parallel:
 | Job | What it produces |
 |-----|-----------------|
 | `cli-binaries` | Standalone CLI binaries for 6 platforms (Linux/macOS/Windows, x64/arm64) via PyInstaller |
-| `docker-images` | Multi-arch Docker images pushed to `ghcr.io/blazeup-ai/observal-api` and `ghcr.io/blazeup-ai/observal-web` |
+| `docker-images` | Multi-arch Docker images pushed to `ghcr.io/observal/observal-api` and `ghcr.io/observal/observal-web` |
 | `server-package` | Deployment tarball (`observal-server-vX.Y.Z.tar.gz`) with Docker Compose, configs, and setup script |
 | `pypi` | Python package published to PyPI via Trusted Publishing |
 
@@ -83,7 +83,7 @@ Commits prefixed with `bump(release):` are automatically excluded from the chang
 ### CLI users
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash
 ```
 
 Downloads the right binary for their OS/arch, verifies the checksum, and installs to `/usr/local/bin/observal`. Or `pip install observal` for Python users.
@@ -91,7 +91,7 @@ Downloads the right binary for their OS/arch, verifies the checksum, and install
 ### Server deployers
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install-server.sh | bash
 ```
 
 Downloads the server tarball, unpacks to `/opt/observal`, and runs an interactive setup that prompts for deployment mode, frontend URL, and auto-generates database passwords. Starts the full Docker Compose stack.
@@ -136,7 +136,7 @@ Ensure the `production` environment exists in GitHub Settings > Environments and
 
 ### PyPI publish fails
 
-Verify that PyPI Trusted Publishing is configured: PyPI > Project > Publishing > Trusted Publisher with `owner=BlazeUp-AI`, `repo=Observal`, `workflow=release.yml`, `environment=pypi`.
+Verify that PyPI Trusted Publishing is configured: PyPI > Project > Publishing > Trusted Publisher with `owner=Observal`, `repo=Observal`, `workflow=release.yml`, `environment=pypi`.
 
 ### Docker push fails
 

--- a/docs/self-hosting/single-node-deploy.md
+++ b/docs/self-hosting/single-node-deploy.md
@@ -116,7 +116,7 @@ docker compose version
 ## Step 3: Clone and configure
 
 ```bash
-git clone https://github.com/BlazeUp-AI/Observal.git
+git clone https://github.com/Observal/Observal.git
 cd Observal
 cp .env.example .env
 ```
@@ -290,7 +290,7 @@ See [Backup and restore](backup-and-restore.md) for detailed restore procedures.
 Install the CLI on your local machine:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash
 ```
 
 Log in:

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -4,7 +4,7 @@
 
 # Troubleshooting
 
-Common failure modes and their fixes. If none of these match, open a [GitHub Discussion](https://github.com/BlazeUp-AI/Observal/discussions) with the output of `observal auth status` and relevant logs from `docker compose logs`.
+Common failure modes and their fixes. If none of these match, open a [GitHub Discussion](https://github.com/Observal/Observal/discussions) with the output of `observal auth status` and relevant logs from `docker compose logs`.
 
 ## Install and CLI
 
@@ -182,5 +182,5 @@ Browser cookies aren't being set. Usually one of:
 * Logs: `docker compose -f docker/docker-compose.yml logs -f`
 * Health: `curl http://localhost/health`
 * Status: `observal auth status`
-* Community: [GitHub Discussions](https://github.com/BlazeUp-AI/Observal/discussions)
-* Bugs: [GitHub Issues](https://github.com/BlazeUp-AI/Observal/issues). Please use Discussions for questions, Issues only for confirmed bugs
+* Community: [GitHub Discussions](https://github.com/Observal/Observal/discussions)
+* Bugs: [GitHub Issues](https://github.com/Observal/Observal/issues). Please use Discussions for questions, Issues only for confirmed bugs

--- a/docs/self-hosting/upgrades.md
+++ b/docs/self-hosting/upgrades.md
@@ -22,7 +22,7 @@ See [`observal server upgrade`](../cli/server.md#observal-server-upgrade) for fu
 ## Before a manual upgrade
 
 1. **Back up `pgdata`** and **`apidata`**. See [Backup and restore](backup-and-restore.md). Backing up `chdata` is nice-to-have; losing telemetry is painful but not catastrophic.
-2. **Read the [CHANGELOG](https://github.com/BlazeUp-AI/Observal/blob/main/CHANGELOG.md)** for the releases you're jumping across. Note any breaking changes.
+2. **Read the [CHANGELOG](https://github.com/Observal/Observal/blob/main/CHANGELOG.md)** for the releases you're jumping across. Note any breaking changes.
 3. **Pin the version you're upgrading to**: don't `git pull main` blindly. Check out a release tag or a known-good commit.
 
 ## Standard upgrade

--- a/docs/use-cases/team-registry.md
+++ b/docs/use-cases/team-registry.md
@@ -66,7 +66,7 @@ Two commands to get them productive:
 
 ```bash
 # The new engineer runs:
-curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash
 observal auth login --server https://observal.your-company.internal
 ```
 

--- a/infra/terraform/aws-ec2/deploy.sh
+++ b/infra/terraform/aws-ec2/deploy.sh
@@ -27,7 +27,7 @@ echo "  Instance:  $INSTANCE_ID"
 echo "  IP:        $PUBLIC_IP"
 echo "  Region:    $REGION"
 echo "  Domain:    ${DOMAIN:-"(none — HTTP only)"}"
-echo "  Image:     ghcr.io/blazeup-ai/observal-api:$IMAGE_TAG"
+echo "  Image:     ghcr.io/observal/observal-api:$IMAGE_TAG"
 echo "  Observability: $OBSERVABILITY_STACK"
 echo ""
 

--- a/infra/terraform/aws-ec2/variables.tf
+++ b/infra/terraform/aws-ec2/variables.tf
@@ -74,5 +74,5 @@ variable "observal_ref" {
 variable "observal_repo" {
   description = "Git repository URL"
   type        = string
-  default     = "https://github.com/BlazeUp-AI/Observal.git"
+  default     = "https://github.com/Observal/Observal.git"
 }

--- a/infra/terraform/aws-standard/variables.tf
+++ b/infra/terraform/aws-standard/variables.tf
@@ -37,13 +37,13 @@ variable "sizing" {
 variable "image_repo_api" {
   description = "Container image repository for api + worker + init."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-api"
+  default     = "ghcr.io/observal/observal-api"
 }
 
 variable "image_repo_web" {
   description = "Container image repository for the web frontend."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-web"
+  default     = "ghcr.io/observal/observal-web"
 }
 
 variable "image_tag" {

--- a/infra/terraform/aws/deploy.sh
+++ b/infra/terraform/aws/deploy.sh
@@ -157,7 +157,7 @@ check_ghcr_image() {
   local image="$1"
   local tag="$2"
   # Use the GitHub container registry API (anonymous, no auth needed for public images)
-  local url="https://ghcr.io/v2/blazeup-ai/$image/manifests/$tag"
+  local url="https://ghcr.io/v2/observal/$image/manifests/$tag"
   local status
   status=$(curl -s -o /dev/null -w "%{http_code}" \
     -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
@@ -168,23 +168,23 @@ check_ghcr_image() {
 TAG="${IMAGE_TAG:-latest}"
 for img in observal-api observal-web; do
   if check_ghcr_image "$img" "$TAG"; then
-    pass "ghcr.io/blazeup-ai/$img:$TAG exists"
+    pass "ghcr.io/observal/$img:$TAG exists"
   else
     # Try with token auth
-    TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:blazeup-ai/$img:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
+    TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:observal/$img:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
     if [ -n "$TOKEN" ]; then
       status=$(curl -s -o /dev/null -w "%{http_code}" \
         -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
         -H "Authorization: Bearer $TOKEN" \
-        "https://ghcr.io/v2/blazeup-ai/$img/manifests/$TAG" 2>/dev/null)
+        "https://ghcr.io/v2/observal/$img/manifests/$TAG" 2>/dev/null)
       if [ "$status" = "200" ]; then
-        pass "ghcr.io/blazeup-ai/$img:$TAG exists"
+        pass "ghcr.io/observal/$img:$TAG exists"
       else
-        fail "ghcr.io/blazeup-ai/$img:$TAG not found (HTTP $status)"
+        fail "ghcr.io/observal/$img:$TAG not found (HTTP $status)"
         info "Check that a release with this tag exists, or use 'latest'"
       fi
     else
-      warn "Cannot verify ghcr.io/blazeup-ai/$img:$TAG (auth required or network issue)"
+      warn "Cannot verify ghcr.io/observal/$img:$TAG (auth required or network issue)"
     fi
   fi
 done
@@ -195,7 +195,7 @@ section "5. Release Tarball"
 if [ "$TAG" = "latest" ]; then
   pass "image_tag=latest: embedded configs used (no tarball needed)"
 else
-  TARBALL_URL="https://github.com/BlazeUp-AI/Observal/releases/download/v${TAG}/observal-server-v${TAG}.tar.gz"
+  TARBALL_URL="https://github.com/Observal/Observal/releases/download/v${TAG}/observal-server-v${TAG}.tar.gz"
   HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -L "$TARBALL_URL" 2>/dev/null)
   if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "302" ]; then
     pass "Release tarball v$TAG exists"

--- a/infra/terraform/aws/user-data.sh.tftpl
+++ b/infra/terraform/aws/user-data.sh.tftpl
@@ -85,7 +85,7 @@ INSTALL_DIR=/opt/observal
 mkdir -p "$INSTALL_DIR"
 cd "$INSTALL_DIR"
 
-TARBALL_URL="https://github.com/BlazeUp-AI/Observal/releases/download/v${image_tag}/observal-server-v${image_tag}.tar.gz"
+TARBALL_URL="https://github.com/Observal/Observal/releases/download/v${image_tag}/observal-server-v${image_tag}.tar.gz"
 TARBALL_OK=false
 if [ "${image_tag}" != "latest" ]; then
   for attempt in 1 2 3 4 5; do

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -100,13 +100,13 @@ variable "sizing" {
 variable "image_repo_api" {
   description = "Container image repository for api + worker + init (they share an image)."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-api"
+  default     = "ghcr.io/observal/observal-api"
 }
 
 variable "image_repo_web" {
   description = "Container image repository for the Next.js web frontend."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-web"
+  default     = "ghcr.io/observal/observal-web"
 }
 
 variable "image_tag" {

--- a/infra/terraform/azure/README.md
+++ b/infra/terraform/azure/README.md
@@ -45,8 +45,8 @@ terraform apply -var-file=staging.tfvars
 # 3. Push images to ACR (after first apply creates the registry)
 ACR=$(terraform output -raw acr_login_server)
 az acr login --name $ACR
-docker tag ghcr.io/blazeup-ai/observal-api:latest $ACR/observal-api:latest
-docker tag ghcr.io/blazeup-ai/observal-web:latest $ACR/observal-web:latest
+docker tag ghcr.io/observal/observal-api:latest $ACR/observal-api:latest
+docker tag ghcr.io/observal/observal-web:latest $ACR/observal-web:latest
 docker push $ACR/observal-api:latest
 docker push $ACR/observal-web:latest
 

--- a/infra/terraform/azure/variables.tf
+++ b/infra/terraform/azure/variables.tf
@@ -67,13 +67,13 @@ variable "domain_name" {
 variable "image_repo_api" {
   description = "Container image repository for api + worker + init."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-api"
+  default     = "ghcr.io/observal/observal-api"
 }
 
 variable "image_repo_web" {
   description = "Container image repository for the web frontend."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-web"
+  default     = "ghcr.io/observal/observal-web"
 }
 
 variable "image_tag" {

--- a/infra/terraform/deploy.sh
+++ b/infra/terraform/deploy.sh
@@ -230,9 +230,9 @@ validate_standard() {
   # Check GHCR image accessibility (requires token even for public images)
   local tag="${image_tag:-latest}"
   local token status
-  token=$(curl -s "https://ghcr.io/token?scope=repository:blazeup-ai/observal-api:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
+  token=$(curl -s "https://ghcr.io/token?scope=repository:observal/observal-api:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
   if [ -n "$token" ]; then
-    status=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://ghcr.io/v2/blazeup-ai/observal-api/manifests/$tag" 2>/dev/null || echo "000")
+    status=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://ghcr.io/v2/observal/observal-api/manifests/$tag" 2>/dev/null || echo "000")
   else
     status="000"
   fi

--- a/infra/terraform/gcp/locals.tf
+++ b/infra/terraform/gcp/locals.tf
@@ -17,8 +17,8 @@ locals {
 
   ar_prefix = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.ghcr_proxy.repository_id}"
 
-  image_repo_api_effective = local.is_enterprise ? "blazeup-ai/observal-api-enterprise" : trimprefix(var.image_repo_api, "ghcr.io/")
-  image_repo_web_effective = local.is_enterprise ? "blazeup-ai/observal-web-enterprise" : trimprefix(var.image_repo_web, "ghcr.io/")
+  image_repo_api_effective = local.is_enterprise ? "observal/observal-api-enterprise" : trimprefix(var.image_repo_api, "ghcr.io/")
+  image_repo_web_effective = local.is_enterprise ? "observal/observal-web-enterprise" : trimprefix(var.image_repo_web, "ghcr.io/")
 
   image_api = "${local.ar_prefix}/${local.image_repo_api_effective}:${var.image_tag}"
   image_web = "${local.ar_prefix}/${local.image_repo_web_effective}:${var.image_tag}"

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -57,13 +57,13 @@ variable "dns_managed_zone_name" {
 variable "image_repo_api" {
   description = "Container image repository for api + worker + init."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-api"
+  default     = "ghcr.io/observal/observal-api"
 }
 
 variable "image_repo_web" {
   description = "Container image repository for the web frontend."
   type        = string
-  default     = "ghcr.io/blazeup-ai/observal-web"
+  default     = "ghcr.io/observal/observal-web"
 }
 
 variable "image_tag" {

--- a/install-server.sh
+++ b/install-server.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Observal Server Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash -s -- [OPTIONS]
+# Usage: curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install-server.sh | bash -s -- [OPTIONS]
 #
 # Options:
 #   --license-key KEY          Enterprise license key (enables enterprise edition)
@@ -20,7 +20,7 @@ set -euo pipefail
 #   OBSERVAL_INSTALL_DIR       Install directory
 #   OBSERVAL_FORCE=1           Skip overwrite confirmation
 
-GITHUB_REPO="BlazeUp-AI/Observal"
+GITHUB_REPO="Observal/Observal"
 
 # Ed25519 public key for license verification (base64-encoded, 32 bytes raw)
 LICENSE_PUBLIC_KEY="X5Ia46wxT2AxZ6nFlvFnT7ZE6vXoVI208Io3TDoX6N8="
@@ -88,7 +88,7 @@ while [ $# -gt 0 ]; do
     -h | --help)
         cat <<'HELP'
 Observal Server Installer
-Usage: curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install-server.sh | bash -s -- [OPTIONS]
+Usage: curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install-server.sh | bash -s -- [OPTIONS]
 
 Options:
   --license-key KEY    Enterprise license key (enables enterprise edition)

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 # Observal CLI Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash -s -- [OPTIONS]
+# Usage: curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash -s -- [OPTIONS]
 #
 # Options:
 #   --license-key KEY          Enterprise license key (enables enterprise edition)
@@ -18,7 +18,7 @@ set -euo pipefail
 #   OBSERVAL_VERSION=latest    Version to install
 #   OBSERVAL_BIN_DIR=/path     Install directory
 
-GITHUB_REPO="BlazeUp-AI/Observal"
+GITHUB_REPO="Observal/Observal"
 
 # Ed25519 public key for license verification (base64-encoded, 32 bytes raw)
 LICENSE_PUBLIC_KEY="X5Ia46wxT2AxZ6nFlvFnT7ZE6vXoVI208Io3TDoX6N8="
@@ -72,7 +72,7 @@ while [ $# -gt 0 ]; do
     -h | --help)
         cat <<'HELP'
 Observal CLI Installer
-Usage: curl -fsSL https://raw.githubusercontent.com/BlazeUp-AI/Observal/main/install.sh | bash -s -- [OPTIONS]
+Usage: curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh | bash -s -- [OPTIONS]
 
 Options:
   --license-key KEY   Enterprise license key (enables enterprise edition)

--- a/observal_cli/cmd_server.py
+++ b/observal_cli/cmd_server.py
@@ -494,21 +494,21 @@ def server_upgrade(
     # Verify image exists on GHCR before any state changes
     with console.status("Verifying image on GHCR..."):
         if not version_check.verify_server_image_exists(target):
-            console.print(f"[red]Image not found on GHCR: ghcr.io/blazeup-ai/observal-api:{target}[/red]")
+            console.print(f"[red]Image not found on GHCR: ghcr.io/observal/observal-api:{target}[/red]")
             console.print("[dim]Check available versions with: observal server versions[/dim]")
             raise typer.Exit(1)
 
     if dry_run:
         console.print(f"[dim]Dry run: would upgrade v{current} → v{target}[/dim]")
-        console.print(f"[dim]  Pull: ghcr.io/blazeup-ai/observal-api:{target}[/dim]")
-        console.print(f"[dim]  Pull: ghcr.io/blazeup-ai/observal-web:{target}[/dim]")
+        console.print(f"[dim]  Pull: ghcr.io/observal/observal-api:{target}[/dim]")
+        console.print(f"[dim]  Pull: ghcr.io/observal/observal-web:{target}[/dim]")
         console.print(f"[dim]  Compose dir: {compose_dir}[/dim]")
         raise typer.Exit(0)
 
     if not force:
         console.print(f"  Current: [dim]v{current}[/dim]")
         console.print(f"  Target:  [green]v{target}[/green]")
-        console.print(f"  Images:  [dim]ghcr.io/blazeup-ai/observal-{{api,web}}:{target}[/dim]")
+        console.print(f"  Images:  [dim]ghcr.io/observal/observal-{{api,web}}:{target}[/dim]")
         if not typer.confirm("\nProceed with server upgrade?"):
             raise typer.Abort()
 
@@ -751,4 +751,4 @@ def server_versions() -> None:
         shown.add(ver)
 
     console.print(table)
-    console.print(f"\n  Current: v{current} | Images: ghcr.io/blazeup-ai/observal-{{api,web}}")
+    console.print(f"\n  Current: v{current} | Images: ghcr.io/observal/observal-{{api,web}}")

--- a/observal_cli/config.py
+++ b/observal_cli/config.py
@@ -26,7 +26,7 @@ DEFAULTS = {
     "timeout": 30,
     "update_check": True,
     "update_check_interval": 86400,  # seconds (24h)
-    "update_check_repo": "",  # empty = BlazeUp-AI/Observal
+    "update_check_repo": "",  # empty = Observal/Observal
 }
 
 

--- a/observal_cli/server/constants.py
+++ b/observal_cli/server/constants.py
@@ -37,7 +37,7 @@ REDIS_VERSION = "8.0"
 
 # ── GitHub repo for downloads ──────────────────────────────────
 
-GITHUB_REPO = "BlazeUp-AI/Observal"
+GITHUB_REPO = "Observal/Observal"
 DEPS_RELEASE_TAG = "deps/v1"
 
 # ── Platform detection ──────────────────────────────────────────

--- a/observal_cli/upgrade_executor.py
+++ b/observal_cli/upgrade_executor.py
@@ -26,7 +26,7 @@ from observal_cli import config
 from observal_cli.constants import REDIRECT_ALLOWLIST
 from observal_cli.install_detector import InstallInfo, InstallMethod
 
-GITHUB_REPO = "BlazeUp-AI/Observal"
+GITHUB_REPO = "Observal/Observal"
 
 
 def execute(install_info: InstallInfo, target_version: str, direction: str, spinner) -> None:

--- a/observal_cli/version_check.py
+++ b/observal_cli/version_check.py
@@ -36,9 +36,9 @@ from observal_cli.config import CONFIG_DIR
 from observal_cli.config import load as load_config
 
 CACHE_FILE = CONFIG_DIR / "version_cache.json"
-GITHUB_REPO_DEFAULT = "BlazeUp-AI/Observal"
+GITHUB_REPO_DEFAULT = "Observal/Observal"
 GITHUB_API_BASE = "https://api.github.com/repos"
-GHCR_API_BASE = "https://ghcr.io/v2/blazeup-ai"
+GHCR_API_BASE = "https://ghcr.io/v2/observal"
 CHECK_INTERVAL_DEFAULT = 86400  # 24 hours
 CHECK_TIMEOUT = 3  # seconds, must never block CLI
 MAX_RESPONSE_SIZE = 1_048_576  # 1MB
@@ -314,7 +314,7 @@ def fetch_available_server_images() -> list[str]:
         # GHCR requires a token even for public images
         # First get an anonymous token
         token_resp = httpx.get(
-            "https://ghcr.io/token?scope=repository:blazeup-ai/observal-api:pull",
+            "https://ghcr.io/token?scope=repository:observal/observal-api:pull",
             timeout=10,
             headers={"User-Agent": f"observal-cli/{get_current_version()}"},
         )
@@ -362,7 +362,7 @@ def verify_server_image_exists(version: str) -> bool:
     """
     try:
         token_resp = httpx.get(
-            "https://ghcr.io/token?scope=repository:blazeup-ai/observal-api:pull",
+            "https://ghcr.io/token?scope=repository:observal/observal-api:pull",
             timeout=10,
             headers={"User-Agent": f"observal-cli/{get_current_version()}"},
         )

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -12,7 +12,7 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "https://github.com/BlazeUp-AI/Observal.git",
+    "url": "https://github.com/Observal/Observal.git",
     "directory": "packages/pi-extension"
   },
   "pi": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,10 @@ classifiers = [
 migrate = ["pyarrow>=15.0.0"]
 
 [project.urls]
-Homepage = "https://github.com/BlazeUp-AI/Observal"
-Repository = "https://github.com/BlazeUp-AI/Observal"
-Changelog = "https://github.com/BlazeUp-AI/Observal/blob/main/CHANGELOG.md"
-Issues = "https://github.com/BlazeUp-AI/Observal/issues"
+Homepage = "https://github.com/Observal/Observal"
+Repository = "https://github.com/Observal/Observal"
+Changelog = "https://github.com/Observal/Observal/blob/main/CHANGELOG.md"
+Issues = "https://github.com/Observal/Observal/issues"
 
 [project.scripts]
 observal = "observal_cli.main:app"

--- a/tests/e2e/kiro-agent-compat.spec.ts
+++ b/tests/e2e/kiro-agent-compat.spec.ts
@@ -6,11 +6,15 @@ import { test, expect } from "@playwright/test";
 import { execSync } from "child_process";
 import { getApiKey, API_BASE } from "./helpers";
 
+const CWD = execSync("git rev-parse --show-toplevel", {
+  encoding: "utf-8",
+}).trim();
+
 function run(cmd: string): string {
   return execSync(cmd, {
     encoding: "utf-8",
     timeout: 30_000,
-    cwd: "/home/haz3/code/blazeup/Observal",
+    cwd: CWD,
   });
 }
 

--- a/tests/e2e/kiro-cli.spec.ts
+++ b/tests/e2e/kiro-cli.spec.ts
@@ -5,7 +5,9 @@ import { test, expect } from "@playwright/test";
 import { execSync } from "child_process";
 
 const CLI_TIMEOUT = 30_000;
-const CWD = "/home/haz3/code/blazeup/Observal";
+const CWD = execSync("git rev-parse --show-toplevel", {
+  encoding: "utf-8",
+}).trim();
 
 function run(cmd: string): string {
   return execSync(cmd, { encoding: "utf-8", timeout: CLI_TIMEOUT, cwd: CWD });

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -78,7 +78,7 @@ class TestShouldCheck:
 
 MOCK_RELEASE_RESPONSE = {
     "tag_name": "v0.8.0",
-    "html_url": "https://github.com/BlazeUp-AI/Observal/releases/tag/v0.8.0",
+    "html_url": "https://github.com/Observal/Observal/releases/tag/v0.8.0",
     "published_at": "2026-05-20T10:00:00Z",
     "prerelease": False,
     "assets": [],

--- a/web/src/components/nav/github-star-banner.tsx
+++ b/web/src/components/nav/github-star-banner.tsx
@@ -29,7 +29,7 @@ export function GitHubStarBanner() {
   return (
     <div className="group/star flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground">
       <a
-        href="https://github.com/BlazeUp-AI/Observal"
+        href="https://github.com/Observal/Observal"
         target="_blank"
         rel="noopener noreferrer"
         className="flex items-center gap-1.5"

--- a/web/src/pages/user/traces/index.tsx
+++ b/web/src/pages/user/traces/index.tsx
@@ -50,7 +50,7 @@ import type { Session } from "@/lib/types";
 
 /** Quickstart docs URL shown in the first-time empty state CTA. */
 const DOCS_QUICKSTART_URL =
-	"https://github.com/BlazeUp-AI/Observal/blob/main/docs/getting-started/quickstart.md";
+	"https://github.com/Observal/Observal/blob/main/docs/getting-started/quickstart.md";
 
 function truncateQuery(q: string, max = 50): string {
 	return q.length > max ? `${q.slice(0, max)}…` : q;


### PR DESCRIPTION
## Purpose / Description
Update repository, CI, package, installer, and infrastructure references after the GitHub organization rename from BlazeUp-AI to Observal.

## Fixes
No linked issue.

## Approach
Updated old GitHub repository URLs to Observal/Observal and GHCR image paths to ghcr.io/observal. Refreshed release, deploy, SBOM, Homebrew tap, Docker Compose, Terraform, CLI update checks, package metadata, install scripts, docs, and issue template references. Legal ownership files and SPDX copyright lines were intentionally left unchanged.

## How Has This Been Tested?

Ran:

```text
git diff --check
uv run pytest tests/test_version_check.py
uv run python -m compileall -q observal_cli
bash -n install.sh install-server.sh infra/terraform/deploy.sh infra/terraform/aws/deploy.sh infra/terraform/aws-ec2/deploy.sh
curl -fsSI https://raw.githubusercontent.com/Observal/Observal/main/install.sh
GHCR manifest checks for ghcr.io/observal/observal-api:latest and ghcr.io/observal/observal-web:latest
```

## Learning (optional, can help others)
The rename affected more than docs. CI repository guards, GHCR namespaces, release URLs, installer defaults, Homebrew tap automation, and Terraform image defaults all depended on the old organization namespace.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas. No new complex code paths were added.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). Not applicable, no UI rendering changes.

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
