### PR TITLE
fix(ee): validate sp_key_encryption_password when SAML is configured

### DIFF
--- a/ee/observal_server/services/config_validator.py
+++ b/ee/observal_server/services/config_validator.py
@@ -51,6 +51,9 @@ def validate_enterprise_config(settings: Settings) -> list[str]:
             saml_cert = ds.get_sync("saml.idp_x509_cert")
             if not saml_cert:
                 issues.append("saml.idp_x509_cert is not set (required when SAML IdP is configured)")
+            sp_enc_pw = ds.get_sync("saml.sp_key_encryption_password")
+            if not sp_enc_pw:
+                issues.append("saml.sp_key_encryption_password is not set (required when SAML IdP is configured)")
             sp_acs = ds.get_sync("saml.sp_acs_url")
             if sp_acs and not sp_acs.startswith("https://"):
                 issues.append("saml.sp_acs_url should use HTTPS for production deployments")
@@ -91,6 +94,8 @@ async def validate_enterprise_config_async(settings: Settings) -> list[str]:
         if saml_entity and saml_sso:
             if not await ds.get("saml.idp_x509_cert"):
                 issues.append("saml.idp_x509_cert is not set (required when SAML IdP is configured)")
+            if not await ds.get("saml.sp_key_encryption_password"):
+                issues.append("saml.sp_key_encryption_password is not set (required when SAML IdP is configured)")
             sp_acs = await ds.get("saml.sp_acs_url")
             if sp_acs and not sp_acs.startswith("https://"):
                 issues.append("saml.sp_acs_url should use HTTPS for production deployments")


### PR DESCRIPTION
## Purpose / Description
`validate_enterprise_config` (both sync and async) does not check for an empty `saml.sp_key_encryption_password` when SAML IdP is fully configured. This causes the test `test_saml_configured_without_encryption_password` to fail.

## Fixes
* Fixes #1556

## Approach
Added a check in both the sync and async validators: when `saml.idp_entity_id`, `saml.idp_sso_url`, and `saml.idp_x509_cert` are all present, also verify that `saml.sp_key_encryption_password` is set. If empty, append an issue string containing the key name.

## How Has This Been Tested?
- `make test` — the previously failing test now passes
- Ran the specific test: `pytest tests/test_saml_scim_integration.py::TestConfigValidatorSaml::test_saml_configured_without_encryption_password` — PASSED

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes (Kiro CLI)
- [x] Was the generated code manually reviewed and tested?