### PR TITLE
feat(agent-builder): add success criteria fields to agent versions

### DIFF
--- a/observal-server/alembic/versions/016_agent_success_criteria.py
+++ b/observal-server/alembic/versions/016_agent_success_criteria.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add success_criteria to agent_versions.
+
+Revision ID: 016_agent_success_criteria
+Revises: 015_sandbox_runtime_config
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "016_agent_success_criteria"
+down_revision = "015_sandbox_runtime_config"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("agent_versions", sa.Column("success_criteria", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agent_versions", "success_criteria")

--- a/observal-server/alembic/versions/021_agent_success_criteria.py
+++ b/observal-server/alembic/versions/021_agent_success_criteria.py
@@ -3,16 +3,16 @@
 
 """Add success_criteria to agent_versions.
 
-Revision ID: 016_agent_success_criteria
-Revises: 015_sandbox_runtime_config
+Revision ID: 021_agent_success_criteria
+Revises: 020_remove_legacy_scope
 """
 
 import sqlalchemy as sa
 
 from alembic import op
 
-revision = "016_agent_success_criteria"
-down_revision = "015_sandbox_runtime_config"
+revision = "021_agent_success_criteria"
+down_revision = "020_remove_legacy_scope"
 branch_labels = None
 depends_on = None
 

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -698,10 +698,12 @@ async def update_agent(
                 raise HTTPException(status_code=422, detail=f"Invalid MCP command: {e}")
         agent.external_mcps = [m.model_dump() for m in req.external_mcps]
 
-    if req.success_criteria is not None:
+    if "success_criteria" in req.model_fields_set:
         if not agent.latest_version:
             raise HTTPException(status_code=400, detail="Agent has no version to update")
-        agent.latest_version.success_criteria = req.success_criteria.model_dump()
+        agent.latest_version.success_criteria = (
+            req.success_criteria.model_dump() if req.success_criteria is not None else None
+        )
 
     if req.components is not None:
         # New components field replaces ALL components (type validated by Pydantic Literal)
@@ -811,6 +813,29 @@ async def update_agent(
 
         agent.required_capabilities = infer_required_features(_AgentProxy(), skill_listings=skill_listings_map_update)
         agent.inferred_supported_harnesses = compute_supported_harnesses(agent.required_capabilities)
+
+    snapshot_fields = (
+        "version",
+        "description",
+        "prompt",
+        "model_name",
+        "model_config_json",
+        "models_by_harness",
+        "supported_harnesses",
+    )
+    snapshot_needs_refresh = (
+        req.version_bump_type is not None
+        or any(getattr(req, field) is not None for field in snapshot_fields)
+        or req.external_mcps is not None
+        or req.components is not None
+        or req.mcp_server_ids is not None
+        or "success_criteria" in req.model_fields_set
+    )
+    if snapshot_needs_refresh:
+        await db.flush()
+        from services.agent_snapshot import build_yaml_snapshot
+
+        agent.latest_version.yaml_snapshot = await build_yaml_snapshot(agent.latest_version, db)
 
     await db.commit()
     agent = await _load_agent(db, str(agent.id), prefer_user_id=current_user.id, current_user=current_user)

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -152,6 +152,7 @@ async def create_agent(
         released_by=current_user.id,
         reviewed_by=current_user.id if target.auto_approve else None,
         reviewed_at=datetime.now(UTC) if target.auto_approve else None,
+        success_criteria=req.success_criteria.model_dump() if req.success_criteria else None,
     )
     db.add(version)
     await db.flush()
@@ -696,6 +697,11 @@ async def update_agent(
             except ValueError as e:
                 raise HTTPException(status_code=422, detail=f"Invalid MCP command: {e}")
         agent.external_mcps = [m.model_dump() for m in req.external_mcps]
+
+    if req.success_criteria is not None:
+        if not agent.latest_version:
+            raise HTTPException(status_code=400, detail="Agent has no version to update")
+        agent.latest_version.success_criteria = req.success_criteria.model_dump()
 
     if req.components is not None:
         # New components field replaces ALL components (type validated by Pydantic Literal)

--- a/observal-server/api/routes/agent/draft.py
+++ b/observal-server/api/routes/agent/draft.py
@@ -155,6 +155,7 @@ async def save_draft(
         supported_harnesses=req.supported_harnesses,
         status=AgentStatus.draft,
         released_by=current_user.id,
+        success_criteria=req.success_criteria.model_dump() if req.success_criteria else None,
     )
     db.add(version)
     await db.flush()
@@ -300,6 +301,9 @@ async def update_draft(
         val = getattr(req, field)
         if val is not None:
             setattr(version, field, val)
+
+    if req.success_criteria is not None:
+        version.success_criteria = req.success_criteria.model_dump()
 
     if req.external_mcps is not None:
         for _mcp in req.external_mcps:

--- a/observal-server/api/routes/agent/draft.py
+++ b/observal-server/api/routes/agent/draft.py
@@ -302,8 +302,8 @@ async def update_draft(
         if val is not None:
             setattr(version, field, val)
 
-    if req.success_criteria is not None:
-        version.success_criteria = req.success_criteria.model_dump()
+    if "success_criteria" in req.model_fields_set:
+        version.success_criteria = req.success_criteria.model_dump() if req.success_criteria is not None else None
 
     if req.external_mcps is not None:
         for _mcp in req.external_mcps:

--- a/observal-server/api/routes/agent/helpers.py
+++ b/observal-server/api/routes/agent/helpers.py
@@ -145,6 +145,7 @@ def _agent_to_response(
         "status",
         "rejection_reason",
         "visibility",
+        "success_criteria",
     ):
         agent_dict[field] = getattr(agent, field)
     if not isinstance(agent_dict.get("models_by_harness"), dict):

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -271,7 +271,7 @@ async def _create_agent_version(
         models_by_harness=req.models_by_harness,
         external_mcps=[m.model_dump() for m in req.external_mcps] if req.external_mcps else [],
         supported_harnesses=req.supported_harnesses,
-        yaml_snapshot=req.yaml_snapshot,
+        yaml_snapshot=None,
         is_prerelease=req.is_prerelease,
         status=initial_status,
         released_by=current_user.id,
@@ -312,16 +312,12 @@ async def _create_agent_version(
     ver.required_capabilities = infer_required_features(_VersionProxy(), skill_listings=skill_listings_map)
     ver.inferred_supported_harnesses = compute_supported_harnesses(ver.required_capabilities)
 
-    # Backfill yaml_snapshot when the client didn't supply one (web builder
-    # path). Without this the reviewer's diff view is blank for everything
-    # that wasn't published from the CLI.
-    if not ver.yaml_snapshot:
-        # Flush pending AgentComponent rows so the snapshot
-        # builder can re-query them from the session.
-        await db.flush()
-        from services.agent_snapshot import build_yaml_snapshot
+    # Always build the snapshot from structured fields so caller-provided text
+    # cannot drift from the version stored in the database.
+    await db.flush()
+    from services.agent_snapshot import build_yaml_snapshot
 
-        ver.yaml_snapshot = await build_yaml_snapshot(ver, db)
+    ver.yaml_snapshot = await build_yaml_snapshot(ver, db)
 
     # Pre-generate harness configs at release time (spec: no generation at request time)
     mcp_comp_ids = [c.component_id for c in req.components if c.component_type == "mcp"]

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -92,6 +92,7 @@ def _version_to_detail(ver: AgentVersion) -> dict:
             "harness_configs": ver.harness_configs,
             "required_capabilities": ver.required_capabilities,
             "inferred_supported_harnesses": ver.inferred_supported_harnesses,
+            "success_criteria": ver.success_criteria,
         }
     )
     d["components"] = [
@@ -275,6 +276,7 @@ async def _create_agent_version(
         status=initial_status,
         released_by=current_user.id,
         released_at=now,
+        success_criteria=req.success_criteria.model_dump() if req.success_criteria else None,
     )
     db.add(ver)
     await db.flush()

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -587,6 +587,7 @@ async def get_review(
             "components_ready": components_ready,
             "component_blockers": blocking,
             "gaming_flags": ver.gaming_flags if ver else None,
+            "success_criteria": (ver.success_criteria if ver else None),
             "components": [
                 {
                     "component_type": c.component_type,

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -68,6 +68,7 @@ class AgentVersion(Base):
     editing_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     editing_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
     gaming_flags: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    success_criteria: Mapped[dict | None] = mapped_column(JSON, nullable=True)
 
     agent: Mapped["Agent"] = relationship(back_populates="versions", foreign_keys=[agent_id])
     components: Mapped[list["AgentComponent"]] = relationship(
@@ -276,6 +277,10 @@ class Agent(Base):
     @property
     def components(self) -> list:
         return self.latest_version.components if self.latest_version else []
+
+    @property
+    def success_criteria(self) -> dict | None:
+        return self.latest_version.success_criteria if self.latest_version else None
 
 
 from models.agent_component import AgentComponent  # noqa: E402

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -29,6 +29,50 @@ class ExternalMcp(BaseModel):
     url: str | None = None  # source URL for reference
 
 
+class SuccessMetric(BaseModel):
+    name: str
+    target: str
+    measurement: str
+
+    @field_validator("name", "target", "measurement")
+    @classmethod
+    def _not_blank_and_bounded(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Must not be blank")
+        if len(v) > 200:
+            raise ValueError("Must be at most 200 characters")
+        return v.strip()
+
+
+class SuccessCriteria(BaseModel):
+    intended_purpose: str
+    success_metrics: list[SuccessMetric] = []
+    evaluation_notes: str = ""
+
+    @field_validator("intended_purpose")
+    @classmethod
+    def _purpose_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Intended purpose must not be blank")
+        if len(v) > 2000:
+            raise ValueError("Intended purpose must be at most 2000 characters")
+        return v.strip()
+
+    @field_validator("success_metrics")
+    @classmethod
+    def _max_metrics(cls, v: list[SuccessMetric]) -> list[SuccessMetric]:
+        if len(v) > 10:
+            raise ValueError("At most 10 success metrics allowed")
+        return v
+
+    @field_validator("evaluation_notes")
+    @classmethod
+    def _notes_bounded(cls, v: str) -> str:
+        if len(v) > 2000:
+            raise ValueError("Evaluation notes must be at most 2000 characters")
+        return v.strip()
+
+
 ComponentType = Literal["mcp", "skill", "hook", "prompt", "sandbox"]
 
 
@@ -56,6 +100,7 @@ class AgentCreateRequest(BaseModel):
     mcp_server_ids: list[uuid.UUID] = []  # kept for backwards compat
     components: list[ComponentRef] = []  # new: all component types
     external_mcps: list[ExternalMcp] = []
+    success_criteria: SuccessCriteria | None = None
 
     _validate_name = field_validator("name")(make_name_validator("name"))
 
@@ -93,6 +138,7 @@ class AgentUpdateRequest(BaseModel):
     mcp_server_ids: list[uuid.UUID] | None = None  # kept for backwards compat
     components: list[ComponentRef] | None = None  # new: all component types
     external_mcps: list[ExternalMcp] | None = None
+    success_criteria: SuccessCriteria | None = None
 
     @field_validator("name", mode="before")
     @classmethod
@@ -156,6 +202,7 @@ class AgentResponse(BaseModel):
     supported_harnesses: list[str]
     required_capabilities: list[str] = []
     inferred_supported_harnesses: list[str] = []
+    success_criteria: dict | None = None
     status: AgentStatus
     rejection_reason: str | None = None
     created_by: uuid.UUID
@@ -253,6 +300,7 @@ class AgentVersionCreateRequest(BaseModel):
     yaml_snapshot: str | None = None
     is_prerelease: bool = False
     save_as_draft: bool = False
+    success_criteria: SuccessCriteria | None = None
 
     @field_validator("version")
     @classmethod

--- a/observal-server/services/agent_snapshot.py
+++ b/observal-server/services/agent_snapshot.py
@@ -118,5 +118,7 @@ async def build_yaml_snapshot(ver: AgentVersion, db: AsyncSession) -> str:
     }
     if ver.model_config_json:
         data["model_config_json"] = ver.model_config_json
+    if ver.success_criteria:
+        data["success_criteria"] = ver.success_criteria
     header = "# Auto-generated snapshot - review the structured fields above and the prompt below.\n"
     return header + yaml.safe_dump(data, sort_keys=False, default_flow_style=False, allow_unicode=True)

--- a/observal-server/tests/test_agent_versions_api.py
+++ b/observal-server/tests/test_agent_versions_api.py
@@ -63,6 +63,7 @@ def _make_version(agent_id: uuid.UUID, ver: str = SEMVER_VALID, status: AgentSta
     v.required_capabilities = ["rules"]
     v.inferred_supported_harnesses = ["claude-code"]
     v.yaml_snapshot = None
+    v.success_criteria = None
     v.harness_configs = None
     v.status = status
     v.is_prerelease = False

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -643,6 +643,19 @@ def agent_show(
         for link in item["mcp_links"]:
             rprint(f"  [cyan]•[/cyan] {link.get('mcp_name', '')} [dim]({link.get('mcp_listing_id', '')})[/dim]")
 
+    # Success criteria
+    sc = item.get("success_criteria")
+    if sc and sc.get("intended_purpose"):
+        rprint("\n[bold]Success Criteria:[/bold]")
+        rprint(f"  [cyan]Purpose:[/cyan] {sc['intended_purpose']}")
+        metrics = sc.get("success_metrics") or []
+        if metrics:
+            rprint("  [cyan]Metrics:[/cyan]")
+            for m in metrics:
+                rprint(f"    • {m['name']} — target: {m['target']} (via: {m['measurement']})")
+        if sc.get("evaluation_notes"):
+            rprint(f"  [cyan]Notes:[/cyan] {sc['evaluation_notes']}")
+
 
 @agent_app.command(name="install")
 def agent_install(
@@ -858,6 +871,7 @@ def agent_init(
         "prompt": prompt_text,
         "supported_harnesses": harnesses,
         "components": [],
+        "success_criteria": None,
     }
 
     _save_agent_yaml(dir_path, data)
@@ -1016,6 +1030,7 @@ def agent_publish(
         "prompt": data.get("prompt", ""),
         "supported_harnesses": data.get("supported_harnesses", []),
         "components": data.get("components", []),
+        "success_criteria": data.get("success_criteria"),
     }
 
     if update:
@@ -1155,6 +1170,7 @@ def agent_release(
         "supported_harnesses": data.get("supported_harnesses", []),
         "components": data.get("components", []),
         "yaml_snapshot": raw_yaml,
+        "success_criteria": data.get("success_criteria"),
     }
 
     rprint("[dim]→[/dim] Pushing definition to registry...")

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -1196,6 +1196,7 @@ def _update_agent_mock(user, *, is_private=False, team_id=None):
     agent.supported_harnesses = []
     agent.status = AgentStatus.approved
     agent.rejection_reason = None
+    agent.success_criteria = None
     agent.created_by = user.id
     agent.created_at = datetime.now(UTC)
     agent.updated_at = datetime.now(UTC)

--- a/tests/test_agent_name_lookup.py
+++ b/tests/test_agent_name_lookup.py
@@ -81,6 +81,7 @@ def _agent_mock(status=AgentStatus.approved, created_by=None, **extra):
     m.deleted_at = None
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
+    m.success_criteria = None
     col_keys = [
         "id",
         "name",

--- a/tests/test_agent_snapshot.py
+++ b/tests/test_agent_snapshot.py
@@ -55,6 +55,7 @@ def _mock_version(*, models_by_harness: dict | None = None, supported_harnesses:
     ver.models_by_harness = models_by_harness if models_by_harness is not None else {}
     ver.supported_harnesses = supported_harnesses or ["claude-code", "kiro"]
     ver.external_mcps = []
+    ver.success_criteria = None
     return ver
 
 

--- a/tests/test_agent_snapshot.py
+++ b/tests/test_agent_snapshot.py
@@ -80,6 +80,27 @@ async def test_snapshot_includes_models_by_harness():
 
 
 @pytest.mark.asyncio
+async def test_snapshot_includes_success_criteria():
+    """Success criteria should be preserved in the reviewer snapshot."""
+    from services.agent_snapshot import build_yaml_snapshot
+
+    criteria = {
+        "intended_purpose": "Review pull requests consistently.",
+        "success_metrics": [
+            {"name": "Review accuracy", "target": "> 95%", "measurement": "Human audit"},
+        ],
+        "evaluation_notes": "Sample completed reviews monthly.",
+    }
+    ver = _mock_version()
+    ver.success_criteria = criteria
+    db = _mock_session_for_snapshot(components=[], goal=None)
+
+    text = await build_yaml_snapshot(ver, db)
+
+    assert yaml.safe_load(text)["success_criteria"] == criteria
+
+
+@pytest.mark.asyncio
 async def test_snapshot_emits_empty_dict_when_no_overrides():
     """An empty ``models_by_harness`` should be present (not omitted) so reviewers
     can tell "no overrides" apart from "data missing"."""

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -106,6 +106,7 @@ def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
     m.deleted_at = None
     m.updated_at = datetime.now(UTC)
     m.components = extra.get("components", [])
+    m.success_criteria = None
     # Edit-lock fields on the latest_version mock
     m.latest_version.is_editing = False
     m.latest_version.editing_by = None

--- a/web/src/components/builder/success-criteria-section.tsx
+++ b/web/src/components/builder/success-criteria-section.tsx
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from "react";
+import { CheckCircle2, ChevronDown, ChevronRight, Plus, Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { SuccessCriteria, SuccessMetric } from "@/lib/types";
+
+interface SuccessCriteriaSectionProps {
+  value: SuccessCriteria | null;
+  onChange: (value: SuccessCriteria | null) => void;
+}
+
+const EMPTY_METRIC: SuccessMetric = { name: "", target: "", measurement: "" };
+
+function hasContent(v: SuccessCriteria | null): boolean {
+  if (!v) return false;
+  return !!(
+    v.intended_purpose?.trim() ||
+    v.evaluation_notes?.trim() ||
+    v.success_metrics?.some((m) => m.name.trim() || m.target.trim() || m.measurement.trim())
+  );
+}
+
+export function SuccessCriteriaSection({ value, onChange }: SuccessCriteriaSectionProps) {
+  const [expanded, setExpanded] = useState(hasContent(value));
+  const defined = hasContent(value);
+
+  function handleToggle() {
+    if (expanded) {
+      setExpanded(false);
+    } else {
+      setExpanded(true);
+    }
+  }
+
+  function update(partial: Partial<SuccessCriteria>) {
+    const current = value ?? { intended_purpose: "", success_metrics: [], evaluation_notes: "" };
+    onChange({ ...current, ...partial });
+  }
+
+  function handleClear() {
+    onChange(null);
+    setExpanded(false);
+  }
+
+  function addMetric() {
+    const metrics = [...(value?.success_metrics ?? []), { ...EMPTY_METRIC }];
+    update({ success_metrics: metrics });
+  }
+
+  function updateMetric(index: number, field: keyof SuccessMetric, fieldValue: string) {
+    const metrics = [...(value?.success_metrics ?? [])];
+    metrics[index] = { ...metrics[index], [field]: fieldValue };
+    update({ success_metrics: metrics });
+  }
+
+  function removeMetric(index: number) {
+    const metrics = (value?.success_metrics ?? []).filter((_, i) => i !== index);
+    update({ success_metrics: metrics });
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleToggle}
+          className="flex items-center gap-2 text-sm font-medium font-[family-name:var(--font-display)] hover:text-foreground/80 transition-colors"
+        >
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          Success Criteria
+          <span className="text-xs font-normal text-muted-foreground">(optional)</span>
+        </button>
+        {!expanded && defined && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+            <CheckCircle2 className="h-3 w-3" />
+            Defined
+          </span>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="space-y-4 pl-6 border-l-2 border-muted">
+          <div className="space-y-2">
+            <Label htmlFor="intended-purpose" className="text-sm font-medium">
+              Intended Purpose
+            </Label>
+            <Textarea
+              id="intended-purpose"
+              placeholder="What problem does this agent solve? What task does it handle?"
+              value={value?.intended_purpose ?? ""}
+              onChange={(e) => update({ intended_purpose: e.target.value })}
+              rows={2}
+              className="resize-y"
+            />
+            <p className="text-xs text-muted-foreground">
+              Required if you define success criteria. Describe the agent&apos;s core purpose.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label className="text-sm font-medium">Success Metrics</Label>
+              {(value?.success_metrics?.length ?? 0) < 10 && (
+                <Button type="button" variant="ghost" size="sm" onClick={addMetric}>
+                  <Plus className="mr-1 h-3 w-3" />
+                  Add Metric
+                </Button>
+              )}
+            </div>
+
+            {(value?.success_metrics ?? []).length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                No metrics defined. Add metrics to quantify what success looks like.
+              </p>
+            )}
+
+            {(value?.success_metrics ?? []).map((metric, index) => (
+              <div key={index} className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_1fr_auto] gap-2 items-start">
+                <Input
+                  placeholder="Metric name"
+                  value={metric.name}
+                  onChange={(e) => updateMetric(index, "name", e.target.value)}
+                  className="text-sm"
+                />
+                <Input
+                  placeholder="Target (e.g. < 5%)"
+                  value={metric.target}
+                  onChange={(e) => updateMetric(index, "target", e.target.value)}
+                  className="text-sm"
+                />
+                <Input
+                  placeholder="How to measure"
+                  value={metric.measurement}
+                  onChange={(e) => updateMetric(index, "measurement", e.target.value)}
+                  className="text-sm"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeMetric(index)}
+                  className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="evaluation-notes" className="text-sm font-medium">
+              Evaluation Notes
+            </Label>
+            <Textarea
+              id="evaluation-notes"
+              placeholder="Any context on how to judge whether this agent is working well..."
+              value={value?.evaluation_notes ?? ""}
+              onChange={(e) => update({ evaluation_notes: e.target.value })}
+              rows={2}
+              className="resize-y"
+            />
+          </div>
+
+          {defined && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleClear}
+              className="text-muted-foreground hover:text-destructive"
+            >
+              <X className="mr-1 h-3 w-3" />
+              Clear Success Criteria
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/builder/success-criteria-section.tsx
+++ b/web/src/components/builder/success-criteria-section.tsx
@@ -16,7 +16,7 @@ interface SuccessCriteriaSectionProps {
 
 const EMPTY_METRIC: SuccessMetric = { name: "", target: "", measurement: "" };
 
-function hasContent(v: SuccessCriteria | null): boolean {
+export function hasSuccessCriteriaContent(v: SuccessCriteria | null): boolean {
   if (!v) return false;
   return !!(
     v.intended_purpose?.trim() ||
@@ -25,9 +25,34 @@ function hasContent(v: SuccessCriteria | null): boolean {
   );
 }
 
+export function validateSuccessCriteria(v: SuccessCriteria | null): string | null {
+  if (!v || !hasSuccessCriteriaContent(v)) return null;
+  if (!v.intended_purpose?.trim()) return "Intended purpose is required when success criteria are defined.";
+  const incompleteMetric = (v.success_metrics ?? []).findIndex(
+    (metric) => !metric.name.trim() || !metric.target.trim() || !metric.measurement.trim(),
+  );
+  return incompleteMetric === -1
+    ? null
+    : `Complete all fields for metric ${incompleteMetric + 1}.`;
+}
+
+export function normalizeSuccessCriteria(v: SuccessCriteria | null): SuccessCriteria | null {
+  if (!v || !hasSuccessCriteriaContent(v)) return null;
+  return {
+    intended_purpose: v.intended_purpose?.trim() ?? "",
+    success_metrics: (v.success_metrics ?? []).map((metric) => ({
+      name: metric.name.trim(),
+      target: metric.target.trim(),
+      measurement: metric.measurement.trim(),
+    })),
+    evaluation_notes: v.evaluation_notes?.trim() ?? "",
+  };
+}
+
 export function SuccessCriteriaSection({ value, onChange }: SuccessCriteriaSectionProps) {
-  const [expanded, setExpanded] = useState(hasContent(value));
-  const defined = hasContent(value);
+  const [expanded, setExpanded] = useState(hasSuccessCriteriaContent(value));
+  const defined = hasSuccessCriteriaContent(value);
+  const validationError = validateSuccessCriteria(value);
 
   function handleToggle() {
     if (expanded) {
@@ -123,18 +148,21 @@ export function SuccessCriteriaSection({ value, onChange }: SuccessCriteriaSecti
               <div key={index} className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_1fr_auto] gap-2 items-start">
                 <Input
                   placeholder="Metric name"
+                  aria-label={`Metric ${index + 1} name`}
                   value={metric.name}
                   onChange={(e) => updateMetric(index, "name", e.target.value)}
                   className="text-sm"
                 />
                 <Input
                   placeholder="Target (e.g. < 5%)"
+                  aria-label={`Metric ${index + 1} target`}
                   value={metric.target}
                   onChange={(e) => updateMetric(index, "target", e.target.value)}
                   className="text-sm"
                 />
                 <Input
                   placeholder="How to measure"
+                  aria-label={`Metric ${index + 1} measurement method`}
                   value={metric.measurement}
                   onChange={(e) => updateMetric(index, "measurement", e.target.value)}
                   className="text-sm"
@@ -143,6 +171,7 @@ export function SuccessCriteriaSection({ value, onChange }: SuccessCriteriaSecti
                   type="button"
                   variant="ghost"
                   size="icon"
+                  aria-label={`Remove metric ${index + 1}`}
                   onClick={() => removeMetric(index)}
                   className="h-9 w-9 text-muted-foreground hover:text-destructive"
                 >
@@ -150,6 +179,11 @@ export function SuccessCriteriaSection({ value, onChange }: SuccessCriteriaSecti
                 </Button>
               </div>
             ))}
+            {validationError && (
+              <p role="alert" className="text-xs text-destructive">
+                {validationError}
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/web/src/components/registry/agent-edit-form.tsx
+++ b/web/src/components/registry/agent-edit-form.tsx
@@ -44,11 +44,13 @@ import {
 import type {
   AgentVersionDetail,
   RegistryItem,
+  SuccessCriteria,
   ValidationResult,
 } from "@/lib/types";
 import type { RegistryType } from "@/lib/api";
 import { ModelPicker } from "@/components/builder/model-picker";
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
+import { SuccessCriteriaSection } from "@/components/builder/success-criteria-section";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { COMPONENT_TYPES, REVERSE_TYPE_MAP, TYPE_MAP } from "@/components/registry/agent-component-constants";
 import { ComponentPicker } from "@/components/registry/component-picker";
@@ -118,6 +120,9 @@ export function AgentEditForm({
     Record<string, RegistryItem[]>
   >({ mcps: [], skills: [], hooks: [], prompts: [], sandboxes: [] });
   const [prompt, setPrompt] = useState<string>(initialPrompt);
+  const [successCriteria, setSuccessCriteria] = useState<SuccessCriteria | null>(
+    vd?.success_criteria ?? null
+  );
 
   // ── Dialog / loading state ────────────────────────────────────
   const [showVersionDialog, setShowVersionDialog] = useState(false);
@@ -132,6 +137,7 @@ export function AgentEditForm({
     modelsByHarness: initialModelsByIde,
     prompt: initialPrompt,
     selectedComponents: {} as Record<string, RegistryItem[]>,
+    successCriteria: (vd?.success_criteria ?? null) as SuccessCriteria | null,
   });
   const [isDirty, setIsDirty] = useState(false);
 
@@ -156,6 +162,7 @@ export function AgentEditForm({
         versionDetail?.models_by_harness,
         versionDetail?.prompt,
         versionDetail?.components,
+        versionDetail?.success_criteria,
       ]),
     [agent.name, currentVersion, versionDetail],
   );
@@ -192,6 +199,7 @@ export function AgentEditForm({
     // Load goal template sections
 
     setPrompt(initialPrompt);
+    setSuccessCriteria(vd?.success_criteria ?? null);
 
     // Sync initial state ref so dirty detection works correctly after re-init
     initialStateRef.current = {
@@ -200,6 +208,7 @@ export function AgentEditForm({
       modelsByHarness: initialModelsByIde,
       prompt: initialPrompt,
       selectedComponents: grouped,
+      successCriteria: vd?.success_criteria ?? null,
     };
     setIsDirty(false);
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -208,14 +217,17 @@ export function AgentEditForm({
   // ── Dirty detection ───────────────────────────────────────────
   useEffect(() => {
     const init = initialStateRef.current;
+    const normalizeCriteria = (c: SuccessCriteria | null) =>
+      c?.intended_purpose?.trim() ? c : null;
     const dirty =
       description !== init.description ||
       modelName !== init.modelName ||
       JSON.stringify(modelsByHarness) !== JSON.stringify(init.modelsByHarness) ||
       prompt !== init.prompt ||
-      JSON.stringify(selectedComponents) !== JSON.stringify(init.selectedComponents);
+      JSON.stringify(selectedComponents) !== JSON.stringify(init.selectedComponents) ||
+      JSON.stringify(normalizeCriteria(successCriteria)) !== JSON.stringify(normalizeCriteria(init.successCriteria));
     setIsDirty(dirty);
-  }, [description, modelName, modelsByHarness, prompt, selectedComponents]);
+  }, [description, modelName, modelsByHarness, prompt, selectedComponents, successCriteria]);
 
   // ── Debounced validation ──────────────────────────────────────
   useEffect(() => {
@@ -315,6 +327,15 @@ export function AgentEditForm({
       }
     }
 
+    const normalizedCriteria = successCriteria?.intended_purpose?.trim()
+      ? {
+          ...successCriteria,
+          success_metrics: successCriteria.success_metrics.filter(
+            (m) => m.name.trim() && m.target.trim() && m.measurement.trim(),
+          ),
+        }
+      : null;
+
     return {
       version,
       description: description.trim(),
@@ -327,6 +348,7 @@ export function AgentEditForm({
       components: components.length > 0 ? components : [],
       yaml_snapshot: null,
       is_prerelease: false,
+      success_criteria: normalizedCriteria,
     };
   }
 
@@ -343,6 +365,7 @@ export function AgentEditForm({
         modelsByHarness,
         prompt,
         selectedComponents,
+        successCriteria,
       };
       setIsDirty(false);
       onSuccess?.();
@@ -365,6 +388,7 @@ export function AgentEditForm({
         modelsByHarness,
         prompt,
         selectedComponents,
+        successCriteria,
       };
       setIsDirty(false);
       onSuccess?.();
@@ -387,6 +411,7 @@ export function AgentEditForm({
     setModelName(init.modelName);
     setModelsByIde(init.modelsByHarness);
     setPrompt(init.prompt ?? "");
+    setSuccessCriteria(init.successCriteria ?? null);
     setSelectedComponents(
       Object.keys(init.selectedComponents).length > 0
         ? init.selectedComponents
@@ -456,6 +481,12 @@ export function AgentEditForm({
         />
         <p className="text-xs text-muted-foreground">Required. Or link a Prompt component in the Components section below.</p>
       </section>
+
+      {/* Success Criteria */}
+      <SuccessCriteriaSection
+        value={successCriteria}
+        onChange={setSuccessCriteria}
+      />
 
       <Separator />
 

--- a/web/src/components/registry/agent-edit-form.tsx
+++ b/web/src/components/registry/agent-edit-form.tsx
@@ -16,6 +16,7 @@ import {
   Save,
   RotateCcw,
 } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -50,7 +51,11 @@ import type {
 import type { RegistryType } from "@/lib/api";
 import { ModelPicker } from "@/components/builder/model-picker";
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
-import { SuccessCriteriaSection } from "@/components/builder/success-criteria-section";
+import {
+  normalizeSuccessCriteria,
+  SuccessCriteriaSection,
+  validateSuccessCriteria,
+} from "@/components/builder/success-criteria-section";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { COMPONENT_TYPES, REVERSE_TYPE_MAP, TYPE_MAP } from "@/components/registry/agent-component-constants";
 import { ComponentPicker } from "@/components/registry/component-picker";
@@ -327,14 +332,7 @@ export function AgentEditForm({
       }
     }
 
-    const normalizedCriteria = successCriteria?.intended_purpose?.trim()
-      ? {
-          ...successCriteria,
-          success_metrics: successCriteria.success_metrics.filter(
-            (m) => m.name.trim() && m.target.trim() && m.measurement.trim(),
-          ),
-        }
-      : null;
+    const normalizedCriteria = normalizeSuccessCriteria(successCriteria);
 
     return {
       version,
@@ -353,6 +351,11 @@ export function AgentEditForm({
   }
 
   async function handleRelease(selectedVersion: string) {
+    const criteriaError = validateSuccessCriteria(successCriteria);
+    if (criteriaError) {
+      toast.error(criteriaError);
+      return;
+    }
     setPublishing(true);
     try {
       const body = buildVersionBody(selectedVersion);
@@ -377,6 +380,11 @@ export function AgentEditForm({
   }
 
   async function handleSaveDraft() {
+    const criteriaError = validateSuccessCriteria(successCriteria);
+    if (criteriaError) {
+      toast.error(criteriaError);
+      return;
+    }
     setSavingDraft(true);
     try {
       const draftVersion = versionSuggestions?.suggestions?.patch ?? currentVersion;

--- a/web/src/components/review/review-detail-sheet.tsx
+++ b/web/src/components/review/review-detail-sheet.tsx
@@ -184,6 +184,47 @@ function AgentConfigSection({ detail }: { detail: ReviewItem }) {
 				value={detail.required_capabilities}
 			/>
 			<DetailField label="Model Config" value={detail.model_config_json} />
+			{detail.prompt && (
+				<div className="col-span-full">
+					<dt className="text-xs font-medium text-muted-foreground">Prompt</dt>
+					<dd className="mt-0.5">
+						<pre className="max-h-60 overflow-auto rounded bg-muted p-2 text-[11px] font-mono leading-relaxed break-words whitespace-pre-wrap">
+							{detail.prompt}
+						</pre>
+					</dd>
+				</div>
+			)}
+			{detail.success_criteria && detail.success_criteria.intended_purpose && (
+				<div className="col-span-full">
+					<dt className="text-xs font-medium text-muted-foreground">Success Criteria</dt>
+					<dd className="mt-0.5 space-y-2 text-sm">
+						<div>
+							<span className="text-[10px] font-medium text-muted-foreground uppercase">Purpose</span>
+							<p className="text-xs whitespace-pre-wrap">{detail.success_criteria.intended_purpose}</p>
+						</div>
+						{(detail.success_criteria.success_metrics?.length ?? 0) > 0 && (
+							<div>
+								<span className="text-[10px] font-medium text-muted-foreground uppercase">Metrics</span>
+								<div className="mt-1 space-y-1">
+									{detail.success_criteria.success_metrics.map((m, i) => (
+										<div key={i} className="flex flex-wrap gap-x-2 text-xs rounded bg-muted/50 px-2 py-1">
+											<span className="font-medium">{m.name}</span>
+											<span className="text-muted-foreground">target: <span className="font-mono">{m.target}</span></span>
+											<span className="text-muted-foreground">via: {m.measurement}</span>
+										</div>
+									))}
+								</div>
+							</div>
+						)}
+						{detail.success_criteria.evaluation_notes && (
+							<div>
+								<span className="text-[10px] font-medium text-muted-foreground uppercase">Evaluation Notes</span>
+								<p className="text-xs whitespace-pre-wrap">{detail.success_criteria.evaluation_notes}</p>
+							</div>
+						)}
+					</dd>
+				</div>
+			)}
 			{detail.components && detail.components.length > 0 && (
 				<div className="col-span-full">
 					<dt className="text-xs font-medium text-muted-foreground mb-1">
@@ -221,16 +262,6 @@ function AgentConfigSection({ detail }: { detail: ReviewItem }) {
 								</div>
 							);
 						})}
-					</dd>
-				</div>
-			)}
-			{detail.prompt && (
-				<div className="col-span-full">
-					<dt className="text-xs font-medium text-muted-foreground">Prompt</dt>
-					<dd className="mt-0.5">
-						<pre className="max-h-60 overflow-auto rounded bg-muted p-2 text-[11px] font-mono leading-relaxed break-words">
-							{detail.prompt}
-						</pre>
 					</dd>
 				</div>
 			)}

--- a/web/src/components/review/review-diff-sheet.tsx
+++ b/web/src/components/review/review-diff-sheet.tsx
@@ -279,6 +279,8 @@ function buildCleanYaml(
 	if (byHarness && Object.keys(byHarness).length) obj.models_by_harness = byHarness;
 	const harnesses = detail.supported_harnesses as string[] | undefined;
 	if (harnesses?.length) obj.supported_harnesses = harnesses;
+	const sc = detail.success_criteria as Record<string, unknown> | null | undefined;
+	if (sc && sc.intended_purpose) obj.success_criteria = sc;
 	if (comps.length) {
 		obj.components = comps.map((c) => {
 			const cached = componentDataMap?.get(String(c.component_id ?? "")) as
@@ -607,6 +609,7 @@ function DiffDialogBody({
 	);
 	const supportedIdes =
 		(detail?.supported_harnesses as string[]) || item.supported_harnesses || [];
+	const successCriteria = detail?.success_criteria as { intended_purpose?: string; success_metrics?: { name: string; target: string; measurement: string }[]; evaluation_notes?: string } | null | undefined;
 	const components =
 		(detail?.components as {
 			component_type: string;
@@ -826,6 +829,44 @@ function DiffDialogBody({
 									<pre className="text-xs font-[family-name:var(--font-mono)] whitespace-pre-wrap break-words bg-muted/40 rounded p-3 leading-relaxed max-h-64 overflow-y-auto">
 										{prompt}
 									</pre>
+								</div>
+							</>
+						)}
+
+						{/* Success Criteria */}
+						{isAgent && successCriteria?.intended_purpose && (
+							<>
+								<Separator />
+								<div className="space-y-2">
+									<h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+										Success Criteria
+									</h4>
+									<div className="space-y-2 text-xs">
+										<div>
+											<span className="text-[10px] font-medium text-muted-foreground uppercase">Purpose</span>
+											<p className="whitespace-pre-wrap">{successCriteria.intended_purpose}</p>
+										</div>
+										{(successCriteria.success_metrics?.length ?? 0) > 0 && (
+											<div>
+												<span className="text-[10px] font-medium text-muted-foreground uppercase">Metrics</span>
+												<div className="mt-1 space-y-1">
+													{successCriteria.success_metrics!.map((m, i) => (
+														<div key={i} className="flex flex-wrap gap-x-2 rounded bg-muted/50 px-2 py-1">
+															<span className="font-medium">{m.name}</span>
+															<span className="text-muted-foreground">target: <span className="font-mono">{m.target}</span></span>
+															<span className="text-muted-foreground">via: {m.measurement}</span>
+														</div>
+													))}
+												</div>
+											</div>
+										)}
+										{successCriteria.evaluation_notes && (
+											<div>
+												<span className="text-[10px] font-medium text-muted-foreground uppercase">Evaluation Notes</span>
+												<p className="whitespace-pre-wrap">{successCriteria.evaluation_notes}</p>
+											</div>
+										)}
+									</div>
 								</div>
 							</>
 						)}

--- a/web/src/components/review/review-diff-sheet.tsx
+++ b/web/src/components/review/review-diff-sheet.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/hooks/use-api";
 import { registry } from "@/lib/api";
 import type { RegistryType } from "@/lib/api";
-import type { ReviewItem, ComponentChange } from "@/lib/types";
+import type { ComponentChange, ReviewItem, SuccessCriteria } from "@/lib/types";
 
 function pluralizeType(type: string): string {
 	if (type === "agent") return "agents";
@@ -609,7 +609,7 @@ function DiffDialogBody({
 	);
 	const supportedIdes =
 		(detail?.supported_harnesses as string[]) || item.supported_harnesses || [];
-	const successCriteria = detail?.success_criteria as { intended_purpose?: string; success_metrics?: { name: string; target: string; measurement: string }[]; evaluation_notes?: string } | null | undefined;
+	const successCriteria = detail?.success_criteria as SuccessCriteria | null | undefined;
 	const components =
 		(detail?.components as {
 			component_type: string;

--- a/web/src/lib/types/registry.ts
+++ b/web/src/lib/types/registry.ts
@@ -100,6 +100,18 @@ export interface AgentComponentReference {
 	status?: string;
 }
 
+export interface SuccessMetric {
+	name: string;
+	target: string;
+	measurement: string;
+}
+
+export interface SuccessCriteria {
+	intended_purpose: string;
+	success_metrics: SuccessMetric[];
+	evaluation_notes: string;
+}
+
 export interface AgentVersionDetail extends AgentVersionSummary {
 	prompt: string;
 	model_name: string;
@@ -111,6 +123,7 @@ export interface AgentVersionDetail extends AgentVersionSummary {
 	required_capabilities?: string[];
 	inferred_supported_harnesses?: string[];
 	components: AgentComponentReference[];
+	success_criteria?: SuccessCriteria | null;
 }
 
 // ── Component Versions ─────────────────────────────────────────────
@@ -333,6 +346,7 @@ export interface ReviewItem {
 	required_capabilities?: string[];
 	component_count?: number;
 	components?: { component_type: string; component_id: string }[];
+	success_criteria?: SuccessCriteria | null;
 }
 
 // ── Scores ──────────────────────────────────────────────────────────

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -44,7 +44,12 @@ import type { ValidationResult } from "@/lib/types";
 const DRAFT_STORAGE_KEY = "observal_agent_draft";
 
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
-import { SuccessCriteriaSection } from "@/components/builder/success-criteria-section";
+import {
+  hasSuccessCriteriaContent,
+  normalizeSuccessCriteria,
+  SuccessCriteriaSection,
+  validateSuccessCriteria,
+} from "@/components/builder/success-criteria-section";
 import { SubmitComponentDialog } from "@/components/registry/submit-component-dialog";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { PreviewPanel } from "@/components/builder/preview-panel";
@@ -305,7 +310,8 @@ function AgentBuilderInner() {
       const hasContent = name || description || modelName || version !== "1.0.0" ||
         Object.keys(modelsByHarness).length > 0 ||
         Object.values(selectedComponents).some((items) => items.length > 0) ||
-        systemPrompt.trim().length > 0;
+        systemPrompt.trim().length > 0 ||
+        hasSuccessCriteriaContent(successCriteria);
 
       if (!hasContent) return;
 
@@ -393,6 +399,11 @@ function AgentBuilderInner() {
       toast.error("An agent prompt is required.");
       return;
     }
+    const criteriaError = validateSuccessCriteria(successCriteria);
+    if (criteriaError) {
+      toast.error(criteriaError);
+      return;
+    }
 
     setSavingDraft(true);
     try {
@@ -468,14 +479,7 @@ function AgentBuilderInner() {
       }
     }
 
-    const normalizedCriteria = successCriteria?.intended_purpose?.trim()
-      ? {
-          ...successCriteria,
-          success_metrics: successCriteria.success_metrics.filter(
-            (m) => m.name.trim() && m.target.trim() && m.measurement.trim(),
-          ),
-        }
-      : null;
+    const normalizedCriteria = normalizeSuccessCriteria(successCriteria);
 
     const body: Record<string, unknown> = {
       name: normalizeAgentName(name),
@@ -509,6 +513,11 @@ function AgentBuilderInner() {
     }
     if (!isValidAgentName(name)) {
       toast.error(`Invalid agent name. ${AGENT_NAME_ERROR}`);
+      return;
+    }
+    const criteriaError = validateSuccessCriteria(successCriteria);
+    if (criteriaError) {
+      toast.error(criteriaError);
       return;
     }
 
@@ -564,6 +573,11 @@ function AgentBuilderInner() {
 
   async function handleUpdateWithVersion(selectedVersion: string) {
     if (!editId) return;
+    const criteriaError = validateSuccessCriteria(successCriteria);
+    if (criteriaError) {
+      toast.error(criteriaError);
+      return;
+    }
 
     setPublishing(true);
     try {

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -38,12 +38,13 @@ import { useRegistryItem, useAgentValidation, useTeams, useWhoami, useSaveDraft,
 import { useAuthGuard } from "@/hooks/use-auth";
 import { registry, type RegistryType } from "@/lib/api";
 import { isValidAgentName, normalizeAgentName, slugifyRegistryText } from "@/lib/registry-name";
-import type { RegistryItem } from "@/lib/types";
+import type { RegistryItem, SuccessCriteria } from "@/lib/types";
 import type { ValidationResult } from "@/lib/types";
 
 const DRAFT_STORAGE_KEY = "observal_agent_draft";
 
 import { SortableComponentList } from "@/components/builder/sortable-component-list";
+import { SuccessCriteriaSection } from "@/components/builder/success-criteria-section";
 import { SubmitComponentDialog } from "@/components/registry/submit-component-dialog";
 import { ValidationPanel } from "@/components/builder/validation-panel";
 import { PreviewPanel } from "@/components/builder/preview-panel";
@@ -134,6 +135,7 @@ function AgentBuilderInner() {
   });
 
   const [systemPrompt, setSystemPrompt] = useState<string>("");
+  const [successCriteria, setSuccessCriteria] = useState<SuccessCriteria | null>(null);
 
   // Goal template sections
 
@@ -190,6 +192,11 @@ function AgentBuilderInner() {
 
     const promptField = (existingAgent as Record<string, unknown>).prompt;
     if (typeof promptField === "string") setSystemPrompt(promptField);
+
+    const agentCriteria = (existingAgent as Record<string, unknown>).success_criteria;
+    if (agentCriteria && typeof agentCriteria === "object" && !Array.isArray(agentCriteria)) {
+      setSuccessCriteria(agentCriteria as SuccessCriteria);
+    }
   }, [existingAgent, draftParam]);
 
   // Edit lock for pending agents, acquire on mount, release on unmount
@@ -311,6 +318,7 @@ function AgentBuilderInner() {
           models_by_harness: modelsByHarness,
           components: selectedComponents,
           prompt: systemPrompt,
+          success_criteria: successCriteria,
           draft_id: draftId,
           // The publication target belongs with the draft. Without it a restored
           // team-private draft silently reverts to a personal public agent, which
@@ -328,7 +336,7 @@ function AgentBuilderInner() {
     return () => {
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     };
-  }, [name, description, version, modelName, modelsByHarness, selectedComponents, systemPrompt, draftId, teamId, visibility, isEditMode]);
+  }, [name, description, version, modelName, modelsByHarness, selectedComponents, systemPrompt, successCriteria, draftId, teamId, visibility, isEditMode]);
 
   function restoreLocalDraft() {
     try {
@@ -344,6 +352,9 @@ function AgentBuilderInner() {
       }
       if (draft.components) setSelectedComponents(draft.components);
       if (typeof draft.prompt === "string") setSystemPrompt(draft.prompt);
+      if (draft.success_criteria && typeof draft.success_criteria === "object") {
+        setSuccessCriteria(draft.success_criteria as SuccessCriteria);
+      }
       if (draft.draft_id) setDraftId(draft.draft_id);
       // Restore the publication target too. A draft saved for a teamspace must
       // not come back as a personal public agent.
@@ -457,6 +468,14 @@ function AgentBuilderInner() {
       }
     }
 
+    const normalizedCriteria = successCriteria?.intended_purpose?.trim()
+      ? {
+          ...successCriteria,
+          success_metrics: successCriteria.success_metrics.filter(
+            (m) => m.name.trim() && m.target.trim() && m.measurement.trim(),
+          ),
+        }
+      : null;
 
     const body: Record<string, unknown> = {
       name: normalizeAgentName(name),
@@ -469,6 +488,7 @@ function AgentBuilderInner() {
       models_by_harness: modelsByHarness,
       components: components.length > 0 ? components : [],
       visibility,
+      success_criteria: normalizedCriteria,
     };
     if (teamId) body.team_id = teamId;
     return body;
@@ -741,6 +761,12 @@ function AgentBuilderInner() {
                 )}
               </div>
             </section>
+
+            {/* Success Criteria */}
+            <SuccessCriteriaSection
+              value={successCriteria}
+              onChange={setSuccessCriteria}
+            />
 
             <Separator />
 

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -53,6 +53,7 @@ import type {
   AgentVersionSummary,
   FeedbackItem,
   InsightReportListItem,
+  SuccessCriteria,
 } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
 import { RegistryName } from "@/components/registry/registry-name";
@@ -240,15 +241,48 @@ function ArchivedComponentsBanner({ components }: { components: ComponentLink[] 
   );
 }
 
+function PromptSection({ prompt }: { prompt: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const lineCount = prompt.split("\n").length;
+  const isLong = lineCount > 12;
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold font-display">Agent Prompt</h3>
+      <div className="relative">
+        <pre
+          className={`select-text rounded-md border border-border bg-surface-sunken px-3 py-2 text-sm font-mono whitespace-pre-wrap break-words leading-relaxed text-foreground ${isLong && !expanded ? "max-h-[280px] overflow-hidden" : ""}`}
+        >
+          {prompt}
+        </pre>
+        {isLong && !expanded && (
+          <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-surface-sunken to-transparent rounded-b-md flex items-end justify-center pb-2">
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="text-xs font-medium text-primary hover:text-primary/80 bg-background/80 backdrop-blur-sm rounded px-2 py-1 border border-border/50"
+            >
+              Show full prompt
+            </button>
+          </div>
+        )}
+        {isLong && expanded && (
+          <button
+            type="button"
+            onClick={() => setExpanded(false)}
+            className="mt-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+          >
+            Collapse
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function AgentVersionContents({
-  description,
-  modelName,
-  prompt,
   components,
 }: {
-  description?: string;
-  modelName?: string;
-  prompt?: string;
   components: ComponentLink[];
 }) {
   const [activeTab, setActiveTab] = useState<ComponentGroupKey>("mcps");
@@ -256,46 +290,6 @@ function AgentVersionContents({
 
   return (
     <div className="space-y-6">
-      <section className="space-y-4">
-        <div className="space-y-2">
-          <h3 className="text-sm font-medium">Description</h3>
-          <div className="min-h-20 max-w-lg select-text rounded-md border border-border bg-surface-sunken px-3 py-2 text-sm leading-relaxed text-foreground cursor-default">
-            {description ? (
-              <p className="whitespace-pre-wrap">{description}</p>
-            ) : (
-              <p className="text-muted-foreground">No description provided.</p>
-            )}
-          </div>
-        </div>
-
-        <div className="space-y-2 max-w-xs">
-          <h3 className="text-sm font-medium">Model</h3>
-          <div className="select-text rounded-md border border-border bg-surface-sunken px-3 py-2 text-sm cursor-default">
-            {modelName ? (
-              <code className="font-mono text-foreground">{modelName}</code>
-            ) : (
-              <span className="text-muted-foreground">No model specified.</span>
-            )}
-          </div>
-        </div>
-      </section>
-
-      <section className="space-y-2">
-        <h3 className="text-sm font-medium">Agent Prompt</h3>
-        <div className="min-h-40 select-text rounded-md border border-border bg-surface-sunken px-3 py-2 text-sm cursor-default">
-          {prompt ? (
-            <pre className="whitespace-pre-wrap break-words font-mono leading-relaxed text-foreground">{prompt}</pre>
-          ) : (
-            <p className="text-muted-foreground">No inline prompt provided.</p>
-          )}
-        </div>
-        <p className="text-xs text-muted-foreground">
-          Version-specific system prompt. Prompt components, when linked, are listed below.
-        </p>
-      </section>
-
-      <Separator />
-
       <section className="space-y-4">
         <div>
           <h3 className="text-sm font-medium font-display">Components</h3>
@@ -650,6 +644,8 @@ export default function AgentDetailPage() {
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const [confirmPublicOpen, setConfirmPublicOpen] = useState(false);
   const { data: versionDetail, isLoading: isVersionDetailLoading } = useAgentVersionDetail(id, selectedVersion);
+  const effectiveVersionForDetail = selectedVersion ?? versionsData?.items?.find(v => v.status === "approved")?.version ?? (agent as unknown as AgentDetail | undefined)?.version ?? null;
+  const { data: effectiveVersionDetail } = useAgentVersionDetail(id, effectiveVersionForDetail);
 
   // Co-authors
   const [coAuthors, setCoAuthors] = useState<CoAuthor[]>([]);
@@ -683,8 +679,8 @@ export default function AgentDetailPage() {
   const latestApprovedVersion = useMemo(() => getLatestApprovedVersion(versions), [versions]);
   const effectiveVersion = selectedVersion ?? latestApprovedVersion ?? a?.version;
   const selectedVersionSummary = versions.find((v) => v.version === effectiveVersion);
-  const vd = versionDetail;
-  const isVersionContentLoading = !!selectedVersion && !vd && isVersionDetailLoading;
+  const vd = versionDetail ?? effectiveVersionDetail;
+  const isVersionContentLoading = !!selectedVersion && !versionDetail && isVersionDetailLoading;
   const baseComponents: ComponentLink[] = a?.component_links ?? a?.mcp_links ?? [];
   const versionComponents = selectedVersion ? normalizeVersionComponents(vd?.components) : undefined;
   const components: ComponentLink[] = selectedVersion ? (versionComponents ?? []) : baseComponents;
@@ -697,6 +693,7 @@ export default function AgentDetailPage() {
   const versionSupportedIdes = vd?.supported_harnesses ?? selectedVersionSummary?.supported_harnesses ?? a?.supported_harnesses;
   const versionRequiredFeatures = vd?.required_capabilities ?? (selectedVersion ? undefined : a?.required_capabilities);
   const versionInferredIdes = vd?.inferred_supported_harnesses ?? (selectedVersion ? undefined : a?.inferred_supported_harnesses);
+  const versionSuccessCriteria = (vd?.success_criteria ?? (selectedVersion ? undefined : a?.success_criteria)) as SuccessCriteria | null | undefined;
   const isOwner = !!(whoami?.id && a?.created_by && whoami.id === String(a.created_by));
   const canTransferOwnership = isOwner;
   const teamRole = a?.team_id ? teams.find((team) => team.id === String(a.team_id))?.role : undefined;
@@ -900,6 +897,44 @@ export default function AgentDetailPage() {
                     </div>
                   )}
 
+                  {versionPrompt && (
+                    <PromptSection prompt={versionPrompt} />
+                  )}
+
+                  {versionSuccessCriteria && versionSuccessCriteria.intended_purpose && (
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-semibold font-display">
+                        Success Criteria
+                      </h3>
+                      <div className="space-y-3 rounded-md border border-border bg-surface-sunken px-4 py-3 text-sm">
+                        <div>
+                          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">Purpose</p>
+                          <p className="text-foreground whitespace-pre-wrap">{versionSuccessCriteria.intended_purpose}</p>
+                        </div>
+                        {(versionSuccessCriteria.success_metrics?.length ?? 0) > 0 && (
+                          <div>
+                            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Metrics</p>
+                            <div className="space-y-2">
+                              {versionSuccessCriteria.success_metrics.map((m, i) => (
+                                <div key={i} className="flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded border border-border/50 bg-background/50 px-3 py-2">
+                                  <span className="font-medium text-foreground">{m.name}</span>
+                                  <span className="text-xs text-muted-foreground">target: <span className="text-foreground font-mono">{m.target}</span></span>
+                                  <span className="text-xs text-muted-foreground">via: <span className="text-foreground">{m.measurement}</span></span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {versionSuccessCriteria.evaluation_notes && (
+                          <div>
+                            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">Evaluation Notes</p>
+                            <p className="text-foreground whitespace-pre-wrap">{versionSuccessCriteria.evaluation_notes}</p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
                   {versionModelName && (
                     <div className="space-y-1">
                       <h3 className="text-sm font-semibold font-display">
@@ -911,8 +946,7 @@ export default function AgentDetailPage() {
                     </div>
                   )}
 
-
-                  {!versionDescription && (
+                  {!versionDescription && !versionPrompt && !versionSuccessCriteria?.intended_purpose && (
                     <p className="text-sm text-muted-foreground">
                       No additional details provided for this agent.
                     </p>
@@ -925,9 +959,6 @@ export default function AgentDetailPage() {
                       <VersionContentLoading />
                     ) : (
                       <AgentVersionContents
-                        description={versionDescription}
-                        modelName={versionModelName}
-                        prompt={versionPrompt}
                         components={components}
                       />
                     )}

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -641,10 +641,12 @@ export default function AgentDetailPage() {
   const { data: teams = [] } = useTeams();
   const updateVisibility = useUpdateRegistryVisibility();
   const { data: versionsData } = useAgentVersions(id);
+  const versions = versionsData?.items ?? [];
+  const latestApprovedVersion = useMemo(() => getLatestApprovedVersion(versions), [versions]);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const [confirmPublicOpen, setConfirmPublicOpen] = useState(false);
   const { data: versionDetail, isLoading: isVersionDetailLoading } = useAgentVersionDetail(id, selectedVersion);
-  const effectiveVersionForDetail = selectedVersion ?? versionsData?.items?.find(v => v.status === "approved")?.version ?? (agent as unknown as AgentDetail | undefined)?.version ?? null;
+  const effectiveVersionForDetail = selectedVersion ?? latestApprovedVersion ?? (agent as unknown as AgentDetail | undefined)?.version ?? null;
   const { data: effectiveVersionDetail } = useAgentVersionDetail(id, effectiveVersionForDetail);
 
   // Co-authors
@@ -675,8 +677,6 @@ export default function AgentDetailPage() {
   );
 
   const a = agent as unknown as AgentDetail | undefined;
-  const versions = versionsData?.items ?? [];
-  const latestApprovedVersion = useMemo(() => getLatestApprovedVersion(versions), [versions]);
   const effectiveVersion = selectedVersion ?? latestApprovedVersion ?? a?.version;
   const selectedVersionSummary = versions.find((v) => v.version === effectiveVersion);
   const vd = versionDetail ?? effectiveVersionDetail;


### PR DESCRIPTION
## Purpose / Description

When creating or publishing an agent today, there's no structured way to define what success looks like. This PR adds optional **success criteria** fields — intended purpose, measurable metrics, and evaluation notes — so teams can establish baselines for agent effectiveness right at creation time.

## Fixes

* Fixes #1593

## Approach

**Backend:**
- New `success_criteria` JSON column on `agent_versions` table (migration 017)
- `SuccessCriteria` / `SuccessMetric` Pydantic models with validation (max lengths, max 10 metrics)
- Wired through all CRUD, draft, version create, and review endpoints
- Included in YAML snapshot for reviewer diffs
- `Agent.success_criteria` property delegates to `latest_version`

**Frontend:**
- Reusable collapsible `SuccessCriteriaSection` form component
- Integrated in both the create (builder) and edit flows
- Displayed on agent detail Overview tab, admin review sheet, and review diff pane
- Dirty tracking with normalization (incomplete metrics stripped on submit)
- Local draft auto-save and restore support

**CLI:**
- `agent publish` and `agent release` pass `success_criteria` from `observal-agent.yaml`
- `agent show` displays criteria with Rich formatting
- `agent init` scaffolds the field as `null`

All fields are optional — existing agents and YAML files work unchanged.

Builder page : 
<img width="1117" height="446" alt="builder" src="https://github.com/user-attachments/assets/961c7846-ffe3-4d36-9758-617360a6b64c" />

Review page :
<img width="1062" height="857" alt="review" src="https://github.com/user-attachments/assets/ee677242-223e-4ef9-a056-e46de19c05e6" />


Overview page :
<img width="1693" height="692" alt="overview" src="https://github.com/user-attachments/assets/652345b7-aafd-48d7-af79-0e42be9f2f36" />


## How Has This Been Tested?

- Created agents with and without success criteria via web UI
- Edited existing agents to add/modify/view criteria
- Verified admin review sheet and diff pane show criteria correctly
- Tested CLI publish, release, and show commands with mock API responses
- Confirmed version switching on detail page loads correct per-version criteria
- Verified empty/null criteria doesn't render broken UI

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes (Claude Code): Used for implementation, code review, and adversarial testing
- [x] Was the generated code manually reviewed and tested?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional success criteria for agents, including intended purpose, evaluation notes, and up to 10 measurable success metrics.
  * Added success-criteria editing to the agent builder, with draft saving and publishing support.
  * Displayed success criteria on agent details, reviews, YAML snapshots, and CLI output.
* **Validation**
  * Added validation and cleanup for incomplete or blank criteria before saving.
* **Bug Fixes**
  * Improved version detail selection when no specific version is chosen.
  * Preserved prompt formatting and added expandable prompt viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->