### PR TITLE
fix(cli): exempt auth from auto-update so downgrades stick

### DIFF
--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -130,11 +130,14 @@ def _try_auto_update() -> None:
 
     Runs silently. Logs a message on success so the user knows the next
     invocation will use the new version.
-    Exempt: self/server subcommands, CI, non-TTY.
+    Exempt: self/server/auth subcommands, CI, non-TTY.
     """
-    # Skip exempt subcommands (check positional args, not flags)
+    # Skip exempt subcommands (check positional args, not flags).
+    # `auth` is exempt so a deliberate `self downgrade` to match an older
+    # server is not reverted by GitHub-latest auto-upgrade during the login
+    # that establishes the server relationship (server not in config yet).
     positional_args = [a for a in sys.argv[1:] if not a.startswith("-")]
-    if positional_args and positional_args[0] in ("self", "server"):
+    if positional_args and positional_args[0] in ("self", "server", "auth"):
         return
     if os.environ.get("CI") or os.environ.get("OBSERVAL_NO_UPDATE_CHECK"):
         return


### PR DESCRIPTION
## Purpose / Description

`observal self downgrade` worked, but the next command silently reverted it. A user who deliberately downgraded the CLI to match an older server found themselves back on GitHub-latest immediately, defeating the downgrade.

## Fixes

Reported during Feature 2 testing: after `observal self downgrade --version 1.9.9`, running `observal auth login --sso --server http://...` printed "Updated. The new version will be used on your next command." and the CLI was back on 1.10.3, still ahead of the 1.9.9 server.

## Approach

Root cause: `_try_auto_update()` runs at startup on every non-exempt command. During `auth login --server X` (the login that establishes the server relationship), the server is not yet in config, so `auto_update_if_needed()` falls back to GitHub-latest mode, sees 1.10.3 > 1.9.9, and silently auto-upgrades back. The downgrade itself was never broken.

Fix: add `auth` to the startup auto-update exempt list, alongside the existing `self` and `server` exemptions. Once login completes and the server is in config, server mode takes over and matches the server version, so auto-update no longer fights the intentional downgrade.

One-line behavioral change in `observal_cli/main.py`. No new state, no new config.

## How Has This Been Tested?

- `observal_cli/tests/` full suite passes (74 tests).
- Ruff clean.
- Reproduced the original flow locally: `observal self downgrade --version 1.10.2` succeeds; the next command no longer re-upgrades during `auth login`.

## Learning

Auto-update has two modes: server mode (match the server's version) and community/GitHub mode (track latest release). The bug was a mode-transition gap: during the first `auth login --server`, neither mode had the server yet, so community mode won and clobbered a deliberate downgrade. Exempting `auth` closes the window; server mode handles everything after.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes(Please specify the tool): Pi coding agent co-authored this PR.
- [x] Was the generated code manually reviewed and tested?
