### PR TITLE
fix(helm): add repo id and contact info for artifacthub for helm charts

### DIFF
--- a/infra/helm/artifacthub-repo.yml
+++ b/infra/helm/artifacthub-repo.yml
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: 2026 amogh-dongre <amoghdongre16@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-# Add the ArtifactHub repository ID here after the repository is registered to
-# enable the Verified Publisher badge.
-# repositoryID: 00000000-0000-0000-0000-000000000000
+
+repositoryID: bcccc095-d7e6-4ae3-b40c-b5c2b6fb2f80
 owners:
   - name: Observal
-    email: contact@observal.io
+    email: harisrini21@gmail.com

--- a/tests/test_helm_oci_release.py
+++ b/tests/test_helm_oci_release.py
@@ -51,13 +51,15 @@ def test_chart_has_artifacthub_metadata_for_oci_listing():
     assert "Documentation" in chart["annotations"]["artifacthub.io/links"]
 
 
-def test_artifacthub_repo_metadata_is_ready_for_verified_publisher_id():
+def test_artifacthub_repo_metadata_has_registerd_verified_publisher_id():
     metadata_text = (ROOT / "infra/helm/artifacthub-repo.yml").read_text()
     metadata = yaml.safe_load(metadata_text)
 
-    assert metadata["owners"] == [{"name": "Observal", "email": "contact@observal.io"}]
-    assert "repositoryID:" in metadata_text
-    assert "00000000-0000-0000-0000-000000000000" in metadata_text
+    # assert metadata["owners"] == [{"name": "Observal", "email": "contact@observal.io"}]
+    # assert "repositoryID:" in metadata_text
+    # assert "00000000-0000-0000-0000-000000000000" in metadata_text
+    assert metadata["owners"] == [{"name": "Observal", "email": "harisrini21@gmail.com"}]
+    assert metadata["repositoryID"] == "bcccc095-d7e6-4ae3-b40c-b5c2b6fb2f80"
 
 
 def test_app_workload_image_tags_default_to_chart_app_version():


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

Follow-up to #1579 / #1610: registers the Observal chart's ArtifactHub repository with a real `repositoryID` and owner contact, enabling Verified Publisher status. #1610 shipped the OCI publishing pipeline and metadata scaffolding with a placeholder `repositoryID` and generic `contact@observal.io` owner email; the repository has since been registered on artifacthub.io, so this PR fills in the real values.

## Fixes

Relates to #1579 (already closed by #1610; no new issue to close here).

## Approach

- Set `repositoryID: bcccc095-d7e6-4ae3-b40c-b5c2b6fb2f80` in `infra/helm/artifacthub-repo.yml`, replacing the commented-out placeholder.
- Updated the `owners` entry's email to the verified ArtifactHub contact (`harisrini21@gmail.com`).
- Updated `test_artifacthub_repo_metadata_is_ready_for_verified_publisher_id` (renamed to `test_artifacthub_repo_metadata_has_registered_verified_publisher_id`) to assert the real registered ID/email instead of the placeholder.

## How Has This Been Tested?

```bash
.venv/bin/python -m pytest tests/test_helm_oci_release.py -q
# 7 passed
```

Also re-verified the full `helm-lint` assertions locally (not just this diff) since the branch had to be rebuilt on top of current `main`:

```bash
helm lint infra/helm/observal
helm package infra/helm/observal --version 1.2.3-test --app-version 1.2.3-test --destination /tmp/chart-dist-check
helm template observal /tmp/chart-dist-check/observal-1.2.3-test.tgz --namespace observal
```

## Learning (optional, can help others)

This branch had drifted: #1610 was merged to `main` before this follow-up commit was rebased, so the branch had to be rebuilt on top of current `main` and only the net-new change (this one) carried forward, to avoid a stale diff against already-merged content.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) — not applicable, no UI changes.

## AI Assistance

- [] No.
- [x] Was the generated code manually reviewed and tested?
