### PR TITLE
fix(pi): resolve latest telemetry version

### DIFF
--- a/observal-server/services/session_ingest.py
+++ b/observal-server/services/session_ingest.py
@@ -188,7 +188,7 @@ def _extract_uuid(parsed: dict, harness: str = "claude-code") -> tuple[str | Non
 
 
 # ---------------------------------------------------------------------------
-# Agent ID resolution (name -> UUID)
+# Agent attribution resolution
 # ---------------------------------------------------------------------------
 
 
@@ -257,6 +257,51 @@ async def _resolve_agent_id(agent_id: str | None) -> str | None:
     return resolved if resolved else agent_id
 
 
+async def _resolve_agent_version(agent_id: str | None, agent_version: str | None) -> str | None:
+    """Resolve the mutable latest alias to the agent's current version."""
+    if agent_version != "latest" or not agent_id or not _is_uuid(agent_id):
+        return agent_version
+
+    from services.redis import get_redis
+
+    cache_key = f"agent_version_resolve:{agent_id}:latest"
+    redis = None
+    try:
+        redis = get_redis()
+        cached = await redis.get(cache_key)
+        if cached is not None:
+            return cached if cached != "__none__" else agent_version
+    except Exception as e:
+        optic.trace("Redis cache read failed for agent version resolution: {}", e)
+
+    from sqlalchemy import select
+
+    from database import async_session
+    from models.agent import Agent, AgentVersion
+
+    resolved = None
+    try:
+        async with async_session() as db:
+            stmt = (
+                select(AgentVersion.version)
+                .join(Agent, Agent.latest_version_id == AgentVersion.id)
+                .where(Agent.id == _uuid.UUID(agent_id))
+                .limit(1)
+            )
+            result = await db.execute(stmt)
+            resolved = result.scalar_one_or_none()
+    except Exception as e:
+        optic.warning("agent_version resolution failed: {}", e)
+
+    if redis:
+        try:
+            await redis.setex(cache_key, 300, resolved or "__none__")
+        except Exception as e:
+            optic.trace("Redis cache write failed for agent version resolution: {}", e)
+
+    return resolved if resolved else agent_version
+
+
 @dataclass
 class IngestResult:
     ingested: int
@@ -309,9 +354,9 @@ async def ingest_session_lines(
     """
     optic.trace("ingesting session lines for session {}", session_id)
 
-    # Normalize agent_id: resolve human-readable names to UUIDs so that
-    # downstream queries (insights, exec dashboard) can match by UUID.
+    # Normalize agent_id and agent_version so downstream queries match canonical versions.
     agent_id = await _resolve_agent_id(agent_id)
+    agent_version = await _resolve_agent_version(agent_id, agent_version)
 
     ingested = 0
     skipped = 0

--- a/observal-server/tests/test_session_attribution.py
+++ b/observal-server/tests/test_session_attribution.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: AGPL-3.0-only
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from services.session_ingest import _resolve_agent_version
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_version_keeps_pinned_version(monkeypatch):
+    def fail_get_redis():
+        raise AssertionError("redis should not be used")
+
+    monkeypatch.setattr("services.redis.get_redis", fail_get_redis)
+
+    result = await _resolve_agent_version(str(uuid.uuid4()), "1.0.0")
+
+    assert result == "1.0.0"
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_version_latest_alias(monkeypatch):
+    class FakeResult:
+        def scalar_one_or_none(self):
+            return "1.0.0"
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def execute(self, stmt):
+            return FakeResult()
+
+    def fail_get_redis():
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setattr("services.redis.get_redis", fail_get_redis)
+    monkeypatch.setattr("database.async_session", lambda: FakeSession())
+
+    result = await _resolve_agent_version(str(uuid.uuid4()), "latest")
+
+    assert result == "1.0.0"

--- a/observal_cli/install_detector.py
+++ b/observal_cli/install_detector.py
@@ -72,7 +72,7 @@ def upgrade_command(target_version: str, install_info: InstallInfo | None = None
         return "brew upgrade observal"
     if info.method == InstallMethod.SYSTEM_PACKAGE and info.managed_by:
         return f"{info.managed_by} upgrade observal"
-    return f"observal self upgrade --version {target_version}"
+    return f"observal self upgrade --version {target_version} --force"
 
 
 def _detect_from_path(binary_path: Path, path_str: str) -> InstallInfo:

--- a/observal_cli/skills/observal-advanced/SKILL.md
+++ b/observal_cli/skills/observal-advanced/SKILL.md
@@ -28,12 +28,14 @@ Not a Typer command. No flags needed.
 
 ```bash
 observal self status
-observal self upgrade
-observal self upgrade --version 2.5.0
+observal self upgrade --force
+observal self upgrade --version 2.5.0 --force
 observal self downgrade --list
-observal self downgrade --version 2.4.0
+observal self downgrade --version 2.4.0 --force
 observal self rollback
 ```
+
+Use `--force` when running upgrades or downgrades from an agent so the command is non-interactive.
 
 ---
 

--- a/packages/pi-extension/extensions/observal.ts
+++ b/packages/pi-extension/extensions/observal.ts
@@ -200,14 +200,20 @@ export default function (pi: ExtensionAPI) {
         applyProfile(choice);
         
         if (state?.config) {
-          state.config.agent_id = choice === "default" ? undefined : choice;
+          const binding = resolvePiAgentBinding(choice);
+          state.config.agent_id = choice === "default" ? undefined : binding.id;
+          state.config.agent_version = choice === "default" ? undefined : binding.version;
           try {
             const configRaw = fs.readFileSync(CONFIG_PATH, "utf-8");
             const configJson = JSON.parse(configRaw);
             if (choice === "default") {
               delete configJson.active_agent;
             } else {
-              configJson.active_agent = { id: choice, version: "latest" };
+              configJson.active_agent = {
+                id: binding.id,
+                name: binding.name,
+                ...(binding.version ? { version: binding.version } : {}),
+              };
             }
             fs.writeFileSync(CONFIG_PATH, JSON.stringify(configJson, null, 2));
           } catch (err) {
@@ -284,12 +290,50 @@ export default function (pi: ExtensionAPI) {
       const data = JSON.parse(raw);
       if (!data.server_url || !data.access_token) return null;
       const config: ObservalConfig = { server_url: data.server_url, access_token: data.access_token };
-      if (data.active_agent?.id) config.agent_id = data.active_agent.id;
-      if (data.active_agent?.version) config.agent_version = data.active_agent.version;
+      if (data.active_agent?.id) {
+        const binding = resolvePiAgentBinding(String(data.active_agent.id), data.active_agent.name, data.active_agent.version);
+        config.agent_id = binding.id;
+        if (binding.version) config.agent_version = binding.version;
+      }
       return config;
     } catch {
       return null;
     }
+  }
+
+  function resolvePiAgentBinding(agent: string, rawName?: unknown, rawVersion?: unknown): { id: string; name: string; version?: string } {
+    const name = typeof rawName === "string" && rawName.trim() ? rawName.trim() : agent;
+    const entry = findPiLockfileAgent(agent, name);
+    return {
+      id: typeof entry?.id === "string" && entry.id.trim() ? entry.id : agent,
+      name: typeof entry?.name === "string" && entry.name.trim() ? entry.name : name,
+      version: normalizeAgentVersion(entry?.version) ?? normalizeAgentVersion(rawVersion),
+    };
+  }
+
+  function findPiLockfileAgent(agent: string, name: string): Record<string, any> | null {
+    try {
+      if (!fs.existsSync(LOCKFILE_PATH)) return null;
+      const data = JSON.parse(fs.readFileSync(LOCKFILE_PATH, "utf-8"));
+      const agents = data.harnesses?.pi?.agents;
+      if (!Array.isArray(agents)) return null;
+      const keys = new Set([agent, name, safeAgentName(agent), safeAgentName(name)].filter(Boolean));
+      return agents.find((item) => keys.has(String(item?.id ?? "")))
+        ?? agents.find((item) => keys.has(String(item?.name ?? "")) || keys.has(safeAgentName(String(item?.name ?? ""))))
+        ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  function normalizeAgentVersion(version: unknown): string | undefined {
+    if (typeof version !== "string") return undefined;
+    const trimmed = version.trim();
+    return trimmed && trimmed !== "latest" ? trimmed : undefined;
+  }
+
+  function safeAgentName(name: string): string {
+    return name.replace(/[^a-zA-Z0-9_-]/g, "-");
   }
 
   function buildPiLayerSnapshot(includeContent: boolean): LayerSnapshot {

--- a/tests/test_install_detector.py
+++ b/tests/test_install_detector.py
@@ -122,3 +122,7 @@ class TestUpgradeCommand:
             "curl -fsSL https://raw.githubusercontent.com/Observal/Observal/main/install.sh "
             "| bash -s -- --version v1.2.0"
         )
+
+    def test_unknown_command_uses_noninteractive_self_upgrade(self):
+        info = InstallInfo(InstallMethod.UNKNOWN, Path("/fake/observal"), True, None)
+        assert upgrade_command("1.2.0", info) == "observal self upgrade --version 1.2.0 --force"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: AGPL-3.0-only -->

<!--- Please fill the necessary details below -->
## Purpose / Description
Pi telemetry could attribute sessions as `vlatest` when the Pi extension wrote `active_agent.version = "latest"` during agent profile swaps. That made traces show a mutable alias instead of the canonical agent version.

This also makes CLI drift guidance safe for agent execution by including the existing `--force` flag in self upgrade instructions.

## Fixes
* No linked issue.

## Approach
Pi attribution now resolves the selected profile through the local Observal lockfile before writing active agent config, preserving the canonical agent UUID and pinned version.

Server ingest also canonicalizes incoming `agent_version = "latest"` to the current latest version for that agent, so older Pi extensions do not keep writing the alias.

CLI upgrade guidance now uses noninteractive self upgrade commands when falling back to `observal self upgrade`, and the bundled advanced skill documents `--force` for upgrade and downgrade commands.

## How Has This Been Tested?

Ran:

```bash
cd observal-server && uv run pytest -q tests/test_session_attribution.py
uv run pytest -q tests/test_install_detector.py
uv run ruff check observal-server/services/session_ingest.py observal-server/tests/test_session_attribution.py observal_cli/install_detector.py tests/test_install_detector.py
uv run ruff format --check observal-server/services/session_ingest.py observal-server/tests/test_session_attribution.py observal_cli/install_detector.py tests/test_install_detector.py
python -m compileall -q observal-server/services/session_ingest.py
observal self upgrade --help | rg -n -- "--force|Skip interactive"
```

All checks passed.

## Learning (optional, can help others)
Pi stores active agent attribution in `~/.observal/config.json`, while canonical installed agent versions live in `~/.observal/lockfile.json`. The bug came from treating `latest` as a concrete version during profile swaps.

No external references used.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. Not applicable, no complex code path required new comments.
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings). Not applicable, no UI changes.

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [MIT License](https://opensource.org/licenses/MIT) |
--->

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
