### PR TITLE
fix: standalone packaging bugs and remove legacy env var system

### DIFF
--- a/docker/clickhouse/config.d/listen.xml
+++ b/docker/clickhouse/config.d/listen.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+</clickhouse>

--- a/docker/clickhouse/config.d/listen.xml
+++ b/docker/clickhouse/config.d/listen.xml
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
 <clickhouse>
     <listen_host>0.0.0.0</listen_host>
 </clickhouse>

--- a/docker/server-package/docker-compose.yml
+++ b/docker/server-package/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     command: ["/app/entrypoint.sh"]
     env_file:
       - ./.env
-    environment:
-      - DATA_RETENTION_DAYS=${DATA_RETENTION_DAYS:-90}
     depends_on:
       observal-db:
         condition: service_healthy
@@ -35,7 +33,6 @@ services:
     env_file:
       - ./.env
     environment:
-      - DATA_RETENTION_DAYS=${DATA_RETENTION_DAYS:-90}
       - JWT_KEY_DIR=/data/keys
       - SKIP_DDL_ON_STARTUP=true
       - DEMO_SUPER_ADMIN_EMAIL=${DEMO_SUPER_ADMIN_EMAIL:-super@demo.example}

--- a/docker/server-package/env.template
+++ b/docker/server-package/env.template
@@ -22,10 +22,6 @@ REDIS_URL=redis://observal-redis:6379
 
 # Deployment mode: "local" or "enterprise"
 
-# Frontend URL (used for CORS, SSO callbacks, email links)
-# Set to your public domain in production
-FRONTEND_URL=__FRONTEND_URL__
-
 # Optional: OAuth / OIDC SSO
 # OAUTH_CLIENT_ID=
 # OAUTH_CLIENT_SECRET=
@@ -41,9 +37,6 @@ FRONTEND_URL=__FRONTEND_URL__
 # EVAL_MODEL_API_KEY=
 # EVAL_MODEL_NAME=
 # EVAL_MODEL_PROVIDER=
-
-# ClickHouse data retention (days). Set to 0 to disable TTL.
-DATA_RETENTION_DAYS=90
 
 # Enterprise license key (leave blank for community edition)
 # Get a key: https://observal.dev/enterprise

--- a/docker/server-package/setup.sh
+++ b/docker/server-package/setup.sh
@@ -217,7 +217,6 @@ sed -i.bak \
     -e "s|__SECRET_KEY__|$SECRET_KEY|g" \
     -e "s|__POSTGRES_PASSWORD__|$POSTGRES_PASSWORD|g" \
     -e "s|__CLICKHOUSE_PASSWORD__|$CLICKHOUSE_PASSWORD|g" \
-    -e "s|__FRONTEND_URL__|$FRONTEND_URL|g" \
     "$ENV_FILE"
 rm -f "$ENV_FILE.bak"
 

--- a/observal-server/config.py
+++ b/observal-server/config.py
@@ -18,7 +18,6 @@ Only infrastructure, crypto, and auth middleware vars remain here.
 """
 
 import os
-import sys
 from typing import Literal
 
 from pydantic_settings import BaseSettings
@@ -74,67 +73,3 @@ settings = Settings()
 # Feature availability is still gated by ee.license.is_feature_licensed();
 # this flag only controls "should we attempt to load ee/ packages."
 HAS_LICENSE: bool = bool(os.environ.get("OBSERVAL_LICENSE_KEY", ""))
-
-
-# ── Legacy Env Var Startup Guard ─────────────────────────────────────────────
-# Refuse to start if legacy env vars are detected. This prevents silent
-# misconfiguration after upgrading to 1.0.
-
-_LEGACY_ENV_VARS = [
-    "EVAL_MODEL_URL",
-    "EVAL_MODEL_API_KEY",
-    "EVAL_MODEL_NAME",
-    "EVAL_MODEL_PROVIDER",
-    "INSIGHT_MODEL_SECTIONS",
-    "INSIGHT_MODEL_SYNTHESIS",
-    "INSIGHT_MODEL_FACETS",
-    "INSIGHT_BATCH_ENABLED",
-    "INSIGHT_BATCH_PERIOD_DAYS",
-    "INSIGHT_MIN_SESSIONS",
-    "INSIGHT_FACET_MAX_CALLS",
-    "INSIGHT_FACET_CONCURRENCY",
-    "INSIGHTS_AVAILABLE",
-    "FRONTEND_URL",
-    "PUBLIC_URL",
-    "CORS_ALLOWED_ORIGINS",
-    "ALLOW_INTERNAL_GIT_URLS",
-    "ALLOW_DRAFT_INSTALL",
-    "RATE_LIMIT_AUTH",
-    "RATE_LIMIT_AUTH_STRICT",
-    "TRUSTED_PROXY_IPS",
-    "JWT_ACCESS_TOKEN_EXPIRE_MINUTES",
-    "JWT_REFRESH_TOKEN_EXPIRE_DAYS",
-    "JWT_HOOKS_TOKEN_EXPIRE_MINUTES",
-    "DATA_RETENTION_DAYS",
-    "CACHE_TTL_DEFAULT",
-    "CACHE_TTL_DASHBOARD",
-    "ENABLE_OPENAPI",
-    "ENABLE_METRICS",
-    "MIN_CLI_VERSION",
-    "GIT_MIRROR_BASE_PATH",
-    "DEPLOYMENT_MODE",
-]
-
-
-def check_legacy_env_vars() -> None:
-    """Check for legacy env vars and refuse to start if any are detected."""
-    detected = [var for var in _LEGACY_ENV_VARS if os.environ.get(var)]
-    if not detected:
-        return
-
-    print("\n" + "=" * 72, file=sys.stderr)
-    print("ERROR: Detected legacy environment variables that are no longer supported:", file=sys.stderr)
-    print(f"  {', '.join(detected[:10])}", file=sys.stderr)
-    if len(detected) > 10:
-        print(f"  ... and {len(detected) - 10} more", file=sys.stderr)
-    print(file=sys.stderr)
-    print("As of v1.0.0, these settings are managed via the Settings page (super admin).", file=sys.stderr)
-    print(file=sys.stderr)
-    print("To fix:", file=sys.stderr)
-    print("  1. cp .env.example .env", file=sys.stderr)
-    print("  2. Fill in only the required boot-time variables", file=sys.stderr)
-    print("  3. After startup, configure remaining settings at /settings", file=sys.stderr)
-    print(file=sys.stderr)
-    print("See: https://docs.observal.dev/upgrade/1.0", file=sys.stderr)
-    print("=" * 72 + "\n", file=sys.stderr)
-    sys.exit(1)

--- a/observal-server/startup.py
+++ b/observal-server/startup.py
@@ -9,7 +9,7 @@ from sqlalchemy import select, update
 
 import services.dynamic_settings as ds
 from api.deps import get_or_create_default_org
-from config import HAS_LICENSE, check_legacy_env_vars, settings
+from config import HAS_LICENSE, settings
 from database import engine
 from models import Base
 from models.user import User
@@ -44,8 +44,6 @@ async def ensure_columns(conn) -> None:
 
 async def run_startup_tasks() -> None:
     """Initialize application dependencies used by the FastAPI lifespan."""
-    check_legacy_env_vars()
-
     if not settings.SKIP_DDL_ON_STARTUP:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes two critical bugs in the standalone deployment package (`observal-server-vX.X.X.tar.gz`) that prevent a successful boot, and completely removes the hard-crashing legacy environment variable guard.

## Fixes
* Fixes standalone deployment bugs reported by user on `v1.9.5`.

## Approach
1. **ClickHouse Listen Host**: Added `docker/clickhouse/config.d/listen.xml` to override the default ClickHouse binding, allowing it to listen on `0.0.0.0` instead of just `127.0.0.1`. Without this, the `observal-api` container on the Docker bridge network cannot reach the DB.
2. **Legacy Environment Variables**: 
   - Stripped `FRONTEND_URL` and `DATA_RETENTION_DAYS` from `env.template`, `setup.sh`, and `docker-compose.yml`. 
   - **Removed the Legacy Env Guard** (`check_legacy_env_vars`) from the server entirely. The server will no longer hard-crash (`sys.exit(1)`) if old v1.0.0 environment variables are present in the `.env` file.

*(Note: The third bug regarding the nginx tmpfs mounts was already resolved in upstream `main` and has been omitted from this PR).*

## How Has This Been Tested?
- Verified the `listen.xml` matches the override required for ClickHouse in Docker environments.
- Verified the legacy environment variables were removed from the template, script interpolation, and compose environment blocks.
- Verified the strict `sys.exit(1)` guard was cleanly removed from `config.py` and `startup.py`.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Raindrop
- [x] Was the generated code manually reviewed and tested?