### PR TITLE
docs: add harness support GitHub issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/harness_support.yml
+++ b/.github/ISSUE_TEMPLATE/harness_support.yml
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2026 Solaris-star <820622658@qq.com>
+# SPDX-License-Identifier: Apache-2.0
+
+name: 🔌 Harness Support Request
+description: Request support for a new coding-agent harness / IDE CLI
+title: "Add harness support: "
+labels: ["enhancement", "harness-support"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new harness!
+
+        Please read **[docs/adding-a-harness.md](https://github.com/Observal/Observal/blob/main/docs/adding-a-harness.md)** first — it is the canonical implementation guide (registry entry, CLI/server adapters, hooks, session parsers, tests).
+
+        Prefer a short discussion in [GitHub Discussions](https://github.com/Observal/Observal/discussions) if you only want to gauge interest.
+
+  - type: checkboxes
+    id: not_duplicate
+    attributes:
+      label: Duplicate check
+      description: Confirm this harness is not already tracked or supported.
+      options:
+        - label: I searched open and closed issues and did not find an existing request for this harness.
+          required: true
+        - label: I reviewed docs/adding-a-harness.md and understand the expected work.
+          required: true
+
+  - type: input
+    id: harness_name
+    attributes:
+      label: Harness name
+      description: Common product name (e.g. Claude Code, Cursor, Windsurf).
+      placeholder: My Harness
+    validations:
+      required: true
+
+  - type: input
+    id: official_docs
+    attributes:
+      label: Official documentation
+      description: Link to the vendor docs for MCP / skills / hooks / config.
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: input
+    id: source_repo
+    attributes:
+      label: Source repository (if open source)
+      description: GitHub/GitLab URL of the harness itself, if public.
+      placeholder: https://github.com/org/repo
+
+  - type: textarea
+    id: interfaces
+    attributes:
+      label: Supported interfaces
+      description: What surfaces does this harness expose that Observal should integrate with?
+      placeholder: |
+        - MCP servers (stdio / SSE / HTTP)
+        - Skills / rules / instruction files
+        - Hooks / lifecycle events
+        - Session logs (JSONL / SQLite / other)
+        - Sandbox / isolation features
+    validations:
+      required: true
+
+  - type: textarea
+    id: operating_systems
+    attributes:
+      label: Operating systems
+      description: Where the harness runs in practice.
+      placeholder: |
+        - macOS
+        - Linux
+        - Windows
+    validations:
+      required: true
+
+  - type: textarea
+    id: config_paths
+    attributes:
+      label: Known user and project configuration paths
+      description: Home-level and project-level paths/formats for MCP, skills, hooks, sessions.
+      placeholder: |
+        Project MCP: .my-harness/mcp.json (key: mcpServers)
+        User skills: ~/.my-harness/skills/
+        Session logs: ~/.my-harness/sessions/*.jsonl
+    validations:
+      required: true
+
+  - type: textarea
+    id: research
+    attributes:
+      label: Research checklist
+      description: Summarize what you already know about each capability (or mark unknown).
+      placeholder: |
+        - MCP servers:
+        - Skills:
+        - Custom agents / subagents:
+        - Hooks / events:
+        - Session storage:
+        - Sandbox support:
+    validations:
+      required: true
+
+  - type: dropdown
+    id: can_test
+    attributes:
+      label: Can you test this harness end-to-end?
+      description: Local install + ability to run scan/pull/reconcile style flows.
+      options:
+        - "Yes — I can install and exercise the harness locally"
+        - "Partially — limited access"
+        - "No — research-only proposal"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, config samples, prior art, related issues.


### PR DESCRIPTION
## Purpose / Description

New harness support requests currently use free-form bug/feature templates, so research fields drift away from `docs/adding-a-harness.md`. This PR adds a dedicated GitHub issue form.

## Fixes
* Fixes #1599

## Approach

Add `.github/ISSUE_TEMPLATE/harness_support.yml` with:

- Title prefix `Add harness support: `
- Labels `enhancement` + `harness-support`
- Required duplicate-check + guide-read confirmation
- Fields for harness name, official docs, source repo, interfaces, OSes, config paths, research checklist, and testability
- Markdown link to `docs/adding-a-harness.md`

## How Has This Been Tested?

- Validated YAML structure against existing `feature_request.yml` / `bug_report_form.yml` patterns
- Form will appear under "New issue" after merge (GitHub-rendered)

## Checklist

- [x] Descriptive commit message
- [x] Self-review completed
- [x] No UI string changes beyond issue form
