### PR TITLE
docs: remove BlazeUp references

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -2,33 +2,33 @@
 
 **Version 1.0**
 
-Thank you for your interest in contributing to Observal, a project maintained by BlazeUp AI LLP ("BlazeUp AI", "we", or "us").
+Thank you for your interest in contributing to Observal, a project maintained by Observal ("Observal", "we", or "us").
 
-To clarify the intellectual property license granted with contributions from any person or entity, BlazeUp AI must have a signed Contributor License Agreement ("CLA") on file from each contributor. This agreement is for your protection as a contributor as well as the protection of BlazeUp AI and its users. It does not change your rights to use your own contributions for any other purpose.
+To clarify the intellectual property license granted with contributions from any person or entity, Observal must have a signed Contributor License Agreement ("CLA") on file from each contributor. This agreement is for your protection as a contributor as well as the protection of Observal and its users. It does not change your rights to use your own contributions for any other purpose.
 
-By signing this agreement, you accept and agree to the following terms and conditions for your present and future contributions submitted to BlazeUp AI. Except for the licenses granted herein, you reserve all right, title, and interest in and to your contributions.
+By signing this agreement, you accept and agree to the following terms and conditions for your present and future contributions submitted to Observal. Except for the licenses granted herein, you reserve all right, title, and interest in and to your contributions.
 
 ---
 
 ## 1. Definitions
 
-**"You"** (or "Your") means the copyright owner or legal entity authorized by the copyright owner that is entering into this Agreement with BlazeUp AI. For legal entities, the entity making a contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+**"You"** (or "Your") means the copyright owner or legal entity authorized by the copyright owner that is entering into this Agreement with Observal. For legal entities, the entity making a contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
 
-**"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to BlazeUp AI for inclusion in, or documentation of, any of the products owned or managed by BlazeUp AI (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to BlazeUp AI or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, BlazeUp AI for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+**"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Observal for inclusion in, or documentation of, any of the products owned or managed by Observal (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to Observal or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Observal for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
 
 ---
 
 ## 2. Grant of Copyright License
 
-Subject to the terms and conditions of this Agreement, You hereby grant to BlazeUp AI and to recipients of software distributed by BlazeUp AI a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+Subject to the terms and conditions of this Agreement, You hereby grant to Observal and to recipients of software distributed by Observal a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
 
-This license grant includes the right for BlazeUp AI to sublicense Your Contributions under any license, including proprietary or commercial licenses, consistent with BlazeUp AI's dual-license structure (Apache-2.0 for the open-source core and the Observal Enterprise License for the `ee/` directory). You acknowledge and agree that BlazeUp AI may offer Your Contributions as part of a commercial product or service.
+This license grant includes the right for Observal to sublicense Your Contributions under any license, including proprietary or commercial licenses, consistent with Observal's dual-license structure (Apache-2.0 for the open-source core and the Observal Enterprise License for the `ee/` directory). You acknowledge and agree that Observal may offer Your Contributions as part of a commercial product or service.
 
 ---
 
 ## 3. Grant of Patent License
 
-Subject to the terms and conditions of this Agreement, You hereby grant to BlazeUp AI and to recipients of software distributed by BlazeUp AI a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted.
+Subject to the terms and conditions of this Agreement, You hereby grant to Observal and to recipients of software distributed by Observal a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was submitted.
 
 If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
 
@@ -36,7 +36,7 @@ If any entity institutes patent litigation against You or any other entity (incl
 
 ## 4. You Represent That You Are Entitled to Grant This License
 
-You represent that you are legally entitled to grant the above licenses. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to BlazeUp AI, or that your employer has executed a separate Corporate CLA with BlazeUp AI.
+You represent that you are legally entitled to grant the above licenses. If your employer(s) has rights to intellectual property that you create that includes your Contributions, you represent that you have received permission to make Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to Observal, or that your employer has executed a separate Corporate CLA with Observal.
 
 ---
 
@@ -54,13 +54,13 @@ You are not expected to provide support for Your Contributions, except to the ex
 
 ## 7. Third-Party Work
 
-Should You wish to submit work that is not Your original creation, You may submit it to BlazeUp AI separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+Should You wish to submit work that is not Your original creation, You may submit it to Observal separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
 
 ---
 
 ## 8. Duty to Notify
 
-You agree to notify BlazeUp AI of any facts or circumstances of which you become aware that would make any of the representations in this Agreement inaccurate in any respect.
+You agree to notify Observal of any facts or circumstances of which you become aware that would make any of the representations in this Agreement inaccurate in any respect.
 
 ---
 
@@ -78,6 +78,6 @@ If you are contributing on behalf of a company or organization, please contact u
 
 ---
 
-*BlazeUp AI LLP*
+*Observal*
 *Registered Office: Chennai, Tamil Nadu, India*
 *Contact: contact@observal.io*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -70,7 +70,7 @@ enterprise code and does not accept community contributions. See
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**contact@blazeup.app**.
+**contact@observal.io**.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for considering contributing to Observal. Contributions of all kinds a
 
 > \[!IMPORTANT] **Discord is our primary communication channel.** Join at [discord.observal.io](https://discord.observal.io) and ask questions in **#contributing**, report bugs in **#bug**, or discuss ideas in **#feature-requests**. GitHub issues and PRs are for concrete, actionable items, not exploratory discussion.
 
-Please read our [Code of Conduct](https://github.com/BlazeUp-AI/Observal/blob/main/CODE_OF_CONDUCT.md) and [AI Policy](AI_POLICY.md) before contributing.
+Please read our [Code of Conduct](https://github.com/Observal/Observal/blob/main/CODE_OF_CONDUCT.md) and [AI Policy](AI_POLICY.md) before contributing.
 
 > Parts of this guide were inspired by the contributing documentation from [AnkiDroid/Anki-Android](https://github.com/ankidroid/Anki-Android). They set a great standard for OSS contributor docs and were one of the first open-source projects some of our maintainers were part of. If you are looking for another welcoming OSS project, check them out.
 
@@ -75,7 +75,7 @@ uv tool install --editable .
 observal auth login
 ```
 
-The stack starts at `http://localhost` (nginx LB on port 80). The `.env.example` seeds demo accounts on first startup, log in with `super@demo.example` / `super-changeme` for admin access. See [SETUP.md](https://github.com/BlazeUp-AI/Observal/blob/main/SETUP.md) for all credentials.
+The stack starts at `http://localhost` (nginx LB on port 80). The `.env.example` seeds demo accounts on first startup, log in with `super@demo.example` / `super-changeme` for admin access. See [SETUP.md](https://github.com/Observal/Observal/blob/main/SETUP.md) for all credentials.
 
 **Frontend only:**
 
@@ -164,7 +164,7 @@ Subject line under 72 characters, imperative mood, no trailing period.
 
 ### Changelog
 
-Add an entry under `[Unreleased]` in [CHANGELOG.md](https://github.com/BlazeUp-AI/Observal/blob/main/CHANGELOG.md) for any user-facing change.
+Add an entry under `[Unreleased]` in [CHANGELOG.md](https://github.com/Observal/Observal/blob/main/CHANGELOG.md) for any user-facing change.
 
 ***
 
@@ -208,7 +208,7 @@ Describe the problem you are solving, not just the solution. Discuss in **#featu
 
 > \[!CAUTION] Community contributions are **not accepted** into `ee/`. Pull requests touching `ee/` files will be closed. The open-source core must never import from `ee/`.
 
-The `ee/` directory is licensed under the [Observal Enterprise License](https://github.com/BlazeUp-AI/Observal/blob/main/ee/LICENSE/README.md). The dependency is strictly one-way: `ee/` may import from the core, never the reverse.
+The `ee/` directory is licensed under the [Observal Enterprise License](https://github.com/Observal/Observal/blob/main/ee/LICENSE/README.md). The dependency is strictly one-way: `ee/` may import from the core, never the reverse.
 
 ***
 
@@ -222,4 +222,4 @@ The `ee/` directory is licensed under the [Observal Enterprise License](ee/LICEN
 
 ## Contributor License Agreement (CLA)
 
-The [CLA-assistant](https://cla-assistant.io) bot will prompt you to sign the [Observal CLA](https://github.com/BlazeUp-AI/Observal/blob/main/CLA.md) on your first PR. You only need to sign once. For corporate contributions, contact contact@observal.io.
+The [CLA-assistant](https://cla-assistant.io) bot will prompt you to sign the [Observal CLA](https://github.com/Observal/Observal/blob/main/CLA.md) on your first PR. You only need to sign once. For corporate contributions, contact contact@observal.io.

--- a/LICENSES/LicenseRef-Observal-Enterprise.txt
+++ b/LICENSES/LicenseRef-Observal-Enterprise.txt
@@ -1,13 +1,13 @@
 Observal Enterprise License
 Version 1.0
 
-Copyright (c) 2026-present Observal (BlazeUp AI LLP)
+Copyright (c) 2026-present Observal
 
 TERMS AND CONDITIONS
 
 1. Grant of Rights
 
-   Subject to the terms of this License, Observal (BlazeUp AI LLP)
+   Subject to the terms of this License, Observal
    ("Licensor") grants you a non-exclusive, non-transferable,
    non-sublicensable license to:
 
@@ -30,7 +30,7 @@ TERMS AND CONDITIONS
 
    To use the Enterprise Code (or any derivative thereof) in
    production, you must obtain a valid commercial license from
-   Observal (BlazeUp AI LLP). Production use is defined as any
+   Observal. Production use is defined as any
    use that:
 
    (a) Serves end users, internal or external;
@@ -74,7 +74,7 @@ TERMS AND CONDITIONS
 
    Community contributions are NOT accepted into this directory.
    All code under this License is written exclusively by
-   Observal (BlazeUp AI LLP) or its authorized contractors and
+   Observal or its authorized contractors and
    employees.
 
    Community contributions should be directed to the open-source
@@ -91,13 +91,13 @@ TERMS AND CONDITIONS
    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
    PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
 
-   IN NO EVENT SHALL BLAZEUP AI LLP OR ITS CONTRIBUTORS BE
+   IN NO EVENT SHALL OBSERVAL OR ITS CONTRIBUTORS BE
    LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER
    IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM,
    OUT OF, OR IN CONNECTION WITH THE ENTERPRISE CODE OR THE
    USE OR OTHER DEALINGS IN THE ENTERPRISE CODE.
 
-   BLAZEUP AI LLP'S TOTAL LIABILITY UNDER THIS LICENSE SHALL
+   OBSERVAL'S TOTAL LIABILITY UNDER THIS LICENSE SHALL
    NOT EXCEED THE FEES PAID BY YOU FOR THE COMMERCIAL LICENSE
    IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
 
@@ -109,10 +109,10 @@ TERMS AND CONDITIONS
 
    (a) Fail to comply with any term of this License;
    (b) Allow your commercial license key to expire without renewal;
-   (c) Have your commercial license revoked by BlazeUp AI LLP
+   (c) Have your commercial license revoked by Observal
        due to breach of the Commercial License Agreement; or
    (d) Initiate any intellectual property litigation against
-       BlazeUp AI LLP relating to the Observal Platform.
+       Observal relating to the Observal Platform.
 
    Upon termination:
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Logs are written to `~/.observal/logs/dev.log` and include structured context fo
 
 ## Security
 
-Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://github.com/Observal/Observal/security/advisories) or email contact@blazeup.app. Do not open a public issue. See [SECURITY.md](SECURITY.md).
+Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://github.com/Observal/Observal/security/advisories) or email contact@observal.io. Do not open a public issue. See [SECURITY.md](SECURITY.md).
 
 ## Star History
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -218,12 +218,12 @@ SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "LICENSE"
-SPDX-FileCopyrightText = "2026-present BlazeUp AI LLP"
+SPDX-FileCopyrightText = "2026-present Observal"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "ee/LICENSE"
-SPDX-FileCopyrightText = "2026-present BlazeUp AI LLP"
+SPDX-FileCopyrightText = "2026-present Observal"
 SPDX-License-Identifier = "LicenseRef-Observal-Enterprise"
 
 [[annotations]]
@@ -298,12 +298,12 @@ SPDX-License-Identifier = "OFL-1.1"
 
 [[annotations]]
 path = ".clabot"
-SPDX-FileCopyrightText = "2026 Observal (BlazeUp AI LLP)"
+SPDX-FileCopyrightText = "2026 Observal"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "packages/pi-extension/package.json"
-SPDX-FileCopyrightText = "2026 Observal (BlazeUp AI LLP)"
+SPDX-FileCopyrightText = "2026 Observal"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@
 If you discover a security vulnerability in Observal, please report it responsibly through one of these channels:
 
 1. **GitHub Private Vulnerability Reporting** (preferred): Go to the [Security Advisories](https://github.com/Observal/Observal/security/advisories) page and click "Report a vulnerability".
-2. **Email**: Send details to **contact@blazeup.app**.
+2. **Email**: Send details to **contact@observal.io**.
 
 ### What to Include
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -70,7 +70,7 @@ We are a small, active community and we take the quality of interactions serious
 >
 > * Pinging contributors, maintainers, or reviewers unnecessarily (outside of a direct reply on your own open PR or issue)
 > * Submitting low-effort or unreviewed PRs (slop), including unreviewed AI output or autonomous agent submissions
-> * Violating the [Code of Conduct](https://github.com/BlazeUp-AI/Observal/blob/main/CODE_OF_CONDUCT.md) in any channel
+> * Violating the [Code of Conduct](https://github.com/Observal/Observal/blob/main/CODE_OF_CONDUCT.md) in any channel
 > * Harassing reviewers over merge timelines
 
 Maintainers volunteer their time. Treat them accordingly.
@@ -310,7 +310,7 @@ They are not interchangeable. Never write telemetry to Postgres or relational da
 
 **Supporting services:** Redis (pub/sub + arq job queue), arq worker, nginx reverse proxy. Prometheus and Grafana are optional.
 
-See [AGENTS.md](https://github.com/BlazeUp-AI/Observal/blob/main/AGENTS.md) for a complete map of every important file and service.
+See [AGENTS.md](https://github.com/Observal/Observal/blob/main/AGENTS.md) for a complete map of every important file and service.
 
 ***
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -25,9 +25,9 @@ Complete reference for the `observal` CLI. Every subcommand has its own page; th
 | [`observal agent`](agent.md)                                                               | Author and publish agents                                                             |
 | [`observal ops`](ops.md)                                                                   | Observability and operations (traces, spans, metrics, feedback)                       |
 | [`observal admin`](admin.md)                                                               | Admin operations (settings, users, review, security)                                  |
-| [`observal support`](https://github.com/BlazeUp-AI/Observal/blob/main/docs/cli/support.md) | Generate and inspect diagnostic support bundles                                       |
+| [`observal support`](https://github.com/Observal/Observal/blob/main/docs/cli/support.md) | Generate and inspect diagnostic support bundles                                       |
 | [`observal doctor`](doctor.md)                                                             | Diagnose harness compatibility; `doctor patch` applies instrumentation                |
-| [`observal migrate`](https://github.com/BlazeUp-AI/Observal/blob/main/docs/cli/migrate.md) | Export/import PostgreSQL registry (shallow copy) and ClickHouse telemetry (deep copy) |
+| [`observal migrate`](https://github.com/Observal/Observal/blob/main/docs/cli/migrate.md) | Export/import PostgreSQL registry (shallow copy) and ClickHouse telemetry (deep copy) |
 | [`observal self`](self.md)                                                                 | Upgrade or downgrade the CLI                                                          |
 | [`observal prompt`](prompt.md)                                                             | Manage reusable prompts in the registry                                               |
 | [`observal server`](server.md)                                                             | Manage the embedded server (start, stop, upgrade, rollback)                           |

--- a/docs/cli/support.md
+++ b/docs/cli/support.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026-present Observal (BlazeUp AI LLP)
+SPDX-FileCopyrightText: 2026-present Observal
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -42,7 +42,7 @@ See [`ee/LICENSE`](../ee/LICENSE) for complete terms.
 
 ## For contributors
 
-All contributions to the open-source core outside `ee/` require signing the [Contributor License Agreement](../CLA.md). The CLA grants BlazeUp AI the right to sublicense contributions, including under a commercial license, while you retain copyright.
+All contributions to the open-source core outside `ee/` require signing the [Contributor License Agreement](../CLA.md). The CLA grants Observal the right to sublicense contributions, including under a commercial license, while you retain copyright.
 
 Community contributions to the `ee/` directory are not accepted.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -48,7 +48,7 @@ OIDC, SAML, and SSO-only mode are configured in **Admin → SSO** and stored in 
 
 ### AWS (Bedrock)
 
-> **Note:** Bedrock now supports [API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) — generate one from the AWS console and use it like any other provider. See [Insights LLM Setup](https://github.com/BlazeUp-AI/Observal/blob/main/docs/insights-setup.md).
+> **Note:** Bedrock now supports [API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) — generate one from the AWS console and use it like any other provider. See [Insights LLM Setup](https://github.com/Observal/Observal/blob/main/docs/insights-setup.md).
 
 These environment variables are **not required** if you use Bedrock API keys (recommended). They exist only for legacy setups using instance roles or ECS task roles where LiteLLM auto-discovers credentials from the environment.
 

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -50,7 +50,7 @@ All services run on a private `observal-net` bridge network. Named volumes (`pgd
 
 Choose the deployment model that fits your team:
 
-|                    | [Single-node](single-node-deploy.md) | [Kubernetes](https://github.com/BlazeUp-AI/Observal/blob/main/docs/self-hosting/kubernetes-helm.md) | [Production](production-deploy.md)    |
+|                    | [Single-node](single-node-deploy.md) | [Kubernetes](https://github.com/Observal/Observal/blob/main/docs/self-hosting/kubernetes-helm.md) | [Production](production-deploy.md)    |
 | ------------------ | ------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | **How**            | Docker Compose on one VM             | Official Helm chart                                                                                 | Terraform on AWS or GCP               |
 | **Best for**       | ≤50 users, internal tools, POCs      | Cloud-native teams, existing K8s infra                                                              | Enterprise, SLA-bound, 50+ users      |
@@ -63,7 +63,7 @@ Choose the deployment model that fits your team:
 | If you want to...                | Read                                                                                                                     |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | Deploy on a single VM (simplest) | [Single-node deployment](single-node-deploy.md)                                                                          |
-| Deploy on Kubernetes with Helm   | [Kubernetes deployment with Helm](https://github.com/BlazeUp-AI/Observal/blob/main/docs/self-hosting/kubernetes-helm.md) |
+| Deploy on Kubernetes with Helm   | [Kubernetes deployment with Helm](https://github.com/Observal/Observal/blob/main/docs/self-hosting/kubernetes-helm.md) |
 | Deploy a production HA stack     | [Production deployment](production-deploy.md)                                                                            |
 | Deploy on AWS specifically       | [AWS deployment with Terraform](aws-terraform.md)                                                                        |
 | Deploy on GCP specifically       | [GCP deployment with Terraform](gcp-terraform.md)                                                                        |

--- a/docs/self-hosting/aws-terraform.md
+++ b/docs/self-hosting/aws-terraform.md
@@ -69,7 +69,7 @@ terraform output app_url
 
 Open that URL in your browser. The API and web tasks start a couple of minutes after the ALB targets register; refresh until you see the Observal login page.
 
-A ready-to-apply call of the module lives at [`infra/terraform/aws/examples/minimal`](https://github.com/BlazeUp-AI/Observal/blob/main/infra/terraform/aws/examples/minimal/README.md).
+A ready-to-apply call of the module lives at [`infra/terraform/aws/examples/minimal`](https://github.com/Observal/Observal/blob/main/infra/terraform/aws/examples/minimal/README.md).
 
 ## Configuration
 
@@ -226,7 +226,7 @@ ecs_security_group_id = "sg-0abc1234def56789b"
 
 The ALB SG must allow inbound TCP 80/443 from your desired CIDRs. The ECS SG must allow inbound TCP 8000 and 3000 from the ALB SG, with outbound to all.
 
-A full working example lives at [`infra/terraform/aws/examples/byovpc`](https://github.com/BlazeUp-AI/Observal/blob/main/infra/terraform/aws/examples/byovpc/README.md).
+A full working example lives at [`infra/terraform/aws/examples/byovpc`](https://github.com/Observal/Observal/blob/main/infra/terraform/aws/examples/byovpc/README.md).
 
 ## Required IAM permissions
 

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,13 +1,13 @@
 Observal Enterprise License
 Version 1.0
 
-Copyright (c) 2026-present Observal (BlazeUp AI LLP)
+Copyright (c) 2026-present Observal
 
 TERMS AND CONDITIONS
 
 1. Grant of Rights
 
-   Subject to the terms of this License, Observal (BlazeUp AI LLP)
+   Subject to the terms of this License, Observal
    ("Licensor") grants you a non-exclusive, non-transferable,
    non-sublicensable license to:
 
@@ -30,7 +30,7 @@ TERMS AND CONDITIONS
 
    To use the Enterprise Code (or any derivative thereof) in
    production, you must obtain a valid commercial license from
-   Observal (BlazeUp AI LLP). Production use is defined as any
+   Observal. Production use is defined as any
    use that:
 
    (a) Serves end users, internal or external;
@@ -74,7 +74,7 @@ TERMS AND CONDITIONS
 
    Community contributions are NOT accepted into this directory.
    All code under this License is written exclusively by
-   Observal (BlazeUp AI LLP) or its authorized contractors and
+   Observal or its authorized contractors and
    employees.
 
    Community contributions should be directed to the open-source
@@ -91,13 +91,13 @@ TERMS AND CONDITIONS
    TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
    PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
 
-   IN NO EVENT SHALL BLAZEUP AI LLP OR ITS CONTRIBUTORS BE
+   IN NO EVENT SHALL OBSERVAL OR ITS CONTRIBUTORS BE
    LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER
    IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM,
    OUT OF, OR IN CONNECTION WITH THE ENTERPRISE CODE OR THE
    USE OR OTHER DEALINGS IN THE ENTERPRISE CODE.
 
-   BLAZEUP AI LLP'S TOTAL LIABILITY UNDER THIS LICENSE SHALL
+   OBSERVAL'S TOTAL LIABILITY UNDER THIS LICENSE SHALL
    NOT EXCEED THE FEES PAID BY YOU FOR THE COMMERCIAL LICENSE
    IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
 
@@ -109,10 +109,10 @@ TERMS AND CONDITIONS
 
    (a) Fail to comply with any term of this License;
    (b) Allow your commercial license key to expire without renewal;
-   (c) Have your commercial license revoked by BlazeUp AI LLP
+   (c) Have your commercial license revoked by Observal
        due to breach of the Commercial License Agreement; or
    (d) Initiate any intellectual property litigation against
-       BlazeUp AI LLP relating to the Observal Platform.
+       Observal relating to the Observal Platform.
 
    Upon termination:
 

--- a/infra/terraform/aws-standard/README.md
+++ b/infra/terraform/aws-standard/README.md
@@ -67,5 +67,5 @@ Set `domain_name`, `route53_zone_id`, and `enable_tls = true` to provision an AC
 
 ## SPDX
 
-SPDX-FileCopyrightText: 2026 BlazeUp AI
+SPDX-FileCopyrightText: 2026 Observal
 SPDX-License-Identifier: Apache-2.0

--- a/infra/terraform/aws-standard/alb.tf
+++ b/infra/terraform/aws-standard/alb.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 resource "aws_lb" "app" {

--- a/infra/terraform/aws-standard/data-host.tf
+++ b/infra/terraform/aws-standard/data-host.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # Data tier: a single EC2 host running Postgres, Redis, ClickHouse, and optional observability.

--- a/infra/terraform/aws-standard/data-user-data.sh.tftpl
+++ b/infra/terraform/aws-standard/data-user-data.sh.tftpl
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 set -eo pipefail

--- a/infra/terraform/aws-standard/ecs-cluster.tf
+++ b/infra/terraform/aws-standard/ecs-cluster.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # ECS cluster backed by EC2 capacity provider (not Fargate).

--- a/infra/terraform/aws-standard/ecs-instances.tf
+++ b/infra/terraform/aws-standard/ecs-instances.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # EC2 launch template + ASG for ECS cluster instances.

--- a/infra/terraform/aws-standard/ecs-services.tf
+++ b/infra/terraform/aws-standard/ecs-services.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # ECS services using EC2 capacity provider strategy.

--- a/infra/terraform/aws-standard/ecs-tasks.tf
+++ b/infra/terraform/aws-standard/ecs-tasks.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # ECS task definitions: api, web, worker, init.

--- a/infra/terraform/aws-standard/iam.tf
+++ b/infra/terraform/aws-standard/iam.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 data "aws_partition" "current" {}

--- a/infra/terraform/aws-standard/locals.tf
+++ b/infra/terraform/aws-standard/locals.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 data "aws_availability_zones" "available" {

--- a/infra/terraform/aws-standard/logs.tf
+++ b/infra/terraform/aws-standard/logs.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # Centralized CloudWatch log groups for ECS tasks and the data host.

--- a/infra/terraform/aws-standard/outputs.tf
+++ b/infra/terraform/aws-standard/outputs.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 output "app_url" {

--- a/infra/terraform/aws-standard/s3.tf
+++ b/infra/terraform/aws-standard/s3.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # Backups bucket — ClickHouse snapshots, Postgres dumps, ad-hoc data exports.

--- a/infra/terraform/aws-standard/secrets.tf
+++ b/infra/terraform/aws-standard/secrets.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # ── Generated secrets ─────────────────────────────────────────────────────

--- a/infra/terraform/aws-standard/security.tf
+++ b/infra/terraform/aws-standard/security.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # ── ALB ────────────────────────────────────────────────────────────────────

--- a/infra/terraform/aws-standard/terraform.tfvars.example
+++ b/infra/terraform/aws-standard/terraform.tfvars.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # Copy to terraform.tfvars and fill in.

--- a/infra/terraform/aws-standard/variables.tf
+++ b/infra/terraform/aws-standard/variables.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 variable "region" {

--- a/infra/terraform/aws-standard/versions.tf
+++ b/infra/terraform/aws-standard/versions.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 terraform {

--- a/infra/terraform/aws-standard/vpc.tf
+++ b/infra/terraform/aws-standard/vpc.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # All VPC networking resources are conditional on local.should_create_vpc.

--- a/infra/terraform/aws/examples/byovpc/README.md
+++ b/infra/terraform/aws/examples/byovpc/README.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2026 BlazeUp AI -->
+<!-- SPDX-FileCopyrightText: 2026 Observal -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Bring Your Own VPC Example

--- a/infra/terraform/aws/examples/byovpc/main.tf
+++ b/infra/terraform/aws/examples/byovpc/main.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 # Deploy Observal into an existing VPC.

--- a/infra/terraform/aws/examples/byovpc/outputs.tf
+++ b/infra/terraform/aws/examples/byovpc/outputs.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 output "app_url" {

--- a/infra/terraform/aws/examples/byovpc/terraform.tfvars.example
+++ b/infra/terraform/aws/examples/byovpc/terraform.tfvars.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 region      = "us-east-1"

--- a/infra/terraform/aws/examples/byovpc/variables.tf
+++ b/infra/terraform/aws/examples/byovpc/variables.tf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 
 variable "region" {

--- a/infra/terraform/deploy.sh
+++ b/infra/terraform/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2026 BlazeUp AI
+# SPDX-FileCopyrightText: 2026 Observal
 # SPDX-License-Identifier: Apache-2.0
 #
 # Unified Observal AWS Deployment


### PR DESCRIPTION
## Purpose / Description

Remove stale BlazeUp references now that project links, contact addresses, and public docs should point to Observal.

## Fixes

* No linked issue.

## Approach

Replaced `BlazeUp-AI` GitHub links with `Observal/Observal` links.

Changed `contact@blazeup.app` references to `contact@observal.io`.

Updated remaining BlazeUp text in legal, license, SPDX annotation, and Terraform docs to use Observal.

## How Has This Been Tested?

Ran a repository search for `blazeup`; no matches remain.

Ran a whitespace diff check.

Ran pre-commit on all touched files. All relevant checks passed.

No UI changes were made, so screenshots are not applicable.

## Learning (optional, can help others)

Used `git grep` to find remaining stale project name, organization URL, and contact email references.

No external libraries or resources were added.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
  - Not applicable, documentation-only change.
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - Not applicable, no UI changes.

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [ ] Was the generated code manually reviewed and tested?
  - Human review pending. Automated checks listed above passed.
