### PR TITLE
Fix/copilot cli attribution

### DIFF
--- a/observal-server/schemas/constants.py
+++ b/observal-server/schemas/constants.py
@@ -37,6 +37,7 @@ HARNESS_CAPABILITY_NAMES: list[str] = [
     "skills",
     "hooks",
     "mcp_servers",
+    "prompts",
 ]
 
 HARNESS_CAPABILITIES: dict[str, set[str]] = get_harness_capability_matrix()

--- a/observal-server/schemas/harness_registry.py
+++ b/observal-server/schemas/harness_registry.py
@@ -198,7 +198,7 @@ HARNESS_REGISTRY: dict[str, dict] = {
     },
     "copilot": {
         "display_name": "Copilot",
-        "capabilities": {"mcp_servers", "hooks", "skills"},
+        "capabilities": {"mcp_servers", "hooks", "skills", "prompts"},
         "session_parser": "copilot-cli",
         "scopes": ["project"],
         "default_scope": "project",
@@ -234,7 +234,7 @@ HARNESS_REGISTRY: dict[str, dict] = {
     },
     "copilot-cli": {
         "display_name": "Copilot CLI",
-        "capabilities": {"mcp_servers", "hooks", "skills"},
+        "capabilities": {"mcp_servers", "hooks", "skills", "prompts"},
         "session_parser": "copilot-cli",
         "scopes": ["project"],
         "default_scope": "project",

--- a/observal-server/services/harness/__init__.py
+++ b/observal-server/services/harness/__init__.py
@@ -29,6 +29,8 @@ class ConfigContext:
     hook_listings: dict | None = None
     skill_listings: dict | None = None
     sandbox_listings: dict | None = None
+    prompt_listings: dict | None = None
+    component_names: dict | None = None
 
 
 @runtime_checkable
@@ -109,7 +111,16 @@ def generate_agent_config(
         if sandbox_mcp:
             mcp_configs.update(sandbox_mcp)
 
-    rules_content = _build_rules_content(agent, component_names, prompt_listings, sandbox_listings)
+    # Harnesses with first-class prompt files (Copilot) emit the full template
+    # into .github/prompts/*.prompt.md, so keep the agent body to a name list
+    # to avoid duplicating the template.
+    emit_prompt_files = harness in ("copilot", "copilot-cli")
+    rules_content = _build_rules_content(
+        agent,
+        component_names,
+        None if emit_prompt_files else prompt_listings,
+        sandbox_listings,
+    )
     skill_configs = _build_skill_configs(agent, skill_listings)
     hook_configs = _build_hook_configs(agent, hook_listings)
     options = options or {}
@@ -135,6 +146,8 @@ def generate_agent_config(
         hook_listings=hook_listings,
         skill_listings=skill_listings,
         sandbox_listings=sandbox_listings,
+        prompt_listings=prompt_listings,
+        component_names=component_names,
     )
     return adapter.format_config(ctx)
 

--- a/observal-server/services/harness/copilot.py
+++ b/observal-server/services/harness/copilot.py
@@ -16,6 +16,7 @@ from loguru import logger as optic
 
 from schemas.harness_registry import HARNESS_REGISTRY
 from services.harness import ConfigContext, register_adapter
+from services.harness.helpers import _generate_prompt_files
 
 
 class CopilotAdapter:
@@ -67,6 +68,10 @@ class CopilotAdapter:
             },
             "scope": copilot_spec["default_scope"],
         }
+        # Native Copilot prompt files (.github/prompts/*.prompt.md)
+        prompt_files = _generate_prompt_files(ctx.prompt_listings, ctx.agent, ctx.component_names)
+        if prompt_files:
+            result["prompt_files"] = prompt_files
         if ctx.compatibility_warnings:
             result["_warnings"] = ctx.compatibility_warnings
 

--- a/observal-server/services/harness/copilot_cli.py
+++ b/observal-server/services/harness/copilot_cli.py
@@ -12,6 +12,7 @@ from schemas.harness_registry import HARNESS_REGISTRY
 from services.harness import ConfigContext, register_adapter
 from services.harness.helpers import (
     _collect_hook_script_files,
+    _generate_prompt_files,
     _generate_skill,
     _merge_hook_components_into_config,
 )
@@ -133,6 +134,10 @@ class CopilotCliAdapter:
         hook_files = _collect_hook_script_files(hook_configs, ctx.hook_listings, "copilot-cli")
         if hook_files:
             result["hook_files"] = hook_files
+        # Native Copilot prompt files (.github/prompts/*.prompt.md)
+        prompt_files = _generate_prompt_files(ctx.prompt_listings, ctx.agent, ctx.component_names)
+        if prompt_files:
+            result["prompt_files"] = prompt_files
         if skills:
             result["skills"] = skills
             result["skill_components"] = [s for s in skill_configs if s.get("git_url")]

--- a/observal-server/services/harness/helpers.py
+++ b/observal-server/services/harness/helpers.py
@@ -778,3 +778,40 @@ def _build_rules_content(
             sections.append("\n".join(lines))
 
     return "\n\n".join(sections) if sections else f"# {agent.name}"
+
+
+def _generate_prompt_files(
+    prompt_listings: dict | None,
+    agent: Agent,
+    component_names: dict | None = None,
+) -> list[dict]:
+    """Build native prompt files for harnesses with first-class prompt support.
+
+    Returns ``[{"path": ".github/prompts/<name>.prompt.md", "content": ...}]``
+    for each prompt component attached to the agent. GitHub Copilot reads these
+    as reusable prompt files, so the full template lives in its own file rather
+    than only being summarised in the agent body.
+
+    Returns ``[]`` when there are no prompt components or listings are missing.
+    """
+    if not prompt_listings:
+        return []
+    names = component_names or {}
+    files: list[dict] = []
+    for comp in getattr(agent, "components", []):
+        if comp.component_type != "prompt":
+            continue
+        listing = prompt_listings.get(comp.component_id)
+        if not listing:
+            continue
+        template = getattr(listing, "template", "") or ""
+        if not template:
+            continue
+        raw_name = getattr(listing, "name", "") or names.get(str(comp.component_id), str(comp.component_id)[:8])
+        safe = _sanitize_name(raw_name)
+        description = getattr(listing, "description", "") or raw_name
+        # Keep the YAML description on one line and quote-safe.
+        desc_yaml = description.replace('"', "'").splitlines()[0] if description else raw_name
+        content = f'---\ndescription: "{desc_yaml}"\n---\n\n{template.rstrip()}\n'
+        files.append({"path": f".github/prompts/{safe}.prompt.md", "content": content})
+    return files

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -770,6 +770,17 @@ def register_pull(app: typer.Typer):
                     os.chmod(p, 0o755)
                 written.append((str(p), "updated" if existed else "created"))
 
+        # ── prompt_files (native Copilot .github/prompts/*.prompt.md) ─
+        for pf in snippet.get("prompt_files") or []:
+            p = _resolve_path(pf["path"], target_dir, allow_home=is_user_scope)
+            if dry_run:
+                written.append((str(p), "would write"))
+            else:
+                existed = p.exists()
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(pf["content"])
+                written.append((str(p), "updated" if existed else "created"))
+
         # ── Direct skill files ─────────────────────────
         for sf in snippet.get("skills") or []:
             p = _resolve_path(sf["path"], target_dir, allow_home=is_user_scope)

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -358,6 +358,38 @@ def _rewrite_kiro_hooks(content: dict, agent_id: str | None = None) -> dict:
     return content
 
 
+def _rewrite_copilot_cli_hooks(content: dict, agent_id: str | None = None) -> dict:
+    """Rewrite Copilot CLI hook commands to inject per-agent attribution.
+
+    The server emits a generic ``.github/hooks/observal.json`` whose commands
+    carry no agent identity, so sessions fall back to best-effort cwd matching
+    and go unattributed for user-scope installs or when the project moves.
+    Rebuilding the Observal hooks with ``build_copilot_cli_hooks(agent_id=...)``
+    prepends ``OBSERVAL_AGENT_ID`` (both bash and powershell forms), which the
+    session push hook resolves to an exact agent+version via the lockfile.
+
+    User-added hooks in the file are preserved; only Observal's entries are
+    replaced. Mirrors _rewrite_kiro_hooks().
+    """
+    optic.trace("content={}, agent_id={}", content, agent_id)
+    hooks = content.get("hooks")
+    if not hooks:
+        return content
+
+    from observal_cli.harness_specs.copilot_cli_hooks_spec import build_copilot_cli_hooks
+
+    desired_hooks = build_copilot_cli_hooks(agent_id=agent_id or "")["hooks"]
+
+    # Replace only Observal hooks, preserve any user-added hooks
+    for event, desired_entries in desired_hooks.items():
+        existing = hooks.get(event, [])
+        cleaned = [h for h in existing if "copilot_cli_session_push" not in h.get("bash", "")]
+        hooks[event] = cleaned + desired_entries
+
+    content["hooks"] = hooks
+    return content
+
+
 def _resolve_path(raw_path: str, target_dir: Path, *, allow_home: bool = False) -> Path:
     """Resolve a path from the config snippet relative to *target_dir*.
 
@@ -676,6 +708,14 @@ def register_pull(app: typer.Typer):
                     raw,
                 )
                 content = json.loads(raw)
+                # Copilot project hooks are one file per project; stamp the
+                # pulled agent's UUID so sessions attribute deterministically
+                # instead of relying on best-effort cwd matching.
+                if harness in ("copilot", "copilot-cli"):
+                    content = _rewrite_copilot_cli_hooks(
+                        content,
+                        agent_id=str(agent_detail.get("id", resolved)),
+                    )
             if dry_run:
                 written.append((str(p), "would write"))
             else:

--- a/observal_cli/constants.py
+++ b/observal_cli/constants.py
@@ -34,6 +34,7 @@ HARNESS_CAPABILITY_NAMES: list[str] = [
     "skills",
     "hooks",
     "mcp_servers",
+    "prompts",
 ]
 
 HARNESS_CAPABILITIES: dict[str, set[str]] = get_harness_capability_matrix()

--- a/observal_cli/harness_registry.py
+++ b/observal_cli/harness_registry.py
@@ -188,7 +188,7 @@ HARNESS_REGISTRY: dict[str, dict] = {
     "copilot": {
         "display_name": "Copilot",
         "session_parser": "copilot-cli",
-        "capabilities": {"mcp_servers", "hooks", "skills"},
+        "capabilities": {"mcp_servers", "hooks", "skills", "prompts"},
         "scopes": ["project"],
         "default_scope": "project",
         "scope_labels": None,
@@ -224,7 +224,7 @@ HARNESS_REGISTRY: dict[str, dict] = {
     "copilot-cli": {
         "display_name": "Copilot CLI",
         "session_parser": "copilot-cli",
-        "capabilities": {"mcp_servers", "hooks", "skills"},
+        "capabilities": {"mcp_servers", "hooks", "skills", "prompts"},
         "scopes": ["project"],
         "default_scope": "project",
         "scope_labels": None,

--- a/observal_cli/harness_specs/copilot_cli_hooks_spec.py
+++ b/observal_cli/harness_specs/copilot_cli_hooks_spec.py
@@ -45,7 +45,7 @@ def _python_cmd() -> str:
     return f'PYTHONPATH="{_PKG_ROOT}" "{sys.executable}"'
 
 
-def build_copilot_cli_hooks() -> dict:
+def build_copilot_cli_hooks(agent_id: str = "") -> dict:
     """Return the complete hook file content for Copilot CLI.
 
     Produces a JSON-serializable dict matching the Copilot CLI hook file
@@ -53,11 +53,26 @@ def build_copilot_cli_hooks() -> dict:
 
     Includes powershell key for Windows environments where Copilot CLI
     executes hooks via PowerShell rather than bash.
+
+    When *agent_id* is supplied, ``OBSERVAL_AGENT_ID`` is prepended to both
+    command forms so the session push hook can attribute events to a specific
+    agent+version via the lockfile. This mirrors the per-agent attribution
+    Kiro gets from build_kiro_hooks(). Copilot CLI project hooks live in
+    ``.github/hooks/observal.json`` (one file per project), so the UUID
+    identifies whichever agent was pulled into that project.
     """
     module = "observal_cli.hooks.copilot_cli_session_push"
     bash_cmd = f"{_python_cmd()} -m {module}"
     # PowerShell command uses bare 'python' which must be on Windows PATH
     ps_cmd = f"python -m {module}"
+
+    if agent_id:
+        if sys.platform == "win32":
+            bash_cmd = f'set "OBSERVAL_AGENT_ID={agent_id}" && {bash_cmd}'
+        else:
+            bash_cmd = f"OBSERVAL_AGENT_ID={agent_id} {bash_cmd}"
+        # PowerShell (used on Windows) sets the env var in-process for the child.
+        ps_cmd = f"$env:OBSERVAL_AGENT_ID='{agent_id}'; {ps_cmd}"
 
     hooks: dict[str, list[dict]] = {}
     for event in COPILOT_CLI_HOOK_EVENTS:

--- a/observal_cli/sessions/base.py
+++ b/observal_cli/sessions/base.py
@@ -463,10 +463,19 @@ def _resolve_agent(
 
     env_agent_id = os.environ.get("OBSERVAL_AGENT_ID", "")
     if env_agent_id:
+        # Prefer a harness-scoped match, but fall back to an unscoped UUID
+        # lookup. A UUID is globally unique, and the harness recorded at pull
+        # time may differ from the one resolving the session: Copilot CLI is
+        # pulled under "copilot" yet reports "copilot-cli", and build_payload
+        # defaults harness to "claude-code" when a caller sets payload["harness"]
+        # after the fact. Scoping the lookup would leave those sessions
+        # unattributed despite a valid OBSERVAL_AGENT_ID.
         lockfile_entry = _lookup_lockfile_agent_by_id(env_agent_id, harness=harness)
+        if lockfile_entry is None:
+            lockfile_entry = _lookup_lockfile_agent_by_id(env_agent_id)
         if lockfile_entry:
             return lockfile_entry.get("id"), lockfile_entry.get("version")
-        optic.warning("OBSERVAL_AGENT_ID={} not found in lockfile for harness={}", env_agent_id, harness)
+        optic.warning("OBSERVAL_AGENT_ID={} not found in lockfile (harness={})", env_agent_id, harness)
         return None, None
 
     if harness == "kiro":

--- a/tests/test_copilot_integration.py
+++ b/tests/test_copilot_integration.py
@@ -32,10 +32,10 @@ class TestRegistryAndFrontend:
     """Registry entries for Copilot harness support."""
 
     def test_copilot_feature_matrix(self):
-        """Copilot features == {"mcp_servers", "hooks", "skills"}."""
+        """Copilot features == {"mcp_servers", "hooks", "skills", "prompts"}."""
         from observal_cli.constants import HARNESS_CAPABILITIES
 
-        assert HARNESS_CAPABILITIES["copilot"] == {"mcp_servers", "hooks", "skills"}
+        assert HARNESS_CAPABILITIES["copilot"] == {"mcp_servers", "hooks", "skills", "prompts"}
 
     def test_copilot_session_parser(self):
         """Copilot session_parser is 'copilot-cli' (shares parser with Copilot CLI)."""
@@ -1022,7 +1022,10 @@ class TestServerAdapterFormatConfig:
             "skill_configs": [],
             "hook_listings": [],
             "compatibility_warnings": [],
+            "prompt_listings": None,
+            "component_names": None,
         }
+        agent_components = overrides.pop("agent_components", [])
         defaults.update(overrides)
 
         ctx = MagicMock(spec=ConfigContext)
@@ -1030,6 +1033,7 @@ class TestServerAdapterFormatConfig:
             setattr(ctx, k, v)
         ctx.agent = MagicMock()
         ctx.agent.description = "Test agent"
+        ctx.agent.components = agent_components
         return ctx
 
     def test_correct_hook_file_format(self):
@@ -1067,6 +1071,52 @@ class TestServerAdapterFormatConfig:
         mcp_config = result["mcp_config"]
         assert mcp_config["path"] == "~/.copilot/mcp-config.json"
         assert "mcpServers" in mcp_config["content"]
+
+    def test_no_prompt_files_without_prompt_components(self):
+        from services.harness.copilot_cli import CopilotCliAdapter
+
+        result = CopilotCliAdapter().format_config(self._make_ctx())
+        assert "prompt_files" not in result
+
+    def test_emits_native_prompt_file(self):
+        """A prompt component becomes .github/prompts/<name>.prompt.md."""
+        from services.harness.copilot_cli import CopilotCliAdapter
+
+        comp = MagicMock()
+        comp.component_type = "prompt"
+        comp.component_id = "pid-1"
+        listing = MagicMock()
+        listing.name = "My Prompt"
+        listing.template = "Do the thing."
+        listing.description = "A test prompt"
+
+        ctx = self._make_ctx(prompt_listings={"pid-1": listing}, agent_components=[comp])
+        result = CopilotCliAdapter().format_config(ctx)
+
+        assert "prompt_files" in result
+        pf = result["prompt_files"]
+        assert len(pf) == 1
+        # sanitize_name preserves case, replaces the space with a hyphen
+        assert pf[0]["path"] == ".github/prompts/My-Prompt.prompt.md"
+        assert "Do the thing." in pf[0]["content"]
+        assert "description:" in pf[0]["content"]
+
+    def test_vscode_copilot_also_emits_prompt_file(self):
+        from services.harness.copilot import CopilotAdapter
+
+        comp = MagicMock()
+        comp.component_type = "prompt"
+        comp.component_id = "pid-9"
+        listing = MagicMock()
+        listing.name = "vs-prompt"
+        listing.template = "vscode prompt body"
+        listing.description = "d"
+
+        ctx = self._make_ctx(prompt_listings={"pid-9": listing}, agent_components=[comp])
+        result = CopilotAdapter().format_config(ctx)
+
+        assert "prompt_files" in result
+        assert result["prompt_files"][0]["path"] == ".github/prompts/vs-prompt.prompt.md"
 
     def test_correct_skill_paths(self):
         from services.harness.copilot_cli import CopilotCliAdapter

--- a/tests/test_copilot_integration.py
+++ b/tests/test_copilot_integration.py
@@ -327,6 +327,125 @@ class TestBuildCopilotCliHooks:
         for event, entries in result["hooks"].items():
             assert entries[0]["timeoutSec"] == 5, f"Event {event} timeout != 5"
 
+    def test_no_agent_id_omits_observal_agent_id(self):
+        """Without an agent_id, commands carry no OBSERVAL_AGENT_ID prefix."""
+        from observal_cli.harness_specs.copilot_cli_hooks_spec import build_copilot_cli_hooks
+
+        result = build_copilot_cli_hooks()
+        for entries in result["hooks"].values():
+            assert "OBSERVAL_AGENT_ID" not in entries[0]["bash"]
+            assert "OBSERVAL_AGENT_ID" not in entries[0]["powershell"]
+
+    def test_agent_id_injected_into_both_command_forms(self):
+        """A supplied agent_id is stamped into bash and powershell commands.
+
+        Regression: Copilot CLI sessions were unattributed because the project
+        hook carried no agent identity. The UUID must reach the push hook so
+        _resolve_agent can map it to an agent+version via the lockfile.
+        """
+        from observal_cli.harness_specs.copilot_cli_hooks_spec import build_copilot_cli_hooks
+
+        result = build_copilot_cli_hooks(agent_id="agent-uuid-42")
+        for event, entries in result["hooks"].items():
+            bash = entries[0]["bash"]
+            ps = entries[0]["powershell"]
+            assert "OBSERVAL_AGENT_ID=agent-uuid-42" in bash, f"{event} bash missing UUID"
+            assert "agent-uuid-42" in ps and "OBSERVAL_AGENT_ID" in ps, f"{event} powershell missing UUID"
+            # The push command must still be present after the prefix.
+            assert "copilot_cli_session_push" in bash
+
+
+class TestRewriteCopilotCliHooks:
+    """_rewrite_copilot_cli_hooks: stamps the pulled agent UUID at pull time."""
+
+    def _server_content(self) -> dict:
+        """Generic hook file as the server emits it (no agent identity)."""
+        push = "python3 -m observal_cli.hooks.copilot_cli_session_push"
+        return {
+            "version": 1,
+            "hooks": {
+                "sessionStart": [{"type": "command", "bash": push, "powershell": push, "timeoutSec": 5}],
+                "userPromptSubmitted": [{"type": "command", "bash": push, "powershell": push, "timeoutSec": 5}],
+            },
+        }
+
+    def test_stamps_agent_id_into_observal_hooks(self):
+        from observal_cli.cmd_pull import _rewrite_copilot_cli_hooks
+
+        out = _rewrite_copilot_cli_hooks(self._server_content(), agent_id="uuid-99")
+        for entries in out["hooks"].values():
+            obs = [e for e in entries if "copilot_cli_session_push" in e.get("bash", "")]
+            assert len(obs) == 1
+            assert "OBSERVAL_AGENT_ID=uuid-99" in obs[0]["bash"]
+
+    def test_preserves_user_added_hooks(self):
+        from observal_cli.cmd_pull import _rewrite_copilot_cli_hooks
+
+        content = self._server_content()
+        content["hooks"]["sessionStart"].append({"type": "command", "bash": "echo user-hook", "timeoutSec": 5})
+        out = _rewrite_copilot_cli_hooks(content, agent_id="uuid-99")
+        bashes = [e["bash"] for e in out["hooks"]["sessionStart"]]
+        assert any("echo user-hook" in b for b in bashes), "user hook must survive"
+
+    def test_is_idempotent_no_duplicate_observal_hooks(self):
+        """Re-pulling must not accumulate duplicate Observal entries."""
+        from observal_cli.cmd_pull import _rewrite_copilot_cli_hooks
+
+        content = _rewrite_copilot_cli_hooks(self._server_content(), agent_id="uuid-1")
+        content = _rewrite_copilot_cli_hooks(content, agent_id="uuid-2")
+        for entries in content["hooks"].values():
+            obs = [e for e in entries if "copilot_cli_session_push" in e.get("bash", "")]
+            assert len(obs) == 1, "exactly one Observal hook per event"
+            assert "OBSERVAL_AGENT_ID=uuid-2" in obs[0]["bash"], "latest UUID wins"
+
+    def test_no_hooks_key_returns_unchanged(self):
+        from observal_cli.cmd_pull import _rewrite_copilot_cli_hooks
+
+        assert _rewrite_copilot_cli_hooks({}, agent_id="uuid-1") == {}
+
+
+class TestResolveAgentCopilotUuidFallback:
+    """_resolve_agent: OBSERVAL_AGENT_ID resolves across a harness-key mismatch."""
+
+    def test_unscoped_fallback_when_harness_scope_misses(self):
+        """Copilot pulls under 'copilot' but pushes with harness 'copilot-cli'
+        (and build_payload defaults to 'claude-code'). A globally-unique UUID
+        must still resolve via the unscoped lockfile lookup.
+        """
+        from unittest.mock import patch
+
+        from observal_cli.sessions.base import _resolve_agent
+
+        entry = {"id": "uuid-cp", "name": "test", "version": "1.2.0"}
+
+        def by_id(agent_id, harness=None):
+            if agent_id != "uuid-cp":
+                return None
+            # Agent is stored only under the 'copilot' harness key.
+            return entry if harness in (None, "copilot") else None
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "uuid-cp"}, clear=True),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id", side_effect=by_id),
+        ):
+            # harness reported by the push payload differs from the lockfile key
+            assert _resolve_agent("/repo", [], None, harness="copilot-cli") == ("uuid-cp", "1.2.0")
+            # build_payload's default harness also differs
+            assert _resolve_agent("/repo", [], None, harness="claude-code") == ("uuid-cp", "1.2.0")
+
+    def test_unknown_uuid_stays_unattributed(self):
+        from unittest.mock import patch
+
+        from observal_cli.sessions.base import _resolve_agent
+
+        with (
+            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "nope"}, clear=True),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id", return_value=None),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent") as cwd_lookup,
+        ):
+            assert _resolve_agent("/repo", [], None, harness="copilot-cli") == (None, None)
+            cwd_lookup.assert_not_called()
+
 
 class TestPatchCopilot:
     """_patch_copilot: hook installation for VS Code Copilot."""

--- a/tests/test_harness_config_e2e.py
+++ b/tests/test_harness_config_e2e.py
@@ -82,7 +82,7 @@ class TestConstants:
 
     def test_copilot_feature_matrix(self):
         assert "copilot" in HARNESS_CAPABILITIES
-        assert HARNESS_CAPABILITIES["copilot"] == {"mcp_servers", "hooks", "skills"}
+        assert HARNESS_CAPABILITIES["copilot"] == {"mcp_servers", "hooks", "skills", "prompts"}
 
     def test_copilot_session_parser(self):
         from observal_cli.harness_registry import HARNESS_REGISTRY
@@ -127,7 +127,7 @@ class TestConstants:
 
     def test_copilot_cli_feature_matrix(self):
         assert "copilot-cli" in HARNESS_CAPABILITIES
-        assert HARNESS_CAPABILITIES["copilot-cli"] == {"mcp_servers", "hooks", "skills"}
+        assert HARNESS_CAPABILITIES["copilot-cli"] == {"mcp_servers", "hooks", "skills", "prompts"}
 
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Purpose / Description
Copilot CLI sessions were not being attributed to the agent they ran under, so their traces never linked back to a specific agent and version. This adds the missing agent identity to the pulled Copilot hook and fixes the resolver that reads it. It also adds native prompt file support for Copilot, so prompt components install as real `.github/prompts/*.prompt.md` files instead of only being summarised in the agent body.

## Approach
Two related changes:

1. Attribution. `observal agent pull` now stamps `OBSERVAL_AGENT_ID` into the project hook (`.github/hooks/observal.json`) for both the bash and powershell commands, matching how Kiro already works. `_resolve_agent` falls back to an unscoped lockfile lookup by UUID, because the harness recorded at pull time (`copilot`) differs from the one seen when the session is resolved (`copilot-cli`, or the `claude-code` default), which previously left the session unattributed even when the UUID was present.

2. Prompt files. A new `_generate_prompt_files` helper builds one `.github/prompts/{name}.prompt.md` per prompt component. Prompt listings are threaded through `ConfigContext`, both Copilot adapters emit the files, and the agent body is reduced to a name list so the template is not duplicated. The `prompts` capability is declared for copilot and copilot-cli. It is not wired into `infer_required_features` on purpose, so other harnesses keep rendering prompts and are not marked incompatible.

Sandboxes already reach Copilot through the rules body and a runnable `observal-sandbox` MCP entry, so they are left as is.

## How Has This Been Tested?
- Unit and integration tests: 199 CLI tests and 35 server tests pass. Ruff check and format are clean on all changed files.
- Live end to end against a local server: published mcp, skill, hook, prompt, and sandbox components to the local registry, attached them to a test agent, and ran `observal agent pull --harness copilot-cli`.
  - The hook command carries `OBSERVAL_AGENT_ID=<agent-uuid>`.
  - `.github/prompts/<name>.prompt.md` is written with the template, and the agent body lists the prompt by name only.
  - The sandbox runs: `observal-sandbox-run ... --command "python --version"` returned `Python 3.12.13`.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
- [x] Yes (Please Specify the tool): Claude Code
- [x] Was the generated code manually reviewed and tested?