### PR TITLE
bump(release): v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.10.2] - 2026-07-21
+## [1.10.3] - 2026-07-21
 
 ### Added
 
@@ -965,6 +965,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- add repo id and contact info for artifacthub (**helm**) ([942f837](https://github.com/Observal/Observal/commit/942f83722084881137eab0aae143a58b3447a9fc))
 - default app images to chart version (**helm**) ([179e481](https://github.com/Observal/Observal/commit/179e481378561fa125714bc4f4cdfca5bd9e9fac))
 - address delivery audit findings (**telemetry**) ([0493e7c](https://github.com/Observal/Observal/commit/0493e7cc709166b1d80b688d57918a64214ef9b8))
 - migrate wrapped configs (**telemetry**) ([9a59b8d](https://github.com/Observal/Observal/commit/9a59b8de39c1163187da8980f2ab79693fadc1b2))

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.10.2"
+version = "1.10.3"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.10.2"
+version = "1.10.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "type": "module",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.10.2"
+version = "1.10.3"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.10.2"
+version = "1.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Release v1.10.3 (patch)

Bumps version `1.10.2` → `1.10.3` and regenerates changelog.

**Merging this PR will automatically trigger the release pipeline.**

### What happens after merge
- CLI binaries built for 6 platforms (Linux/macOS/Windows, x64/arm64)
- Docker images pushed to GHCR
- Server deployment tarball packaged
- PyPI package published
- **Approval required** in the `production` environment before GitHub Release publishes