### PR TITLE
fix(docker): add missing nginx tmpfs mounts for read-only rootfs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -228,6 +228,7 @@ services:
     read_only: true
     tmpfs:
       - /var/cache/nginx
+      - /var/log/nginx
       - /var/run
       - /tmp
     security_opt:

--- a/docker/server-package/docker-compose.yml
+++ b/docker/server-package/docker-compose.yml
@@ -172,6 +172,9 @@ services:
     restart: unless-stopped
     read_only: true
     tmpfs:
+      - /var/cache/nginx
+      - /var/log/nginx
+      - /var/run
       - /tmp
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## Purpose / Description
The nginx-based containers (`observal-lb`) crash on startup when running with `read_only: true` because they cannot write to `/var/cache/nginx`, `/var/log/nginx`, or `/var/run`. The server-package compose was missing these tmpfs mounts entirely, and the dev compose was missing `/var/log/nginx`.

## Fixes
* Fixes #<!-- no linked issue -->

## Approach
Added the necessary tmpfs mounts to both compose files so nginx has writable paths for its cache, logs, PID file, and temp files while keeping the read-only rootfs security posture intact.

- `docker/server-package/docker-compose.yml`: added `/var/cache/nginx`, `/var/log/nginx`, `/var/run`
- `docker/docker-compose.yml`: added `/var/log/nginx`

## How Has This Been Tested?

Rebuilt the server-package tarball and deployed with `docker compose up`. Confirmed `observal-lb` starts cleanly and serves requests without filesystem errors. Verified with `docker inspect` that tmpfs mounts are present.

## Learning (optional, can help others)
Nginx needs writable paths for its PID file (`/var/run`), proxy/fastcgi cache (`/var/cache/nginx`), and access/error logs (`/var/log/nginx`). When using `read_only: true` in Docker, these must be explicitly mounted as tmpfs.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Kiro (Claude Opus 4.6)
- [x] Was the generated code manually reviewed and tested?