### PR TITLE
docs: show Discord member count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <a href="https://pypi.org/project/observal-cli/"><img src="https://img.shields.io/pypi/v/observal-cli?style=flat-square&logo=pypi&logoColor=white&label=pypi" alt="PyPI version"></a>
   <a href="https://codecov.io/gh/Observal/Observal"><img src="https://img.shields.io/codecov/c/github/Observal/Observal?style=flat-square&logo=codecov" alt="Coverage"></a>
   <a href="https://github.com/Observal/Observal/graphs/contributors"><img src="https://img.shields.io/github/contributors/Observal/Observal?style=flat-square&logo=github" alt="Contributors"></a>
-  <a href="https://discord.observal.io"><img src="https://img.shields.io/badge/discord-chat-5865f2?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.com/invite/SFPjnTWddk"><img src="https://dcbadge.limes.pink/api/server/SFPjnTWddk?style=flat-square" alt="Discord members"></a>
   <a href="https://github.com/orgs/Observal/packages?repo_name=Observal"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Haz3-jolt/b28aba6d0efebb0b430d43c8068feb91/raw/ghcr-pulls.json&style=flat-square" alt="GHCR pulls"></a>
 </p>
 


### PR DESCRIPTION
## Purpose / Description
Update the README Discord badge so it shows the current Discord member count instead of a static chat label.

## Fixes
No linked issue.

## Approach
Replaced the static Shields Discord badge with the dcbadge endpoint for the Observal invite code and pointed the badge link at the Discord invite URL.

## How Has This Been Tested?
Verified the badge endpoint returns an SVG and reports the member count:

```bash
curl -sSL 'https://dcbadge.limes.pink/api/server/SFPjnTWddk?style=flat-square' | rg -o 'aria-label="[^"]+"'
```

Output:

```text
aria-label="Observal: 1129 members"
```

## Learning (optional, can help others)
The requested dcbadge endpoint supports Discord invite codes directly and renders the member count without custom badge infrastructure.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. Not applicable, this PR changes only a README badge.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). Not included, this is a README badge change and screenshots were not requested.

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
