### PR TITLE
feat(cli): instant login method selection without Enter key

### DIFF
--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -29,7 +29,7 @@ from rich import print as rprint
 
 from observal_cli import client, config
 from observal_cli.branding import welcome_banner
-from observal_cli.prompts import password_input, text_input
+from observal_cli.prompts import password_input, quick_choice, text_input
 from observal_cli.render import console, kv_panel, spinner, status_badge
 
 # ── Auth subgroup ───────────────────────────────────────────
@@ -251,24 +251,28 @@ def login(
             if oidc_available and saml_available:
                 rprint("  [1] OIDC SSO")
                 rprint("  [2] SAML SSO")
-                choice = text_input("Login method", default="1")
+                choice = quick_choice("Login method", ["1", "2"])
                 sso_provider = "saml" if choice == "2" else "oidc"
             else:
                 rprint(f"  [1] {'SAML SSO' if saml_available else 'SSO'}")
-                text_input("Login method", default="1")
+                quick_choice("Login method", ["1"])
                 sso_provider = "saml" if saml_available else None
             sso_mode = True
             direct_sso = True
         else:
             rprint("  [1] CLI email/username + password")
             rprint("  [2] Web sign-in")
+            valid = ["1", "2"]
             if oidc_available:
                 rprint("  [3] OIDC SSO")
+                valid.append("3")
             elif saml_available:
                 rprint("  [3] SAML SSO")
+                valid.append("3")
             if oidc_available and saml_available:
                 rprint("  [4] SAML SSO")
-            choice = text_input("Login method", default="1")
+                valid.append("4")
+            choice = quick_choice("Login method", valid)
             if choice == "2":
                 sso_mode = True
             elif choice == "3" and sso_available:

--- a/observal_cli/prompts.py
+++ b/observal_cli/prompts.py
@@ -143,3 +143,36 @@ def password_input(message: str) -> str:
         return result
     except EOFError:
         raise KeyboardInterrupt
+
+
+def quick_choice(message: str, valid_keys: list[str]) -> str:
+    """Single-keypress selection — no Enter required.
+
+    Displays the prompt, waits for one of ``valid_keys`` to be pressed,
+    and returns immediately. Falls back to text_input in non-TTY environments.
+    """
+    if not sys.stdin.isatty():
+        import typer
+
+        return typer.prompt(message, default=valid_keys[0])
+
+    import termios
+    import tty
+
+    from rich import print as rprint
+
+    rprint(f"  {message}: ", end="", flush=True)
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        while True:
+            ch = sys.stdin.read(1)
+            if ch == "\x03":  # Ctrl+C
+                print()
+                raise KeyboardInterrupt
+            if ch in valid_keys:
+                rprint(ch)
+                return ch
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
The `observal auth login` method selection prompt had two UX issues:
1. Option `1` was pre-filled as a default, making it look like it was already selected
2. Users had to press Enter after typing their choice number

This PR makes the selection instant — pressing a number key immediately selects the method with no Enter required.

## Fixes
* Improves CLI login UX

## Approach
- Added a `quick_choice()` helper in `prompts.py` that uses raw terminal mode (`tty.setraw`) to read a single keypress
- Only valid keys (matching the displayed options) are accepted; other keys are ignored
- Falls back to standard `typer.prompt` in non-TTY environments (CI, piped input)
- Replaced `text_input("Login method", default="1")` with `quick_choice("Login method", valid_keys)` in the login flow

## How Has This Been Tested?

- Ran `observal auth login` interactively — pressing `1` immediately proceeds to email/password prompt
- Pressing `2` immediately starts web sign-in flow
- Invalid keys are ignored (no crash, no output)
- Ctrl+C cleanly raises KeyboardInterrupt and restores terminal settings

## Learning
Python's `tty.setraw()` + `termios` allows reading individual keypresses without waiting for Enter. The terminal must be restored to its original settings in a `finally` block to avoid leaving the terminal in a broken state.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
Was generative AI tooling used to co-author this PR?

- [x] Yes(Please Specify the tool): Kiro CLI
- [x] Was the generated code manually reviewed and tested?