### PR TITLE
docs: clarify enterprise license boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,4 +337,6 @@ Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://gith
 
 ## License
 
-Apache License 2.0. See [LICENSE](LICENSE).
+The open-source core, all code outside `ee/`, is licensed under the Apache License 2.0. See [LICENSE](LICENSE).
+
+The `ee/` directory contains Enterprise Edition code licensed separately under the [Observal Enterprise License](ee/LICENSE).


### PR DESCRIPTION
## Purpose / Description
Clarify in the root README that Apache-2.0 applies to the open-source core only, and that `ee/` remains separately licensed as Enterprise Edition code.

## Fixes
None.

## Approach
Updated the README license section with a short open-core licensing note and linked to both license files.

## How Has This Been Tested?

Ran:

```bash
git diff --check
```

Result: passed.

## Learning (optional, can help others)

No external research was needed. This follows the licensing split already documented in `docs/licensing.md` and `ee/LICENSE`.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

No code comments were needed because this is a README-only clarification. No screenshots were captured because this does not change product UI.

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
