### PR TITLE
Feat/helm chart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-FileCopyrightText: 2026 ravichopra0107 <shivamchopra1234567890@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 repos:
@@ -20,6 +21,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^infra/helm/.*/templates/.*
       - id: check-toml
       - id: check-json
         exclude: tsconfig\.json  # tsconfig allows comments

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Full docs at **[docs.observal.io](https://docs.observal.io/)**
 | Queue | Redis + arq |
 | CLI | Python, Typer, Rich |
 | Telemetry | Session hooks, stdio shims, push-based ingest |
-| Deployment | Docker Compose (10 services) |
+| Deployment | Docker Compose (10 services), Kubernetes (Helm) |
 
 ## Contributing
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,11 +10,13 @@ set -e
 echo "Ensuring base schema exists..."
 /app/.venv/bin/python -c "
 import asyncio
+from sqlalchemy import text
 from database import engine
 from models import Base
 
 async def init():
     async with engine.begin() as conn:
+        await conn.execute(text('CREATE EXTENSION IF NOT EXISTS pg_trgm;'))
         await conn.run_sync(Base.metadata.create_all)
     await engine.dispose()
 
@@ -23,7 +25,7 @@ asyncio.run(init())
 
 echo "Running database migrations..."
 /app/.venv/bin/python -m alembic upgrade head || {
-    echo "Fresh database detected — stamping current schema version..."
+    echo "Fresh database detected: stamping current schema version..."
     /app/.venv/bin/python -m alembic stamp head
 }
 

--- a/docker/nginx-spa.conf
+++ b/docker/nginx-spa.conf
@@ -23,6 +23,22 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
     }
 
+    location /api/ {
+        proxy_pass http://observal-api:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health {
+        proxy_pass http://observal-api:8000;
+        proxy_set_header Host $host;
+    }
+
     # SPA fallback: try file, then directory, then index.html
     location / {
         try_files $uri $uri/ /index.html;

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -50,19 +50,20 @@ All services run on a private `observal-net` bridge network. Named volumes (`pgd
 
 Choose the deployment model that fits your team:
 
-| | [Single-node](single-node-deploy.md) | [Production](production-deploy.md) |
-|---|---|---|
-| **How** | Docker Compose on one VM | Terraform on AWS or GCP |
-| **Best for** | ≤50 users, internal tools, POCs | Enterprise, SLA-bound, 50+ users |
-| **Cost** | $20–150/mo | ~$180–255/mo |
-| **HA** | No | Yes (Multi-AZ databases, autoscaling) |
-| **Time to deploy** | 10 minutes | 20–30 minutes |
+| | [Single-node](single-node-deploy.md) | [Kubernetes](kubernetes-helm.md) | [Production](production-deploy.md) |
+|---|---|---|---|
+| **How** | Docker Compose on one VM | Official Helm chart | Terraform on AWS or GCP |
+| **Best for** | ≤50 users, internal tools, POCs | Cloud-native teams, existing K8s infra | Enterprise, SLA-bound, 50+ users |
+| **Cost** | $20 to $150/mo | Variable | ~$180 to $255/mo |
+| **HA** | No | Pod resilience & horizontal scaling | Yes (Multi-AZ databases, autoscaling) |
+| **Time to deploy** | 10 minutes | 10 to 15 minutes | 20 to 30 minutes |
 
 **Start here:**
 
 | If you want to... | Read |
 | --- | --- |
 | Deploy on a single VM (simplest) | [Single-node deployment](single-node-deploy.md) |
+| Deploy on Kubernetes with Helm | [Kubernetes deployment with Helm](kubernetes-helm.md) |
 | Deploy a production HA stack | [Production deployment](production-deploy.md) |
 | Deploy on AWS specifically | [AWS deployment with Terraform](aws-terraform.md) |
 | Deploy on GCP specifically | [GCP deployment with Terraform](gcp-terraform.md) |

--- a/docs/self-hosting/kubernetes-helm.md
+++ b/docs/self-hosting/kubernetes-helm.md
@@ -1,0 +1,134 @@
+<!-- SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Kubernetes Deployment with Helm
+
+Deploy Observal onto a Kubernetes cluster using the official Helm chart located in `infra/helm/observal`.
+
+> [!WARNING]
+> **Production Notice**: The in-cluster PostgreSQL, ClickHouse, and Redis StatefulSets deployed by this chart are intended for evaluation, development, and small-scale testing. For production workloads, set `postgresql.enabled=false`, `clickhouse.enabled=false`, and `redis.enabled=false`, then provide `postgresql.externalUrl`, `clickhouse.externalUrl`, and `redis.externalUrl` for managed services such as AWS RDS, Cloud SQL, ClickHouse Cloud, or ElastiCache.
+
+## Prerequisites
+
+- Kubernetes cluster v1.27 or higher
+- `helm` v3.8.0 or higher installed
+- `kubectl` configured to access your cluster
+- Ingress controller (e.g., `ingress-nginx`) installed on the cluster
+- Default `StorageClass` supporting dynamic volume provisioning (PV/PVC)
+
+## Quick Start
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/Observal/Observal.git
+   cd Observal
+   ```
+
+2. Install the chart into a dedicated namespace:
+   ```bash
+   kubectl create namespace observal
+   helm install observal ./infra/helm/observal --namespace observal
+   ```
+
+3. Verify all workloads are running and completed:
+   ```bash
+   kubectl get pods -n observal
+   ```
+
+## Configuration
+
+You can customize the deployment by passing a custom values file (`-f values.yaml`) or setting flags via `--set`.
+
+```bash
+helm install observal ./infra/helm/observal --namespace observal -f custom-values.yaml
+```
+
+### Parameters Reference Table
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `global.imageRegistry` | Global image registry prefix | `""` |
+| `global.imagePullSecrets` | Global image pull secrets list | `[]` |
+| `api.image.repository` | API container image repository | `ghcr.io/observal/observal-api` |
+| `api.image.tag` | API container image tag | `latest` |
+| `api.replicas` | Replicas for API deployment | `1` |
+| `api.workers` | Uvicorn worker count per API pod | `2` |
+| `worker.replicas` | Replicas for background job worker | `1` |
+| `web.replicas` | Replicas for Web UI deployment | `1` |
+| `postgresql.enabled` | Deploy embedded PostgreSQL StatefulSet | `true` |
+| `postgresql.externalUrl` | PostgreSQL URL used when embedded PostgreSQL is disabled | `""` |
+| `postgresql.storage.size` | PVC size for PostgreSQL | `10Gi` |
+| `clickhouse.enabled` | Deploy embedded ClickHouse StatefulSet | `true` |
+| `clickhouse.externalUrl` | ClickHouse URL used when embedded ClickHouse is disabled | `""` |
+| `clickhouse.storage.size` | PVC size for ClickHouse | `50Gi` |
+| `redis.enabled` | Deploy embedded Redis StatefulSet | `true` |
+| `redis.externalUrl` | Redis URL used when embedded Redis is disabled | `""` |
+| `redis.storage.size` | PVC size for Redis | `2Gi` |
+| `ingress.enabled` | Enable Kubernetes Ingress resource | `true` |
+| `ingress.host` | Hostname for Ingress rule | `observal.example.com` |
+| `ingress.tls.enabled` | Enable TLS termination on Ingress | `false` |
+| `ingress.tls.certManager.enabled` | Automatically request cert via cert-manager | `false` |
+| `secrets.existingSecret` | Use pre-existing K8s Secret for credentials | `""` |
+| `secrets.secretKey` | Override generated application secret | `""` |
+| `config.logLevel` | Application log level (`DEBUG`, `INFO`, `WARN`, `ERROR`) | `INFO` |
+| `config.seedDemoAccounts` | Seed demo accounts on startup | `false` |
+
+## Accessing the Application
+
+### Via Port Forwarding (Development/Testing)
+
+To access the Web UI locally without configuring Ingress DNS:
+
+```bash
+kubectl port-forward svc/observal-web 3000:3000 -n observal
+```
+
+Open `http://localhost:3000` in your browser.
+
+### Via Ingress & TLS (Production)
+
+Enable ingress and configure TLS termination using `cert-manager`:
+
+```bash
+helm upgrade --install observal ./infra/helm/observal \
+  --namespace observal \
+  --set ingress.enabled=true \
+  --set ingress.host=observal.mycompany.com \
+  --set ingress.tls.enabled=true \
+  --set ingress.tls.secretName=observal-tls \
+  --set ingress.tls.certManager.enabled=true \
+  --set ingress.tls.certManager.issuerName=letsencrypt-prod
+```
+
+## Maintenance & Operations
+
+### Upgrading
+
+To apply configuration changes or update to a newer chart version:
+
+```bash
+helm upgrade observal ./infra/helm/observal --namespace observal -f custom-values.yaml
+```
+
+### Rollback
+
+If an upgrade encounters issues, rollback to a previous release revision:
+
+```bash
+# View release history
+helm history observal --namespace observal
+
+# Rollback to revision 1
+helm rollback observal 1 --namespace observal
+```
+
+### Uninstalling
+
+To delete the deployment and associated Kubernetes resources:
+
+```bash
+helm uninstall observal --namespace observal
+```
+
+> [!NOTE]
+> Persistent Volume Claims (PVCs) for PostgreSQL, ClickHouse, Redis, and API data are retained by default to prevent accidental data loss. To delete them permanently, execute: `kubectl delete pvc -l app.kubernetes.io/instance=observal -n observal`.

--- a/infra/helm/observal/.helmignore
+++ b/infra/helm/observal/.helmignore
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Patterns to ignore when building packages
+.DS_Store
+.git/
+.gitignore
+.gitmodules
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# CI/CD
+.github/
+.gitlab/
+
+# Testing artifacts
+tests/

--- a/infra/helm/observal/Chart.yaml
+++ b/infra/helm/observal/Chart.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+apiVersion: v2
+name: observal
+description: >
+  Observal, agent-centric registry and observability platform for AI coding agents.
+  Self-hosted Helm chart for Kubernetes deployments.
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - observal
+  - ai-agents
+  - observability
+  - registry
+home: https://github.com/Observal/Observal
+sources:
+  - https://github.com/Observal/Observal
+maintainers:
+  - name: Observal Contributors
+    url: https://github.com/Observal/Observal

--- a/infra/helm/observal/templates/NOTES.txt
+++ b/infra/helm/observal/templates/NOTES.txt
@@ -1,0 +1,46 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+Observal has been installed! 🎉
+
+{{- $scheme := "http" }}
+{{- if .Values.ingress.tls.enabled }}
+{{- $scheme = "https" }}
+{{- end }}
+
+  Access URL: {{ $scheme }}://{{ .Values.ingress.host }}
+
+  Health check:
+    curl {{ $scheme }}://{{ .Values.ingress.host }}/health
+
+  CLI login:
+    observal auth login
+    # Server URL: {{ $scheme }}://{{ .Values.ingress.host }}
+
+{{- if .Values.config.seedDemoAccounts }}
+  Demo accounts are ENABLED. Default credentials:
+    super@demo.example / super-changeme
+    admin@demo.example / admin-changeme
+  ⚠️  Remove before real use: set config.seedDemoAccounts=false
+{{- end }}
+
+{{- if .Values.postgresql.enabled }}
+
+⚠️  WARNING: In-cluster PostgreSQL is running.
+   This is for DEV/EVAL only: no replication, no PITR, no automated failover.
+   For production use a managed database (RDS, Cloud SQL, etc.)
+   See: docs/self-hosting/kubernetes-helm.md
+{{- end }}
+
+{{- if .Values.clickhouse.enabled }}
+
+⚠️  WARNING: In-cluster ClickHouse is running (same caveat as above).
+{{- end }}
+
+  Useful commands:
+    kubectl get pods -n {{ .Release.Namespace }}
+    kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=api -f
+    helm upgrade observal infra/helm/observal -n {{ .Release.Namespace }}
+    helm uninstall observal -n {{ .Release.Namespace }}

--- a/infra/helm/observal/templates/_helpers.tpl
+++ b/infra/helm/observal/templates/_helpers.tpl
@@ -1,0 +1,206 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "observal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "observal.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "observal.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "observal.labels" -}}
+helm.sh/chart: {{ include "observal.chart" . }}
+{{ include "observal.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "observal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "observal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name for the init Job.
+*/}}
+{{- define "observal.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (printf "%s-init" (include "observal.fullname" .)) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding all sensitive env vars.
+*/}}
+{{- define "observal.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- printf "%s-secret" (include "observal.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding JWT signing keys (created by init Job).
+*/}}
+{{- define "observal.jwtSecretName" -}}
+{{- printf "%s-jwt-keys" (include "observal.fullname" .) }}
+{{- end }}
+
+{{/*
+Name of the ConfigMap holding non-sensitive env vars.
+*/}}
+{{- define "observal.configMapName" -}}
+{{- printf "%s-config" (include "observal.fullname" .) }}
+{{- end }}
+
+{{/*
+Image pull policy helper. Takes a dict with repository, tag, pullPolicy.
+*/}}
+{{- define "observal.image" -}}
+{{- $registry := .global.imageRegistry -}}
+{{- $repo := .image.repository -}}
+{{- $tag := .image.tag | default "latest" -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Standard initContainer: wait for Postgres readiness.
+*/}}
+{{- define "observal.initWaitPostgres" -}}
+{{- if .Values.postgresql.enabled }}
+- name: wait-for-postgres
+  image: postgres:16
+  imagePullPolicy: IfNotPresent
+  command:
+    - sh
+    - -c
+    - |
+      until pg_isready -h {{ include "observal.fullname" . }}-db -U postgres; do
+        echo "Waiting for Postgres..."; sleep 2;
+      done
+  env:
+    - name: PGPASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "observal.secretName" . }}
+          key: POSTGRES_PASSWORD
+{{- end }}
+{{- end }}
+
+{{/*
+Standard initContainer: wait for ClickHouse readiness.
+*/}}
+{{- define "observal.initWaitClickhouse" -}}
+{{- if .Values.clickhouse.enabled }}
+- name: wait-for-clickhouse
+  image: curlimages/curl:8.8.0
+  imagePullPolicy: IfNotPresent
+  command:
+    - sh
+    - -c
+    - |
+      until curl -sf http://{{ include "observal.fullname" . }}-clickhouse:8123/ping; do
+        echo "Waiting for ClickHouse..."; sleep 2;
+      done
+{{- end }}
+{{- end }}
+
+{{/*
+Standard initContainer: wait for Redis readiness.
+*/}}
+{{- define "observal.initWaitRedis" -}}
+{{- if .Values.redis.enabled }}
+- name: wait-for-redis
+  image: redis:7-alpine
+  imagePullPolicy: IfNotPresent
+  command:
+    - sh
+    - -c
+    - |
+      until redis-cli -h {{ include "observal.fullname" . }}-redis ping | grep -q PONG; do
+        echo "Waiting for Redis..."; sleep 2;
+      done
+{{- end }}
+{{- end }}
+
+{{/*
+Standard initContainer: wait for init Job completion.
+Polls the Job's succeeded count via the K8s API using the init ServiceAccount.
+*/}}
+{{- define "observal.initWaitInitJob" -}}
+- name: wait-for-init
+  image: bitnami/kubectl:latest
+  imagePullPolicy: IfNotPresent
+  command:
+    - sh
+    - -c
+    - |
+      JOB="{{ include "observal.fullname" . }}-init"
+      NS="{{ .Release.Namespace }}"
+      echo "Waiting for init Job $JOB to complete..."
+      until [ "$(kubectl get job $JOB -n $NS -o jsonpath='{.status.succeeded}' 2>/dev/null)" = "1" ]; do
+        echo "  init Job not yet succeeded, retrying in 5s..."; sleep 5;
+      done
+      echo "Init Job completed."
+{{- end }}
+
+{{/*
+Standard container security context.
+*/}}
+{{- define "observal.securityContext" -}}
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsUser: 1001
+  runAsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}
+
+{{/*
+Standard pod security context.
+*/}}
+{{- define "observal.podSecurityContext" -}}
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}

--- a/infra/helm/observal/templates/api-deployment.yaml
+++ b/infra/helm/observal/templates/api-deployment.yaml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "observal.fullname" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      {{- include "observal.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "observal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      serviceAccountName: {{ include "observal.serviceAccountName" . }}
+      {{- include "observal.podSecurityContext" . | nindent 6 }}
+      initContainers:
+        {{- include "observal.initWaitPostgres" . | nindent 8 }}
+        {{- include "observal.initWaitClickhouse" . | nindent 8 }}
+        {{- include "observal.initWaitRedis" . | nindent 8 }}
+        {{- include "observal.initWaitInitJob" . | nindent 8 }}
+        - name: prepare-jwt-keys
+          image: busybox:latest
+          command: ['sh', '-c', 'mkdir -p /data/keys && cp -f /data/secret-keys/* /data/keys/ 2>/dev/null || true; chown -R 1001:1001 /data/keys && chmod 700 /data/keys']
+          volumeMounts:
+            - mountPath: /data
+              name: apidata
+            - mountPath: /data/secret-keys
+              name: jwt-keys
+      containers:
+        - name: api
+          image: {{ include "observal.image" (dict "global" .Values.global "image" .Values.api.image) }}
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          {{- include "observal.securityContext" . | nindent 10 }}
+          command:
+            - /app/.venv/bin/uvicorn
+            - main:app
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --workers
+            - {{ .Values.api.workers | quote }}
+          env:
+            - name: SKIP_DDL_ON_STARTUP
+              value: "true"
+          envFrom:
+            - configMapRef:
+                name: {{ include "observal.configMapName" . }}
+            - secretRef:
+                name: {{ include "observal.secretName" . }}
+          ports:
+            - containerPort: 8000
+              name: http
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            failureThreshold: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /data
+              name: apidata
+            - mountPath: /data/secret-keys
+              name: jwt-keys
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: apidata
+          persistentVolumeClaim:
+            claimName: {{ include "observal.fullname" . }}-apidata
+        - name: jwt-keys
+          secret:
+            secretName: {{ include "observal.jwtSecretName" . }}
+        - name: tmp
+          emptyDir: {}

--- a/infra/helm/observal/templates/api-service.yaml
+++ b/infra/helm/observal/templates/api-service.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "observal.fullname" . }}-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+  selector:
+    {{- include "observal.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api

--- a/infra/helm/observal/templates/apidata-pvc.yaml
+++ b/infra/helm/observal/templates/apidata-pvc.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "observal.fullname" . }}-apidata
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  {{- if .Values.apidata.storage.storageClassName }}
+  storageClassName: {{ .Values.apidata.storage.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.apidata.storage.size | quote }}

--- a/infra/helm/observal/templates/clickhouse-service.yaml
+++ b/infra/helm/observal/templates/clickhouse-service.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.clickhouse.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "observal.fullname" . }}-clickhouse
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8123
+      targetPort: 8123
+      name: http
+    - port: 9000
+      targetPort: 9000
+      name: native
+  selector:
+    {{- include "observal.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+{{- end }}

--- a/infra/helm/observal/templates/clickhouse-statefulset.yaml
+++ b/infra/helm/observal/templates/clickhouse-statefulset.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.clickhouse.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "observal.fullname" . }}-clickhouse
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+spec:
+  serviceName: {{ include "observal.fullname" . }}-clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "observal.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: clickhouse
+  template:
+    metadata:
+      labels:
+        {{- include "observal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: {{ include "observal.image" (dict "global" .Values.global "image" .Values.clickhouse.image) }}
+          imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CLICKHOUSE_USER
+              value: "default"
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "observal.secretName" . }}
+                  key: CLICKHOUSE_PASSWORD
+          ports:
+            - containerPort: 8123
+              name: http
+            - containerPort: 9000
+              name: native
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.clickhouse.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /var/lib/clickhouse
+              name: chdata
+            - mountPath: /etc/clickhouse-server/config.d/memory.xml
+              subPath: memory.xml
+              name: config
+            - mountPath: /etc/clickhouse-server/users.d/memory.xml
+              subPath: memory.xml
+              name: users
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "observal.fullname" . }}-clickhouse-config
+        - name: users
+          configMap:
+            name: {{ include "observal.fullname" . }}-clickhouse-users
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: chdata
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.clickhouse.storage.storageClassName }}
+        storageClassName: {{ .Values.clickhouse.storage.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.clickhouse.storage.size | quote }}
+{{- end }}

--- a/infra/helm/observal/templates/configmap-clickhouse-config.yaml
+++ b/infra/helm/observal/templates/configmap-clickhouse-config.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.clickhouse.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "observal.fullname" . }}-clickhouse-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+data:
+  memory.xml: |
+    <clickhouse>
+        <listen_host>::</listen_host>
+        <listen_host>0.0.0.0</listen_host>
+        <listen_try>1</listen_try>
+        <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
+        <merge_tree>
+            <parts_to_delay_insert>200</parts_to_delay_insert>
+            <parts_to_throw_insert>500</parts_to_throw_insert>
+            <max_bytes_to_merge_at_max_space_in_pool>5368709120</max_bytes_to_merge_at_max_space_in_pool>
+        </merge_tree>
+        <query_log>
+            <database>system</database>
+            <table>query_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <partition_by>toYYYYMM(event_date)</partition_by>
+            <ttl>event_date + INTERVAL 3 DAY</ttl>
+        </query_log>
+        <trace_log>
+            <database>system</database>
+            <table>trace_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <partition_by>toYYYYMM(event_date)</partition_by>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </trace_log>
+        <text_log>
+            <database>system</database>
+            <table>text_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <partition_by>toYYYYMM(event_date)</partition_by>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </text_log>
+        <metric_log>
+            <database>system</database>
+            <table>metric_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <partition_by>toYYYYMM(event_date)</partition_by>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </metric_log>
+        <asynchronous_metric_log>
+            <database>system</database>
+            <table>asynchronous_metric_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <partition_by>toYYYYMM(event_date)</partition_by>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </asynchronous_metric_log>
+        <part_log>
+            <database>system</database>
+            <table>part_log</table>
+            <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+            <partition_by>toYYYYMM(event_date)</partition_by>
+            <ttl>event_date + INTERVAL 1 DAY</ttl>
+        </part_log>
+    </clickhouse>
+{{- end }}

--- a/infra/helm/observal/templates/configmap-clickhouse-users.yaml
+++ b/infra/helm/observal/templates/configmap-clickhouse-users.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.clickhouse.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "observal.fullname" . }}-clickhouse-users
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+data:
+  memory.xml: |
+    <clickhouse>
+        <profiles>
+            <default>
+                <max_memory_usage>400000000</max_memory_usage>
+                <max_bytes_before_external_group_by>200000000</max_bytes_before_external_group_by>
+                <max_bytes_before_external_sort>200000000</max_bytes_before_external_sort>
+                <max_bytes_in_join>100000000</max_bytes_in_join>
+                <join_algorithm>auto</join_algorithm>
+                <async_insert>1</async_insert>
+                <wait_for_async_insert>0</wait_for_async_insert>
+                <async_insert_max_data_size>1048576</async_insert_max_data_size>
+                <async_insert_busy_timeout_ms>200</async_insert_busy_timeout_ms>
+            </default>
+        </profiles>
+    </clickhouse>
+{{- end }}

--- a/infra/helm/observal/templates/configmap-env.yaml
+++ b/infra/helm/observal/templates/configmap-env.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "observal.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+data:
+  LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  LOG_FORMAT: {{ .Values.config.logFormat | quote }}
+  JWT_SIGNING_ALGORITHM: {{ .Values.config.jwtSigningAlgorithm | quote }}
+  JWT_KEY_DIR: {{ .Values.config.jwtKeyDir | quote }}
+  SEED_DEMO_ACCOUNTS: {{ .Values.config.seedDemoAccounts | quote }}

--- a/infra/helm/observal/templates/configmap-web-nginx.yaml
+++ b/infra/helm/observal/templates/configmap-web-nginx.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "observal.fullname" . }}-web-nginx
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+        listen 3000;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+
+        location /assets/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+        }
+
+        location /api/ {
+            proxy_pass http://{{ include "observal.fullname" . }}-api:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /health {
+            proxy_pass http://{{ include "observal.fullname" . }}-api:8000;
+            proxy_set_header Host $host;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }

--- a/infra/helm/observal/templates/db-service.yaml
+++ b/infra/helm/observal/templates/db-service.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "observal.fullname" . }}-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgresql
+  selector:
+    {{- include "observal.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: db
+{{- end }}

--- a/infra/helm/observal/templates/db-statefulset.yaml
+++ b/infra/helm/observal/templates/db-statefulset.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "observal.fullname" . }}-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: db
+spec:
+  serviceName: {{ include "observal.fullname" . }}-db
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "observal.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: db
+  template:
+    metadata:
+      labels:
+        {{- include "observal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: db
+    spec:
+      containers:
+        - name: postgresql
+          image: {{ include "observal.image" (dict "global" .Values.global "image" .Values.postgresql.image) }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: POSTGRES_DB
+              value: "observal"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "observal.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U postgres
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: pgdata
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.postgresql.storage.storageClassName }}
+        storageClassName: {{ .Values.postgresql.storage.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.storage.size | quote }}
+{{- end }}

--- a/infra/helm/observal/templates/ingress.yaml
+++ b/infra/helm/observal/templates/ingress.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "observal.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+  annotations:
+    {{- if eq .Values.ingress.className "nginx" }}
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    {{- end }}
+    {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.certManager.enabled }}
+    kubernetes.io/tls-acme: "true"
+    {{- if eq (lower .Values.ingress.tls.certManager.issuerKind) "clusterissuer" }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.certManager.issuerName | quote }}
+    {{- else }}
+    cert-manager.io/issuer: {{ .Values.ingress.tls.certManager.issuerName | quote }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "observal.fullname" .)) | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "observal.fullname" . }}-api
+                port:
+                  number: 8000
+          - path: /health
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "observal.fullname" . }}-api
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "observal.fullname" . }}-web
+                port:
+                  number: 3000
+{{- end }}

--- a/infra/helm/observal/templates/init-job.yaml
+++ b/infra/helm/observal/templates/init-job.yaml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "observal.fullname" . }}-init
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: init
+spec:
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        {{- include "observal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: init
+    spec:
+      serviceAccountName: {{ include "observal.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: false
+      initContainers:
+        {{- include "observal.initWaitPostgres" . | nindent 8 }}
+        {{- include "observal.initWaitClickhouse" . | nindent 8 }}
+        {{- include "observal.initWaitRedis" . | nindent 8 }}
+      containers:
+        - name: init
+          image: {{ include "observal.image" (dict "global" .Values.global "image" .Values.api.image) }}
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: false
+            runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - bash
+            - -c
+            - |
+              set -e
+              echo "Executing entrypoint script for DB migrations..."
+              /app/entrypoint.sh
+
+              echo "Syncing JWT keys in K8s Secret..."
+              /app/.venv/bin/python -c "
+              import os, ssl, json, urllib.request, urllib.error
+              from cryptography.hazmat.primitives.asymmetric import ec
+              from cryptography.hazmat.primitives import serialization
+
+              secret_name = '{{ include "observal.jwtSecretName" . }}'
+              ns = '{{ .Release.Namespace }}'
+              token_path = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+              ca_path = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+
+              if os.path.exists(token_path):
+                  with open(token_path) as f:
+                      token = f.read().strip()
+                  ctx = ssl.create_default_context(cafile=ca_path)
+                  headers = {'Authorization': 'Bearer ' + token, 'Content-Type': 'application/json'}
+                  url = f'https://kubernetes.default.svc/api/v1/namespaces/{ns}/secrets/{secret_name}'
+
+                  exists = False
+                  try:
+                      req = urllib.request.Request(url, headers=headers, method='GET')
+                      with urllib.request.urlopen(req, context=ctx) as resp:
+                          if resp.status == 200:
+                              exists = True
+                  except urllib.error.HTTPError as e:
+                      if e.code != 404:
+                          raise
+
+                  if not exists:
+                      print('Generating new JWT keypair and creating Secret...')
+                      key = ec.generate_private_key(ec.SECP256R1())
+                      priv = key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()).decode()
+                      pub = key.public_key().public_bytes(serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo).decode()
+
+                      create_url = f'https://kubernetes.default.svc/api/v1/namespaces/{ns}/secrets'
+                      body = {
+                          'apiVersion': 'v1',
+                          'kind': 'Secret',
+                          'metadata': {'name': secret_name, 'namespace': ns},
+                          'stringData': {'signing.pem': priv, 'signing.pub': pub, 'jwt_es256.pem': priv, 'jwt_es256.pub': pub}
+                      }
+                      create_req = urllib.request.Request(create_url, data=json.dumps(body).encode(), headers=headers, method='POST')
+                      with urllib.request.urlopen(create_req, context=ctx) as resp:
+                          print(f'Secret {secret_name} created successfully.')
+                  else:
+                      print(f'Secret {secret_name} already exists.')
+              "
+          envFrom:
+            - configMapRef:
+                name: {{ include "observal.configMapName" . }}
+            - secretRef:
+                name: {{ include "observal.secretName" . }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/infra/helm/observal/templates/redis-service.yaml
+++ b/infra/helm/observal/templates/redis-service.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "observal.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis
+  selector:
+    {{- include "observal.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/infra/helm/observal/templates/redis-statefulset.yaml
+++ b/infra/helm/observal/templates/redis-statefulset.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "observal.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "observal.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "observal.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "observal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: {{ include "observal.image" (dict "global" .Values.global "image" .Values.redis.image) }}
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - redis-server
+            - "--maxmemory"
+            - {{ .Values.redis.maxmemory | quote }}
+            - "--maxmemory-policy"
+            - "noeviction"
+          ports:
+            - containerPort: 6379
+              name: redis
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /data
+              name: redisdata
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: redisdata
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.redis.storage.storageClassName }}
+        storageClassName: {{ .Values.redis.storage.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.storage.size | quote }}
+{{- end }}

--- a/infra/helm/observal/templates/role.yaml
+++ b/infra/helm/observal/templates/role.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.serviceAccount.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "observal.fullname" . }}-init-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/infra/helm/observal/templates/rolebinding.yaml
+++ b/infra/helm/observal/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.serviceAccount.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "observal.fullname" . }}-init-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "observal.fullname" . }}-init-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "observal.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/infra/helm/observal/templates/secret.yaml
+++ b/infra/helm/observal/templates/secret.yaml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if not .Values.secrets.existingSecret }}
+{{- $secretName := include "observal.secretName" . }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $pgPass := "" }}
+{{- $chPass := "" }}
+{{- $secKey := "" }}
+{{- $dbUrl := "" }}
+{{- $chUrl := "" }}
+{{- $redisUrl := "" }}
+{{- if and $existingSecret $existingSecret.data }}
+  {{- $pgPass = index $existingSecret.data "POSTGRES_PASSWORD" | b64dec }}
+  {{- $chPass = index $existingSecret.data "CLICKHOUSE_PASSWORD" | b64dec }}
+  {{- $secKey = index $existingSecret.data "SECRET_KEY" | b64dec }}
+{{- else }}
+  {{- $pgPass = .Values.secrets.postgresPassword | default (randAlphaNum 24) }}
+  {{- $chPass = .Values.secrets.clickhousePassword | default (randAlphaNum 24) }}
+  {{- $secKey = .Values.secrets.secretKey | default (randAlphaNum 32) }}
+{{- end }}
+{{- if .Values.postgresql.enabled }}
+  {{- $dbUrl = printf "postgresql+asyncpg://postgres:%s@%s-db:5432/observal" $pgPass (include "observal.fullname" .) }}
+{{- else }}
+  {{- $dbUrl = required "postgresql.externalUrl is required when postgresql.enabled=false" .Values.postgresql.externalUrl }}
+{{- end }}
+{{- if .Values.clickhouse.enabled }}
+  {{- $chUrl = printf "clickhouse://default:%s@%s-clickhouse:8123/observal" $chPass (include "observal.fullname" .) }}
+{{- else }}
+  {{- $chUrl = required "clickhouse.externalUrl is required when clickhouse.enabled=false" .Values.clickhouse.externalUrl }}
+{{- end }}
+{{- if .Values.redis.enabled }}
+  {{- $redisUrl = printf "redis://%s-redis:6379" (include "observal.fullname" .) }}
+{{- else }}
+  {{- $redisUrl = required "redis.externalUrl is required when redis.enabled=false" .Values.redis.externalUrl }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "observal.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  SECRET_KEY: {{ $secKey | quote }}
+  POSTGRES_PASSWORD: {{ $pgPass | quote }}
+  CLICKHOUSE_PASSWORD: {{ $chPass | quote }}
+  DATABASE_URL: {{ $dbUrl | quote }}
+  CLICKHOUSE_URL: {{ $chUrl | quote }}
+  REDIS_URL: {{ $redisUrl | quote }}
+  {{- if .Values.secrets.licenseKey }}
+  OBSERVAL_LICENSE_KEY: {{ .Values.secrets.licenseKey | quote }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/observal/templates/serviceaccount.yaml
+++ b/infra/helm/observal/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "observal.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/observal/templates/web-deployment.yaml
+++ b/infra/helm/observal/templates/web-deployment.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "observal.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      {{- include "observal.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "observal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+        - name: web
+          image: {{ include "observal.image" (dict "global" .Values.global "image" .Values.web.image) }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 3000
+              name: http
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/cache/nginx
+              name: cache
+            - mountPath: /var/run
+              name: run
+            - mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              name: nginx-config
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: {{ include "observal.fullname" . }}-web-nginx

--- a/infra/helm/observal/templates/web-service.yaml
+++ b/infra/helm/observal/templates/web-service.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "observal.fullname" . }}-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: http
+  selector:
+    {{- include "observal.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/infra/helm/observal/templates/worker-deployment.yaml
+++ b/infra/helm/observal/templates/worker-deployment.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "observal.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "observal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      {{- include "observal.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "observal.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      serviceAccountName: {{ include "observal.serviceAccountName" . }}
+      {{- include "observal.podSecurityContext" . | nindent 6 }}
+      initContainers:
+        {{- include "observal.initWaitPostgres" . | nindent 8 }}
+        {{- include "observal.initWaitClickhouse" . | nindent 8 }}
+        {{- include "observal.initWaitRedis" . | nindent 8 }}
+        {{- include "observal.initWaitInitJob" . | nindent 8 }}
+        - name: prepare-jwt-keys
+          image: busybox:latest
+          command: ['sh', '-c', 'mkdir -p /data/keys && cp -f /data/secret-keys/* /data/keys/ 2>/dev/null || true; chown -R 1001:1001 /data/keys && chmod 700 /data/keys']
+          volumeMounts:
+            - mountPath: /data
+              name: apidata
+            - mountPath: /data/secret-keys
+              name: jwt-keys
+      containers:
+        - name: worker
+          image: {{ include "observal.image" (dict "global" .Values.global "image" .Values.worker.image) }}
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- include "observal.securityContext" . | nindent 10 }}
+          command:
+            - /app/.venv/bin/python
+            - -c
+            - "import asyncio; asyncio.set_event_loop(asyncio.new_event_loop()); from arq import run_worker; from worker import WorkerSettings; run_worker(WorkerSettings)"
+          envFrom:
+            - configMapRef:
+                name: {{ include "observal.configMapName" . }}
+            - secretRef:
+                name: {{ include "observal.secretName" . }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /data
+              name: apidata
+            - mountPath: /data/secret-keys
+              name: jwt-keys
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: apidata
+          persistentVolumeClaim:
+            claimName: {{ include "observal.fullname" . }}-apidata
+        - name: jwt-keys
+          secret:
+            secretName: {{ include "observal.jwtSecretName" . }}
+        - name: tmp
+          emptyDir: {}

--- a/infra/helm/observal/values.yaml
+++ b/infra/helm/observal/values.yaml
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# =============================================================================
+# Observal Helm values
+# =============================================================================
+
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+
+api:
+  image:
+    repository: ghcr.io/observal/observal-api
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  workers: 2
+  resources:
+    limits:
+      memory: 1536Mi
+    requests:
+      memory: 256Mi
+      cpu: 100m
+
+worker:
+  image:
+    repository: ghcr.io/observal/observal-api
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    limits:
+      memory: 1536Mi
+    requests:
+      memory: 256Mi
+      cpu: 50m
+
+web:
+  image:
+    repository: ghcr.io/observal/observal-web
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 64Mi
+      cpu: 50m
+
+postgresql:
+  enabled: true
+  externalUrl: ""
+  image:
+    repository: postgres
+    tag: "16"
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 1Gi
+    requests:
+      memory: 256Mi
+      cpu: 100m
+  storage:
+    size: 10Gi
+    storageClassName: ""
+
+clickhouse:
+  enabled: true
+  externalUrl: ""
+  image:
+    repository: clickhouse/clickhouse-server
+    tag: "26.3"
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 3Gi
+    requests:
+      memory: 512Mi
+      cpu: 250m
+  storage:
+    size: 50Gi
+    storageClassName: ""
+
+redis:
+  enabled: true
+  externalUrl: ""
+  image:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      memory: 512Mi
+    requests:
+      memory: 128Mi
+      cpu: 50m
+  maxmemory: "400mb"
+  storage:
+    size: 2Gi
+    storageClassName: ""
+
+ingress:
+  enabled: true
+  className: nginx
+  host: observal.example.com
+  tls:
+    enabled: false
+    secretName: ""
+    certManager:
+      enabled: false
+      issuerName: letsencrypt-prod
+      issuerKind: ClusterIssuer
+  annotations: {}
+
+secrets:
+  # Use a pre-existing Secret instead of creating one. Secret must contain all
+  # keys: SECRET_KEY, POSTGRES_PASSWORD, CLICKHOUSE_PASSWORD, DATABASE_URL,
+  # CLICKHOUSE_URL, REDIS_URL
+  existingSecret: ""
+  secretKey: ""
+  postgresPassword: ""
+  clickhousePassword: ""
+  licenseKey: ""
+
+config:
+  logLevel: INFO
+  logFormat: json
+  jwtSigningAlgorithm: ES256
+  jwtKeyDir: /data/keys
+  seedDemoAccounts: false
+
+apidata:
+  storage:
+    size: 5Gi
+    storageClassName: ""
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}

--- a/observal-server/services/crypto.py
+++ b/observal-server/services/crypto.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Ravi Chopra <shivamchopra1234567890@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
 """Asymmetric key management for JWT signing and verification (ES256 / ECDSA P-256).
@@ -105,8 +106,11 @@ class KeyManager:
         """Load or generate the signing key pair.  Call once at startup."""
         optic.debug("initializing key manager")
         self._key_dir.mkdir(parents=True, exist_ok=True)
-        # Restrict directory to owner-only
-        os.chmod(self._key_dir, 0o700)
+        # Restrict directory to owner-only (ignore on read-only secret mounts)
+        try:
+            os.chmod(self._key_dir, 0o700)
+        except OSError:
+            pass
 
         signing_path = self._key_dir / "signing.pem"
         if signing_path.exists():
@@ -267,7 +271,7 @@ class KeyManager:
             kid = header.get("kid", self.get_kid())
             pub = self.find_public_key(kid)
             if pub is None:
-                raise ValueError(f"Unknown key id: {kid}")
+                raise pyjwt.InvalidTokenError(f"Unknown key id: {kid}")
             return pyjwt.decode(token, pub, algorithms=["ES256"])
         except ImportError:
             pass


### PR DESCRIPTION
## Purpose / Description
Adds official Helm chart for Observal (`infra/helm/observal`) enabling self-hosting on Kubernetes clusters. This covers PR 1 (Core Chart) of the Helm migration plan.

## Fixes
* Fixes #1500

## Approach
- **Hand-written Helm templates**: Hand-rolled production-ready Kubernetes templates (`Deployment`, `StatefulSet`, `Service`, `Ingress`, `ConfigMap`, `Secret`, `ServiceAccount`, `RBAC`) instead of raw kompose generation.
- **StatefulSets for internal DBs**: PostgreSQL 16, ClickHouse 26.3, and Redis 7-alpine with headless services and dynamic PVCs (`volumeClaimTemplates`).
- **Regular Init Job**: Migration job runs as a standard K8s `Job` with init containers waiting for DB readiness, avoiding Helm hook lifecycle deadlocks.
- **K8s Secret Decoupling for JWT**: Auto-generates ES256 JWT signing keys during initialization and stores them in a K8s Secret (`*-jwt-keys`) instead of relying on cross-node shared PVC mounts.
- **Hardened Security Contexts**: All pods enforce `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, with in-memory `emptyDir` mounts for temporary work dirs (`/tmp`).
- **Complete Self-Hosting Docs**: Created `docs/self-hosting/kubernetes-helm.md` and updated deployment tier matrices across documentation.

## How Has This Been Tested?
- **Static Validation**: `helm lint` (0 errors) and `helm template` dry-runs with default and custom values.
- **Functional Verification on Minikube**:
  - Deployed stack in dedicated `observal` namespace with 6 pods running/completed, 5 services, and 4 PVCs bound.
  - Port-forwarded API and Web UI; verified `/readyz` and `/health` returned HTTP 200 `{"status":"ok"}`.
  - Verified cross-container connectivity for Postgres (`psycopg2`), Redis (`ping`), and ClickHouse (`SELECT 1`).
- **Lifecycle Testing**: Verified full `helm uninstall` clean up and reinstall cycles.

## Scope & Deferred Items (PR 2 Plan)
This PR delivers **PR 1 (Core Chart)**. The following production hardening features are deferred to **PR 2**:
- **External DB Toggles**: `postgresql.enabled=false`, `clickhouse.enabled=false`, `redis.enabled=false` with external connection parameters.
- **Bitnami Subchart Integration**: Option to replace hand-rolled StatefulSets with Bitnami production subcharts.
- **Observability Subcharts**: Optional `grafana.enabled` and `prometheus.enabled` subchart toggles.
- **Network & Resilience Policies**: `NetworkPolicy` specs and `PodDisruptionBudgets` (PDBs) for API and worker workloads.
- **Upgrade Migration Tests**: Automated verification of data persistence across chart upgrade revisions.
- **CI checks for helm charts**

## Learning (optional, can help others)
- Using a standard K8s `Job` (with initContainers) instead of Helm hooks avoids release cycle deadlock when DB components are part of the same chart release.
- Storing generated JWT keys directly into a K8s Secret via service account RBAC avoids multi-node PVC access mode constraints (`ReadWriteOnce`).

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes (Google Antigravity / Gemini 3.5 Flash)
- [x] Was the generated code manually reviewed and tested? Yes
