### PR TITLE
fix(web): danger zone title click expands section instead of opening docs

### DIFF
--- a/web/src/pages/admin/settings.tsx
+++ b/web/src/pages/admin/settings.tsx
@@ -1389,7 +1389,12 @@ export default function SettingsPage() {
 												<details key={section.title} className="group rounded-md border-l-4 border-amber-500/60 border-2 border-border/70 bg-card">
 													<summary className="flex items-center gap-2 px-4 py-3 cursor-pointer select-none hover:bg-muted/30 transition-colors">
 														{sectionIcon(section)}
-														<span className={`text-sm font-semibold text-foreground/80 flex-1 ${SECTION_DOCS[section.title] ? "hover:text-primary transition-colors" : ""}`} onClick={(e) => { if (SECTION_DOCS[section.title]) { e.preventDefault(); e.stopPropagation(); openHelp(undefined, section.title); } }}>{section.title}</span>
+														<span className="text-sm font-semibold text-foreground/80 flex-1">{section.title}</span>
+														{SECTION_DOCS[section.title] && (
+															<button type="button" className="text-muted-foreground hover:text-primary" onClick={(e) => { e.preventDefault(); e.stopPropagation(); openHelp(undefined, section.title); }} aria-label={`Open ${section.title} documentation`}>
+																<HelpCircle className="h-3.5 w-3.5" />
+															</button>
+														)}
 														<span className="text-[10px] text-amber-600 dark:text-amber-400 font-medium">CAUTION</span>
 													</summary>
 													<div className="px-4 pb-4 pt-1">


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
In the admin settings page, clicking anywhere on the Danger Zone section title text opened the documentation/info page instead of expanding the section. Users had to click specifically on the small expand icon to actually open the settings editor, which was unintuitive.

## Fixes
* Fixes UX issue with danger zone section expand behavior

## Approach
- Removed the `onClick` handler from the section title `<span>` that was hijacking clicks to open the help page
- Added a separate `<HelpCircle>` icon button (with `stopPropagation`) for opening docs — matching the pattern used by all non-danger sections
- Clicking the title/bar now correctly toggles the `<details>` expand/collapse as expected

## How Has This Been Tested?

- Rebuilt the web container and verified:
  - Clicking the section title/bar expands and collapses the danger zone section
  - Clicking the HelpCircle icon opens the documentation page
  - Non-danger sections remain unaffected
<img width="1582" height="497" alt="image" src="https://github.com/user-attachments/assets/6a8f1940-ef05-43fb-87c9-f873a8a15487" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
Was generative AI tooling used to co-author this PR?

- [x] Yes(Please Specify the tool): Kiro CLI
- [x] Was the generated code manually reviewed and tested?