### PR TITLE
fix(cli): show installer upgrade commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -209,6 +209,8 @@ if [ "$VERSION" = "latest" ]; then
     VERSION=$(curl -fsSL "https://api.github.com/repos/$GITHUB_REPO/releases/latest" |
         grep '"tag_name"' | head -1 | cut -d'"' -f4)
     [ -n "$VERSION" ] || die "Could not determine latest version"
+elif [ "${VERSION#v}" = "$VERSION" ]; then
+    VERSION="v$VERSION"
 fi
 
 info "Installing Observal CLI $VERSION ($OS/$ARCH) [$EDITION edition]"
@@ -265,11 +267,30 @@ else
     sudo chmod +x "$INSTALL_PATH"
 fi
 
+# ── Write install metadata ──────────────────────────────────
+
+CONFIG_DIR="${HOME}/.observal"
+mkdir -p "$CONFIG_DIR"
+INSTALL_METADATA="$CONFIG_DIR/install.json"
+json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+if ! cat >"$INSTALL_METADATA" <<EOF
+{
+  "method": "curl",
+  "manager": "curl",
+  "path": "$(json_escape "$INSTALL_PATH")",
+  "version": "$(json_escape "$VERSION")"
+}
+EOF
+then
+    warn "Could not write install metadata to $INSTALL_METADATA"
+fi
+
 # ── Write license key to config ──────────────────────────────
 
 if [ "$EDITION" = "enterprise" ] && [ -n "$LICENSE_KEY" ]; then
-    CONFIG_DIR="${HOME}/.observal"
-    mkdir -p "$CONFIG_DIR"
     CONFIG_FILE="$CONFIG_DIR/config.json"
 
     if [ -f "$CONFIG_FILE" ]; then

--- a/observal-server/middleware.py
+++ b/observal-server/middleware.py
@@ -191,7 +191,7 @@ def _should_require_cli_version_header(request: Request) -> bool:
 
 
 def _cli_version_response(server_ver: str, cli_ver_str: str | None) -> JSONResponse:
-    install_command = f"python -m pip install observal-cli=={server_ver}"
+    install_command = f"observal self upgrade --version {server_ver}"
     shown_cli_version = cli_ver_str or "unknown"
     return JSONResponse(
         status_code=426,

--- a/observal-server/tests/test_config.py
+++ b/observal-server/tests/test_config.py
@@ -68,7 +68,7 @@ def test_version_middleware_rejects_cli_drift(monkeypatch):
     response = client.get("/api/v1/example", headers={"X-Observal-CLI-Version": "1.6.1"})
 
     assert response.status_code == 426
-    assert response.json()["install_command"] == "python -m pip install observal-cli==1.6.2"
+    assert response.json()["install_command"] == "observal self upgrade --version 1.6.2"
 
 
 def test_version_middleware_allows_exact_cli_match(monkeypatch):
@@ -113,7 +113,7 @@ def test_version_middleware_rejects_cli_without_version_header(monkeypatch):
     )
 
     assert response.status_code == 426
-    assert response.json()["install_command"] == "python -m pip install observal-cli==1.6.2"
+    assert response.json()["install_command"] == "observal self upgrade --version 1.6.2"
 
 
 def test_version_middleware_allows_browser_without_cli_header(monkeypatch):

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -105,7 +105,9 @@ def _ensure_cli_matches_server(server_url: str) -> None:
     if cli_version == server_version:
         return
 
-    install_command = f"pipx install --force 'observal-cli=={server_ver}'"
+    from observal_cli.install_detector import upgrade_command
+
+    install_command = upgrade_command(server_ver)
     direction = "ahead of" if cli_version > server_version else "behind"
     rprint(
         f"\n[bold red]CLI version {cli_ver_str} is {direction} server {server_ver}.[/bold red]\n"

--- a/observal_cli/install_detector.py
+++ b/observal_cli/install_detector.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-"""Detect how the CLI was installed to determine upgrade strategy.
-
-Supports: uv tool, pip, standalone binary (PyInstaller), Homebrew, system package.
-"""
+"""Detect how the CLI was installed to determine upgrade strategy."""
 
 from __future__ import annotations
 
+import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -16,9 +15,12 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+INSTALLER_URL = "https://raw.githubusercontent.com/Observal/Observal/main/install.sh"
+
 
 class InstallMethod(Enum):
     UV_TOOL = "uv_tool"
+    PIPX = "pipx"
     PIP = "pip"
     BINARY = "binary"
     HOMEBREW = "homebrew"
@@ -29,12 +31,11 @@ class InstallMethod(Enum):
 @dataclass(frozen=True)
 class InstallInfo:
     method: InstallMethod
-    path: Path  # Path to the observal binary/script
-    writable: bool  # Whether current user can write to it
-    managed_by: str | None  # e.g., "brew", "apt", "uv", "pip"
+    path: Path
+    writable: bool
+    managed_by: str | None
 
 
-# Module-level cache (detect once per process)
 _cached_info: InstallInfo | None = None
 
 
@@ -48,14 +49,35 @@ def detect() -> InstallInfo:
     path_str = str(binary_path).lower()
 
     info = _detect_from_path(binary_path, path_str)
+    if info.method == InstallMethod.PIPX:
+        _write_install_metadata(info)
     _cached_info = info
     return info
 
 
-def _detect_from_path(binary_path: Path, path_str: str) -> InstallInfo:
-    """Internal detection logic (separated for testability)."""
+def upgrade_command(target_version: str, install_info: InstallInfo | None = None) -> str:
+    """Return the command users should run to install a specific CLI version."""
+    info = install_info or detect()
+    package = f"observal-cli=={target_version}"
 
-    # 1. Homebrew (most specific path check)
+    if info.method == InstallMethod.UV_TOOL:
+        return f"uv tool install --force {shlex.quote(package)}"
+    if info.method == InstallMethod.PIPX:
+        return f"pipx install --force {shlex.quote(package)}"
+    if info.method == InstallMethod.PIP:
+        return f"{shlex.quote(sys.executable)} -m pip install {shlex.quote(package)}"
+    if info.method == InstallMethod.BINARY and info.managed_by == "curl":
+        return f"curl -fsSL {INSTALLER_URL} | bash -s -- --version {_release_tag(target_version)}"
+    if info.method == InstallMethod.HOMEBREW:
+        return "brew upgrade observal"
+    if info.method == InstallMethod.SYSTEM_PACKAGE and info.managed_by:
+        return f"{info.managed_by} upgrade observal"
+    return f"observal self upgrade --version {target_version}"
+
+
+def _detect_from_path(binary_path: Path, path_str: str) -> InstallInfo:
+    """Internal detection logic, separated for testability."""
+
     if "/homebrew/" in path_str or "/linuxbrew/" in path_str or "linuxbrew" in path_str:
         return InstallInfo(
             method=InstallMethod.HOMEBREW,
@@ -64,7 +86,6 @@ def _detect_from_path(binary_path: Path, path_str: str) -> InstallInfo:
             managed_by="brew",
         )
 
-    # 2. System package manager (/usr/bin, /usr/sbin)
     if path_str.startswith(("/usr/bin/", "/usr/sbin/")):
         return InstallInfo(
             method=InstallMethod.SYSTEM_PACKAGE,
@@ -73,16 +94,25 @@ def _detect_from_path(binary_path: Path, path_str: str) -> InstallInfo:
             managed_by=_detect_system_pkg_mgr(),
         )
 
-    # 3. Standalone binary (PyInstaller frozen)
+    if _is_pipx_path(binary_path):
+        return InstallInfo(
+            method=InstallMethod.PIPX,
+            path=binary_path,
+            writable=True,
+            managed_by="pipx",
+        )
+
+    metadata = _read_install_metadata()
+    managed_by = "curl" if metadata.get("method") == "curl" and _same_path(metadata.get("path"), binary_path) else None
+
     if getattr(sys, "frozen", False):
         return InstallInfo(
             method=InstallMethod.BINARY,
             path=binary_path,
             writable=os.access(binary_path, os.W_OK),
-            managed_by=None,
+            managed_by=managed_by,
         )
 
-    # 4. uv tool (fast path: check if under uv tool directory)
     uv_tool_dir = Path.home() / ".local" / "share" / "uv" / "tools"
     if str(binary_path).startswith(str(uv_tool_dir)):
         return InstallInfo(
@@ -92,7 +122,6 @@ def _detect_from_path(binary_path: Path, path_str: str) -> InstallInfo:
             managed_by="uv",
         )
 
-    # 5. uv tool (slow path: ask uv)
     if _check_uv_tool_list():
         return InstallInfo(
             method=InstallMethod.UV_TOOL,
@@ -101,7 +130,14 @@ def _detect_from_path(binary_path: Path, path_str: str) -> InstallInfo:
             managed_by="uv",
         )
 
-    # 6. Default: assume pip
+    if _check_pipx_list():
+        return InstallInfo(
+            method=InstallMethod.PIPX,
+            path=binary_path,
+            writable=True,
+            managed_by="pipx",
+        )
+
     return InstallInfo(
         method=InstallMethod.PIP,
         path=binary_path,
@@ -122,6 +158,70 @@ def _check_uv_tool_list() -> bool:
         return r.returncode == 0 and "observal-cli" in r.stdout
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return False
+
+
+def _check_pipx_list() -> bool:
+    """Check if observal-cli is in pipx list output."""
+    try:
+        r = subprocess.run(
+            ["pipx", "list"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return r.returncode == 0 and "observal-cli" in r.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _is_pipx_path(binary_path: Path) -> bool:
+    homes = [
+        Path.home() / ".local" / "share" / "pipx",
+        Path.home() / ".local" / "pipx",
+    ]
+    if pipx_home := os.environ.get("PIPX_HOME"):
+        homes.append(Path(pipx_home))
+    path = str(binary_path)
+    return any(path.startswith(str(home / "venvs")) for home in homes)
+
+
+def _install_metadata_path() -> Path:
+    return Path.home() / ".observal" / "install.json"
+
+
+def _read_install_metadata() -> dict:
+    path = _install_metadata_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_install_metadata(info: InstallInfo) -> None:
+    path = _install_metadata_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "method": info.managed_by if info.managed_by == "curl" else info.method.value,
+        "manager": info.managed_by,
+        "path": str(info.path),
+    }
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _same_path(value: object, path: Path) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        return Path(value).resolve() == path.resolve()
+    except OSError:
+        return False
+
+
+def _release_tag(version: str) -> str:
+    return version if version.startswith("v") else f"v{version}"
 
 
 def _detect_system_pkg_mgr() -> str | None:

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -290,6 +290,8 @@ def _show_update_banner() -> None:
         from packaging.version import Version
         from rich import print as _rprint
 
+        from observal_cli.install_detector import upgrade_command
+
         # Only show banner for major version upgrades (community mode)
         # Hard block already handles minor mismatches; auto-update handles patches
         if update.source == "github":
@@ -298,7 +300,7 @@ def _show_update_banner() -> None:
             if latest_v.major > current_v.major:
                 _rprint(
                     f"\n[yellow]Major update available: v{update.current} \u2192 v{update.latest}[/yellow]\n"
-                    f"  Run: [bold cyan]pipx install --force 'observal-cli=={update.latest}'[/bold cyan]"
+                    f"  Run: [bold cyan]{upgrade_command(update.latest)}[/bold cyan]"
                 )
     except Exception:
         pass  # Never crash the CLI for a version check

--- a/observal_cli/upgrade_executor.py
+++ b/observal_cli/upgrade_executor.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: AGPL-3.0-only
 
-"""CLI upgrade executor - handles uv/pip/binary install paths.
+"""CLI upgrade executor - handles uv/pipx/pip/binary install paths.
 
 Extracted from cmd_ops.py for testability and readability.
 """
@@ -40,6 +40,8 @@ def execute(install_info: InstallInfo, target_version: str, direction: str, spin
     """
     if install_info.method == InstallMethod.UV_TOOL:
         _install_via_uv(target_version, direction, spinner)
+    elif install_info.method == InstallMethod.PIPX:
+        _install_via_pipx(target_version, direction, spinner)
     elif install_info.method == InstallMethod.PIP:
         _install_via_pip(target_version, direction, spinner)
     elif install_info.method == InstallMethod.BINARY:
@@ -65,10 +67,22 @@ def _install_via_uv(target_version: str, direction: str, spinner) -> None:
         raise typer.Exit(1)
 
 
+def _install_via_pipx(target_version: str, direction: str, spinner) -> None:
+    with spinner(f"{direction.capitalize()}ing to v{target_version}..."):
+        result = subprocess.run(
+            ["pipx", "install", f"observal-cli=={target_version}", "--force"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    if result.returncode != 0:
+        rprint(f"[red]{direction.capitalize()} failed:[/red] {result.stderr.strip()}")
+        raise typer.Exit(1)
+
+
 def _install_via_pip(target_version: str, direction: str, spinner) -> None:
     # Uses sys.executable to target the current Python environment. If the CLI
-    # is installed via uv (preferred), the uv path is used instead (see execute()).
-    # sys.executable is only reached for plain pip/pipx installs.
+    # is installed via uv or pipx, those paths are used instead.
     with spinner(f"{direction.capitalize()}ing to v{target_version}..."):
         result = subprocess.run(
             [sys.executable, "-m", "pip", "install", f"observal-cli=={target_version}", "--quiet"],
@@ -241,6 +255,14 @@ def execute_silent(install_info: InstallInfo, target_version: str, direction: st
         if install_info.method == InstallMethod.UV_TOOL:
             result = subprocess.run(
                 ["uv", "tool", "install", f"observal-cli=={target_version}", "--force"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return result.returncode == 0
+        elif install_info.method == InstallMethod.PIPX:
+            result = subprocess.run(
+                ["pipx", "install", f"observal-cli=={target_version}", "--force"],
                 capture_output=True,
                 text=True,
                 timeout=30,

--- a/observal_cli/version_check.py
+++ b/observal_cli/version_check.py
@@ -587,7 +587,9 @@ def check_version_compatibility(server_url: str) -> None:
     if cli_v == srv_v:
         return
 
-    install_command = f"pipx install --force 'observal-cli=={server_ver}'"
+    from observal_cli.install_detector import upgrade_command
+
+    install_command = upgrade_command(server_ver)
     direction = "ahead of" if cli_v > srv_v else "behind"
     rprint(
         f"\n[bold red]\u2716 CLI version {cli_ver_str} is {direction} server {server_ver}.[/bold red]\n"
@@ -657,10 +659,12 @@ def auto_update_if_needed() -> bool:
         if sys.stdout.isatty():
             from rich import print as _rprint
 
+            from observal_cli.install_detector import upgrade_command
+
             _rprint(
                 f"\n[yellow]Major update available: v{current_str} \u2192 v{target_str}[/yellow]\n"
                 f"  This may include breaking changes.\n"
-                f"  Run: [bold cyan]pipx install --force 'observal-cli=={target_str}'[/bold cyan]\n"
+                f"  Run: [bold cyan]{upgrade_command(target_str)}[/bold cyan]\n"
             )
         return False
 

--- a/tests/test_install_detector.py
+++ b/tests/test_install_detector.py
@@ -9,8 +9,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 from observal_cli.install_detector import (
+    InstallInfo,
     InstallMethod,
     _detect_from_path,
+    _write_install_metadata,
+    upgrade_command,
 )
 
 
@@ -54,13 +57,36 @@ class TestDetectFromPath:
         assert result.method == InstallMethod.UV_TOOL
         assert result.managed_by == "uv"
 
+    def test_pipx_path_detected(self, monkeypatch, tmp_path):
+        pipx_dir = tmp_path / ".local" / "share" / "pipx" / "venvs" / "observal-cli" / "bin"
+        pipx_dir.mkdir(parents=True)
+        binary = pipx_dir / "observal"
+        binary.touch()
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = _detect_from_path(binary, str(binary).lower())
+        assert result.method == InstallMethod.PIPX
+        assert result.managed_by == "pipx"
+
+    def test_curl_metadata_detected(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        binary = tmp_path / "bin" / "observal"
+        binary.parent.mkdir()
+        binary.touch()
+        _write_install_metadata(InstallInfo(InstallMethod.BINARY, binary, True, "curl"))
+        monkeypatch.setattr("sys.frozen", True, raising=False)
+
+        result = _detect_from_path(binary, str(binary).lower())
+        assert result.method == InstallMethod.BINARY
+        assert result.managed_by == "curl"
+
     def test_fallback_pip(self, monkeypatch):
         monkeypatch.delattr("sys.frozen", raising=False)
         path = Path("/home/user/.venv/bin/observal")
-        # Not under uv dir, not homebrew, not system, not frozen
         with (
             patch("os.access", return_value=True),
             patch("observal_cli.install_detector._check_uv_tool_list", return_value=False),
+            patch("observal_cli.install_detector._check_pipx_list", return_value=False),
         ):
             result = _detect_from_path(path, str(path).lower())
         assert result.method == InstallMethod.PIP
@@ -70,9 +96,12 @@ class TestDetectFromPath:
 class TestWritableCheck:
     def test_writable_true(self):
         path = Path("/tmp/observal")
-        with patch("os.access", return_value=True):
+        with (
+            patch("os.access", return_value=True),
+            patch("observal_cli.install_detector._check_uv_tool_list", return_value=False),
+            patch("observal_cli.install_detector._check_pipx_list", return_value=False),
+        ):
             result = _detect_from_path(path, str(path).lower())
-        # Falls through to pip since not frozen, not uv, etc.
         assert result.writable is True
 
     def test_writable_false(self):
@@ -80,3 +109,16 @@ class TestWritableCheck:
         with patch("os.access", return_value=False):
             result = _detect_from_path(path, str(path).lower())
         assert result.writable is False
+
+
+class TestUpgradeCommand:
+    def test_pipx_command(self):
+        info = InstallInfo(InstallMethod.PIPX, Path("/fake/observal"), True, "pipx")
+        assert upgrade_command("1.2.0", info) == "pipx install --force observal-cli==1.2.0"
+
+    def test_curl_command_uses_installer(self):
+        info = InstallInfo(InstallMethod.BINARY, Path("/fake/observal"), True, "curl")
+        assert upgrade_command("1.2.0", info) == (
+            "curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh "
+            "| bash -s -- --version v1.2.0"
+        )

--- a/tests/test_self_commands.py
+++ b/tests/test_self_commands.py
@@ -129,6 +129,38 @@ class TestSelfDowngrade:
         result = runner.invoke(app, ["self", "downgrade", "--version", "1.3.0"])
         assert "not older" in result.output.lower() or "upgrade" in result.output.lower()
 
+    def test_downgrade_pipx_install(self, mock_version, mock_lock, monkeypatch):
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+
+        info = InstallInfo(InstallMethod.PIPX, Path("/home/user/.local/bin/observal"), True, "pipx")
+        install_called = {}
+        monkeypatch.setattr("observal_cli.install_detector.detect", lambda: info)
+        monkeypatch.setattr(
+            "observal_cli.cmd_ops._do_install",
+            lambda i, target, direction: install_called.update(i=i, target=target, direction=direction),
+        )
+
+        app = _get_app()
+        result = runner.invoke(app, ["self", "downgrade", "--version", "1.1.0", "--force"])
+        assert result.exit_code == 0
+        assert install_called == {"i": info, "target": "1.1.0", "direction": "downgrade"}
+
+    def test_downgrade_curl_install(self, mock_version, mock_lock, monkeypatch):
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+
+        info = InstallInfo(InstallMethod.BINARY, Path("/usr/local/bin/observal"), True, "curl")
+        install_called = {}
+        monkeypatch.setattr("observal_cli.install_detector.detect", lambda: info)
+        monkeypatch.setattr(
+            "observal_cli.cmd_ops._do_install",
+            lambda i, target, direction: install_called.update(i=i, target=target, direction=direction),
+        )
+
+        app = _get_app()
+        result = runner.invoke(app, ["self", "downgrade", "--version", "1.1.0", "--force"])
+        assert result.exit_code == 0
+        assert install_called == {"i": info, "target": "1.1.0", "direction": "downgrade"}
+
 
 class TestSelfRollback:
     def test_rollback_no_backup(self, monkeypatch, tmp_path):

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -362,8 +362,11 @@ class TestCheckVersionCompatibility:
     def test_cli_behind_exits(self, monkeypatch, capsys):
         from click.exceptions import Exit
 
+        import observal_cli.install_detector as install_detector
+
         monkeypatch.setattr(version_check, "get_current_version", lambda: "1.0.0")
         monkeypatch.setattr(version_check, "_read_cache", lambda: None)
+        monkeypatch.setattr(install_detector, "upgrade_command", lambda version: f"upgrade to {version}")
 
         def mock_get(*args, **kwargs):
             return httpx.Response(200, json={"server_version": "1.2.0"})
@@ -371,7 +374,7 @@ class TestCheckVersionCompatibility:
         monkeypatch.setattr(httpx, "get", mock_get)
         with pytest.raises(Exit):
             version_check.check_version_compatibility("http://localhost:8000")
-        assert "pipx install --force 'observal-cli==1.2.0'" in capsys.readouterr().out
+        assert "upgrade to 1.2.0" in capsys.readouterr().out
 
     def test_uses_short_ttl_cache(self, monkeypatch):
         """Cache younger than 60s is trusted, skipping network."""
@@ -500,6 +503,16 @@ class TestExecuteSilent:
         from observal_cli.upgrade_executor import execute_silent
 
         info = InstallInfo(method=InstallMethod.PIP, path="/fake", writable=True, managed_by=None)
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
+        assert execute_silent(info, "1.1.0", "upgrade") is True
+
+    def test_pipx_success(self, monkeypatch):
+        import subprocess
+
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+        from observal_cli.upgrade_executor import execute_silent
+
+        info = InstallInfo(method=InstallMethod.PIPX, path="/fake", writable=True, managed_by="pipx")
         monkeypatch.setattr(subprocess, "run", lambda *a, **kw: type("R", (), {"returncode": 0})())
         assert execute_silent(info, "1.1.0", "upgrade") is True
 


### PR DESCRIPTION
## Purpose / Description
Fix version mismatch prompts so users see the right recovery command for how the CLI was installed. The previous generic command was wrong for standalone installs from the shell installer and not ideal for pipx.

## Fixes
No issue.

## Approach
Use install detection to format upgrade guidance:

- shell installer: run the installer for the exact release tag
- pipx: use pipx install with force for the exact package version
- uv: use uv tool install with force for the exact package version
- pip: use the active Python environment
- server-only responses still use `observal self upgrade` because the server cannot know the local install method

The shell installer now writes install metadata to `~/.observal/install.json`. Pipx installs write the same metadata when detected by the CLI.

## How Has This Been Tested?
Targeted tests passed:

```text
pytest tests/test_install_detector.py tests/test_version_check.py::TestCheckVersionCompatibility::test_cli_behind_exits tests/test_version_check.py::TestExecuteSilent -q
uv run --project observal-server pytest observal-server/tests/test_config.py::test_version_middleware_rejects_cli_drift observal-server/tests/test_config.py::test_version_middleware_rejects_cli_without_version_header -q
uv run pytest tests/test_self_commands.py -q
```

Known unrelated result:

```text
pytest tests/test_self_commands.py -q
```

This fails without the uv environment because `loguru` is not installed in the system Python. The same test passes under `uv run`.

## Learning (optional, can help others)
The shell installer installs a standalone binary, so Python package-manager commands are not always safe recovery guidance. The CLI already detects install method, so the lazy fix is to reuse that path instead of adding another source of truth.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?