### PR TITLE
fix(server,web): resolve latest open issues

### DIFF
--- a/observal-server/alembic/versions/002_drop_visibility.py
+++ b/observal-server/alembic/versions/002_drop_visibility.py
@@ -20,8 +20,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.drop_table("agent_team_access")
-    op.drop_column("agents", "visibility")
+    inspector = sa.inspect(op.get_bind())
+    if inspector.has_table("agent_team_access"):
+        op.drop_table("agent_team_access")
+    if "visibility" in {column["name"] for column in inspector.get_columns("agents")}:
+        op.drop_column("agents", "visibility")
     op.execute("DROP TYPE IF EXISTS agentvisibility")
 
 

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -607,11 +607,11 @@ function ComponentMetadata({ item }: { item: RegistryItem }) {
           <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Environment Variables</h3>
           <div className="rounded-md border border-border divide-y divide-border">
             {envVars.map((ev) => (
-              <div key={ev.name} className="px-3 py-2 flex items-center justify-between text-sm">
-                <code className="font-mono text-xs">{ev.name}</code>
-                <div className="flex items-center gap-2">
-                  {ev.description && <span className="text-xs text-muted-foreground">{ev.description}</span>}
-                  {ev.required && <Badge variant="secondary" className="text-[10px]">required</Badge>}
+              <div key={ev.name} className="px-3 py-2 flex items-start justify-between gap-3 text-sm">
+                <code className="font-mono text-xs shrink-0 pt-0.5">{ev.name}</code>
+                <div className="min-w-0 flex flex-wrap items-start justify-end gap-2 text-right">
+                  {ev.description && <span className="min-w-0 break-words text-xs leading-relaxed text-muted-foreground">{ev.description}</span>}
+                  {ev.required && <Badge variant="secondary" className="shrink-0 text-[10px]">required</Badge>}
                 </div>
               </div>
             ))}

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -329,16 +329,13 @@ export default function ComponentDetailPage() {
                               <p className="text-xs text-muted-foreground/70 italic truncate max-w-xl">{v.changelog}</p>
                             )}
                           </div>
-                          <div className="shrink-0 text-right space-y-0.5">
-                            {v.released_by && (
-                              <p className="text-xs text-muted-foreground">{v.released_by}</p>
-                            )}
-                            {v.released_at && (
+                          {v.released_at && (
+                            <div className="shrink-0 text-right space-y-0.5">
                               <p className="text-xs text-muted-foreground">
                                 {new Date(v.released_at).toLocaleDateString()}
                               </p>
-                            )}
-                          </div>
+                            </div>
+                          )}
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## Purpose / Description
Fix the three latest open issues in one PR, with one commit per issue.

## Fixes
* Fixes #1555
* Fixes #1553
* Fixes #1552

## Approach
* Make migration `002_drop_visibility` safe on fresh databases by checking for the legacy table and column before dropping them.
* Let long MCP environment variable descriptions wrap inside the overview panel and align rows from the top.
* Remove raw IDs from component version rows so the Versions tab only shows version information.

## How Has This Been Tested?

Ran:

```bash
cd observal-server && uv run ruff check alembic/versions/002_drop_visibility.py
cd observal-server && uv run python - <<'PY'
import importlib.util
from pathlib import Path
from unittest.mock import Mock, patch

path = Path('alembic/versions/002_drop_visibility.py')
spec = importlib.util.spec_from_file_location('drop_visibility', path)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)

inspector = Mock()
inspector.has_table.return_value = False
inspector.get_columns.return_value = [{'name': 'id'}]
op = Mock()
op.get_bind.return_value = object()
with patch.object(mod, 'op', op), patch.object(mod.sa, 'inspect', return_value=inspector):
    mod.upgrade()

op.drop_table.assert_not_called()
op.drop_column.assert_not_called()
op.execute.assert_called_once_with('DROP TYPE IF EXISTS agentvisibility')
print('migration 002 fresh-db smoke passed')
PY
cd web && pnpm typecheck
```

`pnpm exec eslint src/pages/registry/components/detail.tsx` was also attempted, but this repo config reported the file as ignored, so `pnpm typecheck` is the usable web verification here.

## Learning (optional, can help others)
No external references used. The fixes came from the issue reports and the existing migration and component detail code.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?
