### PR TITLE
fix(ee): remove unnecessary quotes from type annotation

### DIFF
--- a/ee/observal_server/middleware/enterprise_guard.py
+++ b/ee/observal_server/middleware/enterprise_guard.py
@@ -29,7 +29,7 @@ class EnterpriseGuardMiddleware(BaseHTTPMiddleware):
     so settings changes via the UI take effect immediately across all workers.
     """
 
-    def __init__(self, app, settings: "Settings") -> None:
+    def __init__(self, app, settings: Settings) -> None:
         super().__init__(app)
         self._settings = settings
 


### PR DESCRIPTION
## Purpose / Description
The file `ee/observal_server/middleware/enterprise_guard.py` already uses `from __future__ import annotations`, making the quoted string annotation on line 32 redundant. Ruff UP037 flags this.

## Fixes
* Fixes #1557

## Approach
Remove the quotes around `Settings` in the `__init__` signature since `from __future__ import annotations` already defers evaluation.

## How Has This Been Tested?
`make lint` passes cleanly after this change.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes (Kiro CLI)
- [x] Was the generated code manually reviewed and tested?