### PR TITLE
docs: add Copilot integration documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -59,6 +59,7 @@
 
 ## Integrations
 
+* [Copilot](integrations/copilot.md)
 * [Kiro](integrations/kiro.md)
 * [OpenCode](integrations/opencode.md)
 

--- a/docs/integrations/copilot.md
+++ b/docs/integrations/copilot.md
@@ -1,0 +1,109 @@
+<!-- SPDX-FileCopyrightText: 2026 Faatih <22oo1cso41faatih@gmail.com> -->
+<!-- SPDX-License-Identifier: AGPL-3.0-only -->
+
+# Copilot
+
+Copilot is a first-class Observal harness integration. Observal can install
+GitHub Copilot agents, configure MCP servers, expose skills, and bridge
+telemetry hooks.
+
+---
+
+## Overview
+
+Copilot agent profiles are Markdown files stored in
+`.github/agents/`.
+
+Copilot currently supports project installation scope only. MCP servers,
+hooks, skills, and agent profiles are managed through the project
+configuration.
+
+---
+
+## Supported capabilities
+
+| Capability      | Support                              |
+| --------------- | ------------------------------------ |
+| Agent profiles  | Project scope                        |
+| Hook bridge     | Supported                            |
+| MCP servers     | `.vscode/mcp.json`                   |
+| Skills          | `.github/skills/{name}/SKILL.md`     |
+| Session parsing | Built-in `copilot-cli` session parser |
+| Default scope   | Project                              |
+
+---
+
+## Setup
+
+### 1. Install the Observal CLI
+
+```bash
+uv tool install observal-cli
+# or: pipx install observal-cli
+```
+
+### 2. Authenticate
+
+```bash
+observal auth login
+```
+
+This writes credentials to `~/.observal/config.json`.
+
+### 3. Pull an agent into Copilot
+
+```bash
+observal agent pull <agent-name> --harness copilot
+```
+
+By default, the agent is written to:
+
+```
+.github/agents/{name}.agent.md
+```
+
+---
+
+## Config paths
+
+| Purpose | Project scope |
+| -------- | ------------- |
+| Agent profile | `.github/agents/{name}.agent.md` |
+| MCP config | `.vscode/mcp.json` |
+| Skills | `.github/skills/{name}/SKILL.md` |
+| Hook config | `.github/hooks/{name}.json` |
+
+Copilot MCP configuration uses the `servers` key.
+
+---
+
+## Hook spec
+
+### Event map
+
+| Observal event | Copilot event |
+| -------------- | ------------- |
+| `SessionStart` | `SessionStart` |
+| `UserPromptSubmit` | `UserPromptSubmit` |
+| `PreToolUse` | `PreToolUse` |
+| `PostToolUse` | `PostToolUse` |
+| `Stop` | `Stop` |
+
+---
+
+## Session parsing
+
+Copilot uses the built-in `copilot-cli` session parser.
+
+---
+
+## Caveats
+
+**Only project scope is supported.** Agents are installed into
+`.github/agents/`.
+
+**Configuration is split across project directories.** MCP servers are stored
+in `.vscode/mcp.json`, while hooks and skills live under `.github/`.
+
+**Rules are not supported.** Copilot supports agent profiles, MCP servers,
+skills, and hooks, but does not expose a rules configuration.


### PR DESCRIPTION
## Purpose / Description

Adds the missing integration documentation page for Copilot (`docs/integrations/copilot.md`). Copilot is a supported Observal harness with agent profiles, MCP servers, hooks, and skills, but currently has no dedicated integration documentation page.

## Fixes

Fixes #864

## Approach

Created `docs/integrations/copilot.md` using the current implementation as the source of truth.

Verified paths, hook names, event names, supported capabilities, and configuration against:

- `observal_cli/harness/copilot.py` — adapter scan logic for Copilot agents, MCP servers, hooks, and project detection
- `observal_cli/shared/harness_registry.py` — Copilot paths, supported capabilities, guidance files, default scope, MCP configuration, hook events, and agent profile locations
- `observal-server/schemas/harness_registry.py` — server-side registry values for Copilot

Also updated:

- `docs/SUMMARY.md` — added the Copilot integration page to the Integrations section.

The page covers:

- Overview
- Supported capabilities
- Setup steps
- Project configuration paths
- Hook specification and event map
- Session parsing
- Copilot-specific caveats

## How Has This Been Tested?

Verified manually that the documented paths, hook names, event names, supported capabilities, and configuration match the current implementation.

- `make test` → passed
- `make lint` → passed

## Checklist

_Please, go through these checks before submitting the PR._

- [x] Descriptive Commit Message
- [x] Tests Run for affected areas
- [x] Self-review completed
- [x] UI changes: N/A (documentation only)

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes (Please Specify the tool): ChatGPT (OpenAI GPT-5.5)
- [x] Was the generated code manually reviewed and tested?