### PR TITLE
docs: add Cursor integration guide

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -60,6 +60,7 @@
 ## Integrations
 
 * [Copilot](integrations/copilot.md)
+* [Cursor](integrations/cursor.md)
 * [Kiro](integrations/kiro.md)
 * [OpenCode](integrations/opencode.md)
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -4,7 +4,7 @@
 # Cursor
 
 Cursor is a first-class Observal harness integration. Observal can install Cursor agents,
-configure MCP servers, expose rules, and collect Cursor session telemetry.
+configure MCP servers, and collect Cursor session telemetry.
 
 ---
 
@@ -13,7 +13,7 @@ configure MCP servers, expose rules, and collect Cursor session telemetry.
 Cursor agent profiles are Markdown files. Project agents live in `.cursor/agents/`.
 User agents live in `~/.cursor/agents/`.
 
-Cursor supports project and user installation scopes. MCP servers, rules, hooks,
+Cursor supports project and user installation scopes. MCP servers, hooks,
 and agent profiles are managed under the `.cursor` configuration directory.
 
 ---
@@ -25,7 +25,6 @@ and agent profiles are managed under the `.cursor` configuration directory.
 | Agent profiles  | Project and user scope                                      |
 | Hook bridge     | Supported                                                   |
 | MCP servers     | `.cursor/mcp.json` and `~/.cursor/mcp.json`                 |
-| Rules           | `.cursor/rules/{name}.mdc` and `~/.cursor/rules/{name}.mdc` |
 | Session parsing | Built-in Cursor session parser                              |
 | Default scope   | Project                                                     |
 
@@ -73,7 +72,6 @@ User agents are written to `~/.cursor/agents/{name}.md`.
 | ------------- | -------------------------------- | ---------------------------------- |
 | Agent profile | `.cursor/agents/{name}.md`       | `~/.cursor/agents/{name}.md`       |
 | MCP config    | `.cursor/mcp.json`               | `~/.cursor/mcp.json`               |
-| Rules         | `.cursor/rules/{name}.mdc`       | `~/.cursor/rules/{name}.mdc`       |
 | Skills        | `.cursor/skills/{name}/SKILL.md` | `~/.cursor/skills/{name}/SKILL.md` |
 | Hook config   | `.cursor/hooks.json`             | `~/.cursor/hooks.json`             |
 
@@ -108,7 +106,7 @@ Cursor uses the built-in `cursor` session parser.
 writes to `.cursor/agents/` unless `--scope user` is specified.
 
 **Configuration lives under `.cursor`.** Agent profiles, MCP configuration,
-rules, skills, and hooks are stored in the `.cursor` directory for project
+skills, and hooks are stored in the `.cursor` directory for project
 installs and under `~/.cursor` for user installs.
 
 **Auto model sentinel configuration is not available.**

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,114 @@
+<!-- SPDX-FileCopyrightText: 2026 Faatih <22oo1cso41faatih@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Cursor
+
+Cursor is a first-class Observal harness integration. Observal can install Cursor agents,
+configure MCP servers, expose rules, and collect Cursor session telemetry.
+
+---
+
+## Overview
+
+Cursor agent profiles are Markdown files. Project agents live in `.cursor/agents/`.
+User agents live in `~/.cursor/agents/`.
+
+Cursor supports project and user installation scopes. MCP servers, rules, hooks,
+and agent profiles are managed under the `.cursor` configuration directory.
+
+---
+
+## Supported capabilities
+
+| Capability      | Support                                                     |
+| --------------- | ----------------------------------------------------------- |
+| Agent profiles  | Project and user scope                                      |
+| Hook bridge     | Supported                                                   |
+| MCP servers     | `.cursor/mcp.json` and `~/.cursor/mcp.json`                 |
+| Rules           | `.cursor/rules/{name}.mdc` and `~/.cursor/rules/{name}.mdc` |
+| Session parsing | Built-in Cursor session parser                              |
+| Default scope   | Project                                                     |
+
+---
+
+## Setup
+
+### 1. Install the Observal CLI
+
+```bash
+uv tool install observal-cli
+# or: pipx install observal-cli
+```
+
+### 2. Authenticate
+
+```bash
+observal auth login
+```
+
+This writes credentials to `~/.observal/config.json`.
+
+### 3. Pull an agent into Cursor
+
+```bash
+observal agent pull <agent-name> --harness cursor
+```
+
+Cursor's default scope is project scope. By default, the agent is written to
+`.cursor/agents/{name}.md`.
+
+To install into your user configuration:
+
+```bash
+observal agent pull <agent-name> --harness cursor --scope user
+```
+
+User agents are written to `~/.cursor/agents/{name}.md`.
+
+---
+
+## Config paths
+
+| Purpose       | Project scope                    | User scope                         |
+| ------------- | -------------------------------- | ---------------------------------- |
+| Agent profile | `.cursor/agents/{name}.md`       | `~/.cursor/agents/{name}.md`       |
+| MCP config    | `.cursor/mcp.json`               | `~/.cursor/mcp.json`               |
+| Rules         | `.cursor/rules/{name}.mdc`       | `~/.cursor/rules/{name}.mdc`       |
+| Skills        | `.cursor/skills/{name}/SKILL.md` | `~/.cursor/skills/{name}/SKILL.md` |
+| Hook config   | `.cursor/hooks.json`             | `~/.cursor/hooks.json`             |
+
+Cursor MCP configs use the `mcpServers` key.
+
+---
+
+## Hook spec
+
+### Event map
+
+| Observal event     | Cursor event         |
+| ------------------ | -------------------- |
+| `PreToolUse`       | `preToolUse`         |
+| `PostToolUse`      | `postToolUse`        |
+| `Stop`             | `sessionEnd`         |
+| `SessionStart`     | `sessionStart`       |
+| `UserPromptSubmit` | `beforeSubmitPrompt` |
+| `SubagentStop`     | `subagentStop`       |
+
+---
+
+## Session parsing
+
+Cursor uses the built-in `cursor` session parser.
+
+---
+
+## Caveats
+
+**Default scope is project.** `observal agent pull <agent-name> --harness cursor`
+writes to `.cursor/agents/` unless `--scope user` is specified.
+
+**Configuration lives under `.cursor`.** Agent profiles, MCP configuration,
+rules, skills, and hooks are stored in the `.cursor` directory for project
+installs and under `~/.cursor` for user installs.
+
+**Auto model sentinel configuration is not available.**


### PR DESCRIPTION
## Purpose / Description

Adds the missing integration documentation page for Cursor
(`docs/integrations/cursor.md`). Cursor is a first-class harness in Observal with
hook bridge, MCP servers, rules, and session parsing, but has no integration
documentation page.

## Fixes

Fixes #1360 

## Approach

Created `docs/integrations/cursor.md` using the current implementation as the source of truth.

The page follows the existing integration documentation format used by other
harnesses to maintain a consistent documentation experience.

Verified paths, hook names, event names, and supported capabilities against:

* `observal_cli/harness/cursor.py` — adapter scan logic for Cursor agents, MCP servers, hooks, and rules
* `observal_cli/shared/harness_registry.py` — Cursor paths, scope labels, MCP config, hook events, supported capabilities, guidance files, and default scope

Also updated:

* `docs/SUMMARY.md` — added the Cursor integration page to the Integrations section.

The page covers:

* Overview of Cursor agent profiles
* Supported capabilities
* Setup steps
* Project and user configuration paths
* Hook specification and event map
* Session parsing
* Cursor-specific caveats

## How Has This Been Tested?

Verified manually that the documented paths, hook names, event names, and supported capabilities match the current implementation.

* `make test` → passed
* `make lint` → passed

## Checklist

*Please, go through these checks before submitting the PR.*

* [x] Descriptive Commit Message
* [x] Tests Run for affected areas
* [x] Self-review completed
* [x] UI changes: N/A (documentation only)

## AI Assistance

*Was generative AI tooling used to co-author this PR?*

* [x] Yes (Please Specify the tool): ChatGPT (OpenAI GPT-5.5)
* [x] Was the generated code manually reviewed and tested?
