### PR TITLE
fix(cli): restore strict version match, show correct upgrade/downgrade

### DIFF
--- a/observal-server/middleware.py
+++ b/observal-server/middleware.py
@@ -191,14 +191,24 @@ def _should_require_cli_version_header(request: Request) -> bool:
 
 
 def _cli_version_response(server_ver: str, cli_ver_str: str | None) -> JSONResponse:
-    install_command = f"observal self upgrade --version {server_ver}"
+    from packaging.version import InvalidVersion, Version
+
+    # Determine direction: if CLI is ahead, suggest downgrade; otherwise upgrade
+    direction = "upgrade"
+    if cli_ver_str:
+        try:
+            if Version(cli_ver_str) > Version(server_ver):
+                direction = "downgrade"
+        except InvalidVersion:
+            pass
+
+    install_command = f"observal self {direction} --version {server_ver}"
     shown_cli_version = cli_ver_str or "unknown"
     return JSONResponse(
         status_code=426,
         content={
             "detail": (
-                f"Observal CLI {shown_cli_version} cannot connect to server {server_ver}. "
-                f"Install the matching CLI with: {install_command}"
+                f"Observal CLI {shown_cli_version} cannot connect to server {server_ver}. Run: {install_command}"
             ),
             "server_version": server_ver,
             "cli_version": cli_ver_str,
@@ -228,11 +238,7 @@ def configure_version_middleware(app: FastAPI) -> None:
                 try:
                     client_ver = Version(cli_ver_str)
                     server_version = Version(server_ver)
-                    # Allow newer CLI within same major (forward-compatible).
-                    # Block if CLI is behind or major version differs.
-                    if client_ver.major != server_version.major:
-                        return _cli_version_response(server_ver, cli_ver_str)
-                    if client_ver < server_version:
+                    if client_ver != server_version:
                         return _cli_version_response(server_ver, cli_ver_str)
                     effective = str(server_version)
                 except InvalidVersion:

--- a/observal-server/tests/test_config.py
+++ b/observal-server/tests/test_config.py
@@ -51,7 +51,7 @@ def test_demo_env_vars_default_to_none():
 
 
 def test_version_middleware_rejects_cli_drift(monkeypatch):
-    """CLI requests behind server version should be rejected."""
+    """CLI requests must match the exact server version."""
     import version
     from middleware import configure_version_middleware
 
@@ -71,8 +71,8 @@ def test_version_middleware_rejects_cli_drift(monkeypatch):
     assert response.json()["install_command"] == "observal self upgrade --version 1.6.2"
 
 
-def test_version_middleware_allows_newer_cli(monkeypatch):
-    """CLI requests ahead of server within same major should pass."""
+def test_version_middleware_rejects_newer_cli(monkeypatch):
+    """CLI requests ahead of server should also be rejected (strict match)."""
     import version
     from middleware import configure_version_middleware
 
@@ -88,28 +88,9 @@ def test_version_middleware_allows_newer_cli(monkeypatch):
     client = TestClient(app)
     response = client.get("/api/v1/example", headers={"X-Observal-CLI-Version": "1.9.8"})
 
-    assert response.status_code == 200
-    assert response.headers["X-Observal-Server"] == "1.6.2"
-
-
-def test_version_middleware_rejects_major_mismatch(monkeypatch):
-    """CLI requests with different major version should be rejected."""
-    import version
-    from middleware import configure_version_middleware
-
-    monkeypatch.setattr(version, "get_server_version", lambda: "1.6.2")
-
-    app = FastAPI()
-    configure_version_middleware(app)
-
-    @app.get("/api/v1/example")
-    async def example():
-        return {"ok": True}
-
-    client = TestClient(app)
-    response = client.get("/api/v1/example", headers={"X-Observal-CLI-Version": "2.0.0"})
-
     assert response.status_code == 426
+    assert response.json()["server_version"] == "1.6.2"
+    assert response.json()["install_command"] == "observal self downgrade --version 1.6.2"
 
 
 def test_version_middleware_allows_exact_cli_match(monkeypatch):

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -77,12 +77,11 @@ def _prompt_password(prompt_text: str = "New password") -> str:
 
 
 def _ensure_cli_matches_server(server_url: str) -> None:
-    """Block login when the CLI is incompatible with the server.
+    """Block login when the CLI does not exactly match the server version.
 
-    Compatibility policy (forward-compatible):
-    - Same major version and CLI >= server: allowed (newer CLI talks to older server)
-    - CLI behind server (same major): blocked (server may use APIs the CLI lacks)
-    - Different major version: blocked (breaking API changes expected)
+    The server is the source of truth. CLI pings the server to get its
+    version, then requires an exact match. Shows the correct upgrade or
+    downgrade command so the user knows exactly what to run.
     """
     from packaging.version import InvalidVersion, Version
 
@@ -108,25 +107,23 @@ def _ensure_cli_matches_server(server_url: str) -> None:
     except InvalidVersion:
         return
 
-    # Same major and CLI >= server: forward-compatible, allow
-    if cli_version.major == server_version.major and cli_version >= server_version:
+    if cli_version == server_version:
         return
 
     from observal_cli.install_detector import upgrade_command
 
-    install_command = upgrade_command(server_ver)
-
-    if cli_version.major != server_version.major:
+    if cli_version > server_version:
+        install_command = f"observal self downgrade --version {server_ver}"
         rprint(
-            f"\n[bold red]CLI version {cli_ver_str} is incompatible with server {server_ver} "
-            f"(major version mismatch).[/bold red]\n"
-            f"  Install a compatible CLI:\n\n"
+            f"\n[bold red]CLI version {cli_ver_str} is ahead of server {server_ver}.[/bold red]\n"
+            f"  Downgrade the CLI to match your server:\n\n"
             f"    [cyan]{install_command}[/cyan]\n"
         )
     else:
+        install_command = upgrade_command(server_ver)
         rprint(
             f"\n[bold red]CLI version {cli_ver_str} is behind server {server_ver}.[/bold red]\n"
-            f"  Upgrade the CLI to connect:\n\n"
+            f"  Upgrade the CLI to match your server:\n\n"
             f"    [cyan]{install_command}[/cyan]\n"
         )
     raise typer.Exit(1)

--- a/observal_cli/version_check.py
+++ b/observal_cli/version_check.py
@@ -544,12 +544,11 @@ def fetch_all_releases(include_pre: bool = False) -> list[dict]:
 
 
 def check_version_compatibility(server_url: str) -> None:
-    """Enforce forward-compatible CLI/server version policy.
+    """Enforce exact CLI/server version match.
 
-    Compatibility rules:
-    - Same major version and CLI >= server: allowed (newer CLI is backward-compatible)
-    - CLI behind server (same major): blocked (missing API features)
-    - Different major version: blocked (breaking changes)
+    The server version is the canonical target. CLI pings the server to
+    get its version, then requires an exact match. Shows the correct
+    upgrade or downgrade command based on which direction the mismatch is.
 
     Reads from the local version cache first (populated by auto-update check)
     to avoid a duplicate network call. Falls back to a fresh fetch if needed.
@@ -562,7 +561,7 @@ def check_version_compatibility(server_url: str) -> None:
     if cli_ver_str == "0.0.0":
         return  # dev install, skip check
 
-    # Use cache if fresh (< 60s), otherwise fetch live.
+    # Use cache if fresh (< 60s), otherwise fetch live from the server.
     server_ver = None
     cache = _read_cache()
     if cache and cache.get("server_version") and cache.get("source") == "server" and not _should_check(cache, 60):
@@ -587,25 +586,23 @@ def check_version_compatibility(server_url: str) -> None:
     except InvalidVersion:
         return
 
-    # Same major and CLI >= server: forward-compatible, allow
-    if cli_v.major == srv_v.major and cli_v >= srv_v:
+    if cli_v == srv_v:
         return
 
     from observal_cli.install_detector import upgrade_command
 
-    install_command = upgrade_command(server_ver)
-
-    if cli_v.major != srv_v.major:
+    if cli_v > srv_v:
+        install_command = f"observal self downgrade --version {server_ver}"
         rprint(
-            f"\n[bold red]\u2716 CLI version {cli_ver_str} is incompatible with server {server_ver} "
-            f"(major version mismatch).[/bold red]\n"
-            f"  Install a compatible CLI:\n\n"
+            f"\n[bold red]\u2716 CLI version {cli_ver_str} is ahead of server {server_ver}.[/bold red]\n"
+            f"  Downgrade the CLI to match your server:\n\n"
             f"    [cyan]{install_command}[/cyan]\n"
         )
     else:
+        install_command = upgrade_command(server_ver)
         rprint(
             f"\n[bold red]\u2716 CLI version {cli_ver_str} is behind server {server_ver}.[/bold red]\n"
-            f"  Upgrade the CLI to connect:\n\n"
+            f"  Upgrade the CLI to match your server:\n\n"
             f"    [cyan]{install_command}[/cyan]\n"
         )
     raise typer.Exit(1)

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -345,8 +345,8 @@ class TestCheckVersionCompatibility:
         with pytest.raises(RuntimeError):
             version_check.check_version_compatibility("http://localhost:8000")
 
-    def test_cli_ahead_allowed(self, monkeypatch):
-        """CLI ahead of server within same major should be allowed."""
+    def test_cli_ahead_exits(self, monkeypatch):
+        """CLI ahead of server should also block (strict match)."""
         monkeypatch.setattr(version_check, "get_current_version", lambda: "1.2.0")
         monkeypatch.setattr(version_check, "_read_cache", lambda: None)
 
@@ -354,8 +354,8 @@ class TestCheckVersionCompatibility:
             return httpx.Response(200, json={"server_version": "1.0.0"})
 
         monkeypatch.setattr(httpx, "get", mock_get)
-        # Should NOT raise - newer CLI is forward-compatible
-        version_check.check_version_compatibility("http://localhost:8000")
+        with pytest.raises(RuntimeError):
+            version_check.check_version_compatibility("http://localhost:8000")
 
     def test_cli_ahead_different_major_exits(self, monkeypatch):
         """CLI ahead with different major version should block."""


### PR DESCRIPTION
## Purpose / Description

PR #1551 relaxed version enforcement to allow newer CLIs to talk to older servers. The feedback was: do not loosen the rule. Instead, keep strict version coupling and coordinate with the server to show the correct command.

This PR reverts the forward-compatibility logic and restores strict CLI/server version matching. The server is the source of truth. Any mismatch (CLI ahead or behind) is blocked, and the user sees the exact command to fix it.

## Fixes

* Fixes the version drift issue from #1551 review feedback

## Approach

- Middleware: reverted back to `client_ver != server_version` (strict equality)
- `_cli_version_response` now detects direction (ahead vs behind) and shows `observal self downgrade --version X.Y.Z` or `observal self upgrade --version X.Y.Z` accordingly
- `cmd_auth.py` (`_ensure_cli_matches_server`): strict match, talks to server, shows correct direction
- `version_check.py` (`check_version_compatibility`): same strict match with correct direction messaging
- Tests updated to assert strict behavior (newer CLI is also rejected)

## How Has This Been Tested?

- `uv run pytest tests/test_version_check.py -k TestCheckVersionCompatibility` (10 passed)
- `uv run pytest observal-server/tests/test_config.py -k version_middleware` (5 passed)
- Covers: exact match passes, CLI behind blocks with upgrade command, CLI ahead blocks with downgrade command, major mismatch blocks, dev installs skip

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes (Kiro)
- [x] Was the generated code manually reviewed and tested?