### PR TITLE
fix(registry): add updated_at to listing summary schemas

### DIFF
--- a/observal-server/schemas/hook.py
+++ b/observal-server/schemas/hook.py
@@ -138,6 +138,7 @@ class HookListingSummary(BaseModel):
     owner: str
     status: ListingStatus
     rejection_reason: str | None = None
+    updated_at: datetime | None = None
     model_config = {"from_attributes": True}
 
 

--- a/observal-server/schemas/mcp.py
+++ b/observal-server/schemas/mcp.py
@@ -190,6 +190,7 @@ class McpListingSummary(BaseModel):
     supported_ides: list[str]
     status: ListingStatus
     rejection_reason: str | None = None
+    updated_at: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/observal-server/schemas/prompt.py
+++ b/observal-server/schemas/prompt.py
@@ -91,6 +91,7 @@ class PromptListingSummary(BaseModel):
     owner: str
     status: ListingStatus
     rejection_reason: str | None = None
+    updated_at: datetime | None = None
     model_config = {"from_attributes": True}
 
 

--- a/observal-server/schemas/sandbox.py
+++ b/observal-server/schemas/sandbox.py
@@ -111,4 +111,5 @@ class SandboxListingSummary(BaseModel):
     supported_ides: list[str]
     status: ListingStatus
     rejection_reason: str | None = None
+    updated_at: datetime | None = None
     model_config = {"from_attributes": True}

--- a/observal-server/schemas/skill.py
+++ b/observal-server/schemas/skill.py
@@ -132,6 +132,7 @@ class SkillListingSummary(BaseModel):
     target_agents: list[str]
     status: ListingStatus
     rejection_reason: str | None = None
+    updated_at: datetime | None = None
     model_config = {"from_attributes": True}
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

## Purpose / Description
The registry components page table shows `-` for the "Updated" column because the `updated_at` field was missing from the lightweight summary schemas (e.g. `McpListingSummary`, `SkillListingSummary`) returned by the list API, causing `row.original.updated_at` to be undefined on the frontend.

## Fixes
* Fixes missing Updated timestamps in the registry components list view.

## Approach
Added `updated_at: datetime | None = None` to the Pydantic summary schemas in `observal-server/schemas/` (mcp, hook, prompt, sandbox, skill).

## How Has This Been Tested?
Ran `make test` passing all 3938 unit/integration tests successfully. Checked typing with `make lint`.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes(Please Specify the tool): Pi
- [x] Was the generated code manually reviewed and tested? Yes