### PR TITLE
docs: add license commitment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,9 @@ The `ee/` directory is licensed under the [Observal Enterprise License](https://
 
 ## License
 
-All code outside `ee/` is licensed under [Apache-2.0](https://github.com/BlazeUp-AI/Observal/blob/main/LICENSE/README.md). The `ee/` directory is licensed under the [Observal Enterprise License](https://github.com/BlazeUp-AI/Observal/blob/main/ee/LICENSE/README.md).
+All code outside `ee/` is licensed under [Apache-2.0](LICENSE). See the [License Commitment](LICENSE_COMMITMENT.md) for the project's Apache-2.0 commitment and license history.
+
+The `ee/` directory is licensed under the [Observal Enterprise License](ee/LICENSE).
 
 ***
 

--- a/LICENSE_COMMITMENT.md
+++ b/LICENSE_COMMITMENT.md
@@ -1,0 +1,24 @@
+<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# License Commitment
+
+Observal's open-source core is licensed under Apache-2.0.
+
+## Our commitment
+
+The open-source core, all code outside `ee/`, is Apache-2.0. We will not move the open-source core to a more restrictive license.
+
+The `ee/` directory may contain Enterprise Edition code under a separate license. That does not change the Apache-2.0 license of the open-source core.
+
+## License history
+
+Observal originally launched under Apache-2.0. We later moved the project to AGPL-3.0-only while we evaluated the best balance between open collaboration, adoption, and commercial sustainability.
+
+We have now returned the open-source core to Apache-2.0. This is intentional. Apache-2.0 is simpler for individuals, startups, and enterprises to adopt, and better matches our goal of making Observal broadly usable inside engineering teams.
+
+## What this means
+
+Previously released Apache-2.0 versions remain Apache-2.0. The Apache-2.0 license for those versions is irrevocable.
+
+Going forward, our commitment is that Observal's open-source core remains Apache-2.0.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,6 @@ Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://gith
 
 ## License
 
-The open-source core, all code outside `ee/`, is licensed under the Apache License 2.0. See [LICENSE](LICENSE).
+The open-source core, all code outside `ee/`, is licensed under the Apache License 2.0. See [LICENSE](LICENSE) and our [License Commitment](LICENSE_COMMITMENT.md).
 
 The `ee/` directory contains Enterprise Edition code licensed separately under the [Observal Enterprise License](ee/LICENSE).


### PR DESCRIPTION
## Purpose / Description

Document Observal's Apache-2.0 commitment clearly for users, contributors, and companies reviewing the project license.

## Fixes

* No linked issue.

## Approach

Added `LICENSE_COMMITMENT.md` with a short Apache-2.0 commitment, the Apache to AGPL to Apache license history, and the Enterprise Edition boundary.

Linked the commitment from `README.md` and `CONTRIBUTING.md`.

## How Has This Been Tested?

Ran pre-commit for `LICENSE_COMMITMENT.md`, `README.md`, and `CONTRIBUTING.md`.

Ran a git diff whitespace check for the same files.

All relevant checks passed.

No UI changes were made, so screenshots are not applicable.

## Learning (optional, can help others)

Inspected the existing README, CONTRIBUTING guide, LICENSE, and CLA wording before adding the commitment.

No external libraries or resources were added.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
  - Not applicable, documentation-only change.
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - Not applicable, no UI changes.

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [ ] Was the generated code manually reviewed and tested?
  - Human review pending. Automated checks listed above passed.
