### PR TITLE
fix(cli): strip quotes from env and header values

### DIFF
--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1457,12 +1457,12 @@ def install(
     for item in env or []:
         k, _, v = item.partition("=")
         if k:
-            env_overrides[k.strip()] = v
+            env_overrides[k.strip()] = v.strip("\"'")
     header_overrides = {}
     for item in header or []:
         k, _, v = item.partition("=")
         if k:
-            header_overrides[k.strip()] = v
+            header_overrides[k.strip()] = v.strip("\"'")
     _install_impl(
         mcp_id,
         ide,

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -288,7 +288,7 @@ def prompt_render(
     variables = {}
     for v in var:
         k, _, val = v.partition("=")
-        variables[k] = val
+        variables[k] = val.strip("\"'")
     with spinner("Rendering prompt..."):
         result = client.post(f"/api/v1/prompts/{resolved}/render", {"variables": variables})
     rprint(result.get("rendered", result))

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -587,14 +587,14 @@ def register_pull(app: typer.Typer):
         for item in env or []:
             k, _, v = item.partition("=")
             if k:
-                env_overrides[k.strip()] = v
+                env_overrides[k.strip()] = v.strip("\"'")
 
         # Parse --header flags into overrides dict
         header_overrides: dict[str, str] = {}
         for item in header or []:
             k, _, v = item.partition("=")
             if k:
-                header_overrides[k.strip()] = v
+                header_overrides[k.strip()] = v.strip("\"'")
 
         # Fetch agent details to discover MCP env vars
         with spinner("Fetching agent details..."):

--- a/observal_cli/sandbox_runner.py
+++ b/observal_cli/sandbox_runner.py
@@ -286,7 +286,7 @@ def main():
             i += 2
         elif args[i] == "--env" and i + 1 < len(args):
             k, _, v = args[i + 1].partition("=")
-            env[k] = v
+            env[k] = v.strip("\"'")
             i += 2
         elif args[i] == "--":
             command = " ".join(args[i + 1 :])


### PR DESCRIPTION
## Purpose
Fixes an issue where `--env` and `--header` options in the CLI failed to parse values properly or retained literal quotes when users provided over-escaped strings like `--env KEY="VALUE"`.

## Fixes
Fixes deterministic failures when running commands like:
`observal agent pull incident-resolver --harness kiro --env "JIRA_URL=https://appian-eng.appian.com?foo=bar" --env "JIRA_EMAIL=foo@bar.com" --header "Authorization=Bearer kQCHz2cC"`

## Approach
Updated the parsers in `cmd_pull.py`, `cmd_mcp.py`, `sandbox_runner.py`, and `cmd_prompt.py` to use `v.strip("\"'")` after partitioning on `=`, so that any leftover literal quotes are safely stripped before the value enters the configuration system.

## How Tested
Tested manually via a custom python wrapper mimicking Typer's parsing over the changed functions. Verified that values with embedded `=` and explicit quotes are properly cleaned.

## Checklist
- [x] Tested manually
- [x] Run `make format`
