### PR TITLE
Feat/registry namespace display

### DIFF
--- a/observal-server/api/routes/auth.py
+++ b/observal-server/api/routes/auth.py
@@ -52,7 +52,7 @@ from schemas.sso_health import make_check
 from services import sso_diagnostics
 from services.jwt_service import create_access_token, create_refresh_token, decode_access_token, decode_refresh_token
 from services.redis import get_redis
-from services.registry_namespace import user_has_listings
+from services.registry_namespace import is_valid_namespace, rename_namespace, user_has_listings
 from services.security_events import (
     EventType,
     SecurityEvent,
@@ -1807,10 +1807,18 @@ async def set_username(
     existing = await db.execute(select(User).where(User.username == req.username, User.id != current_user.id))
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="Username already taken")
-    if await user_has_listings(db, current_user.id):
+
+    # A username that isn't a valid namespace (dots, uppercase, … kept verbatim by
+    # migration 016) can never publish, so the publish lock would trap the user
+    # for good. Let them out, and carry any pre-validation listings across so the
+    # old namespace is not left orphaned.
+    stuck_namespace = None if is_valid_namespace(current_user.username) else current_user.username
+    if stuck_namespace is None and await user_has_listings(db, current_user.id):
         raise HTTPException(status_code=409, detail="Username cannot change after publishing a registry item")
 
     current_user.username = req.username
+    if stuck_namespace is not None:
+        await rename_namespace(db, stuck_namespace, req.username)
     try:
         await db.commit()
     except IntegrityError:

--- a/observal-server/services/harness/helpers.py
+++ b/observal-server/services/harness/helpers.py
@@ -264,11 +264,25 @@ def _local_registry_names(listings: dict) -> dict:
     """Use bare slugs unless this install contains the same slug from multiple namespaces."""
     slugs = Counter(registry_item_slug(listing) for listing in listings.values())
     duplicates = {slug for slug, count in slugs.items() if count > 1}
-    names = {}
+    names: dict = {}
+    used: set[str] = set()
     for listing_id, listing in listings.items():
         slug = registry_item_slug(listing)
         namespace = getattr(listing, "namespace", "")
-        names[listing_id] = f"{namespace}-{slug}" if slug in duplicates and isinstance(namespace, str) else slug
+        if slug in duplicates and isinstance(namespace, str):
+            # Local names become harness config keys and on-disk names, where a dot
+            # reads as a file extension, so flatten it out of the qualifier.
+            candidate = f"{namespace.replace('.', '-')}-{slug}"
+        else:
+            candidate = slug
+        # Flattening can make `a.b` and `a-b` land on the same qualifier; a harness
+        # config keyed by name silently drops the loser, so keep them distinct.
+        unique, attempt = candidate, 2
+        while unique in used:
+            unique = f"{candidate}-{attempt}"
+            attempt += 1
+        used.add(unique)
+        names[listing_id] = unique
     return names
 
 

--- a/observal-server/services/registry_namespace.py
+++ b/observal-server/services/registry_namespace.py
@@ -10,12 +10,14 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import select, union_all, update
 
+# The namespace charset is shared with the CLI, which enforces it client-side.
+from observal_shared.namespace_rules import NAMESPACE_RULE_TEXT, is_valid_namespace
+
 if TYPE_CHECKING:
     import uuid
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
-NAMESPACE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 RESERVED_NAMESPACES = frozenset({"admin", "api", "auth", "registry", "root", "system", "teams", "users"})
 RESERVED_SLUGS = frozenset({"archive", "draft", "install", "resolve", "restore", "submit", "unarchive", "versions"})
@@ -23,8 +25,8 @@ RESERVED_SLUGS = frozenset({"archive", "draft", "install", "resolve", "restore",
 
 def validate_namespace(handle: str, *, allow_reserved: bool = False) -> str:
     value = handle.strip().lower()
-    if not NAMESPACE_RE.fullmatch(value):
-        raise ValueError("Namespace must be 3-32 characters using lowercase letters, numbers, and hyphens")
+    if not is_valid_namespace(value):
+        raise ValueError(NAMESPACE_RULE_TEXT)
     if not allow_reserved and value in RESERVED_NAMESPACES:
         raise ValueError(f"Namespace '{value}' is reserved")
     return value
@@ -52,22 +54,18 @@ def validate_slug(slug: str, *, allow_reserved: bool = False) -> str:
     return value
 
 
-def is_valid_namespace(handle: str | None) -> bool:
-    """Whether a username can be used verbatim as a registry namespace."""
-    return bool(handle) and NAMESPACE_RE.fullmatch(handle.strip().lower()) is not None
-
-
 def namespace_for_user(user) -> str:
     if not user.username:
         raise ValueError("A username is required before publishing registry items")
     if not is_valid_namespace(user.username):
-        # Usernames predating namespace validation (dots, uppercase, …) were kept
-        # verbatim by migration 016, so they only fail here, on the write path.
-        # Name the offender and the way out — the generic regex message reads as a
-        # dead end, and set_username lets these users rename despite the lock.
+        # Usernames predating namespace validation (spaces, underscores, ``..``)
+        # were kept verbatim by migration 016, so they only fail here, on the write
+        # path; case is normalised rather than rejected. Name the offender and the
+        # way out, since the bare rule reads as a dead end and set_username lets
+        # exactly these users rename despite the publish lock.
         raise ValueError(
             f"Your username '{user.username}' cannot be used as a registry namespace. "
-            "Namespaces must be 3-32 characters using lowercase letters, numbers, and hyphens. "
+            f"{NAMESPACE_RULE_TEXT}. "
             "Pick a valid username first: `observal auth set-username <name>`, or Account "
             "settings in the web UI."
         )

--- a/observal-server/services/registry_namespace.py
+++ b/observal-server/services/registry_namespace.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from sqlalchemy import select, union_all
+from sqlalchemy import select, union_all, update
 
 if TYPE_CHECKING:
     import uuid
@@ -52,9 +52,25 @@ def validate_slug(slug: str, *, allow_reserved: bool = False) -> str:
     return value
 
 
+def is_valid_namespace(handle: str | None) -> bool:
+    """Whether a username can be used verbatim as a registry namespace."""
+    return bool(handle) and NAMESPACE_RE.fullmatch(handle.strip().lower()) is not None
+
+
 def namespace_for_user(user) -> str:
     if not user.username:
         raise ValueError("A username is required before publishing registry items")
+    if not is_valid_namespace(user.username):
+        # Usernames predating namespace validation (dots, uppercase, …) were kept
+        # verbatim by migration 016, so they only fail here, on the write path.
+        # Name the offender and the way out — the generic regex message reads as a
+        # dead end, and set_username lets these users rename despite the lock.
+        raise ValueError(
+            f"Your username '{user.username}' cannot be used as a registry namespace. "
+            "Namespaces must be 3-32 characters using lowercase letters, numbers, and hyphens. "
+            "Pick a valid username first: `observal auth set-username <name>`, or Account "
+            "settings in the web UI."
+        )
     # Existing deployments may already contain a now-reserved username. It remains
     # usable so migration does not silently rename login identities.
     return validate_namespace(user.username, allow_reserved=True)
@@ -97,6 +113,27 @@ async def user_has_listings(db: AsyncSession, user_id: uuid.UUID) -> bool:
         select(SandboxListing.id.label("id")).where(SandboxListing.submitted_by == user_id),
     ).subquery()
     return (await db.execute(select(ownership.c.id).limit(1))).first() is not None
+
+
+async def rename_namespace(db: AsyncSession, old: str, new: str) -> int:
+    """Re-point every listing in ``old`` to ``new``. Returns the row count.
+
+    A namespace is always a username, and usernames are unique, so every row in
+    ``old`` belongs to the single user who holds it — matching on namespace alone
+    leaves no listing stranded in a namespace nobody owns. Does not commit.
+    """
+    from models.agent import Agent
+    from models.hook import HookListing
+    from models.mcp import McpListing
+    from models.prompt import PromptListing
+    from models.sandbox import SandboxListing
+    from models.skill import SkillListing
+
+    moved = 0
+    for model in (Agent, McpListing, SkillListing, HookListing, PromptListing, SandboxListing):
+        result = await db.execute(update(model).where(model.namespace == old).values(namespace=new))
+        moved += result.rowcount or 0
+    return moved
 
 
 async def identity_exists(

--- a/observal-server/tests/test_registry_namespace.py
+++ b/observal-server/tests/test_registry_namespace.py
@@ -188,6 +188,69 @@ async def test_username_change_is_blocked_after_publish():
     assert user.username == "alice"
 
 
+def test_username_that_is_not_a_namespace_names_itself_and_the_way_out():
+    from services.registry_namespace import is_valid_namespace, namespace_for_user
+
+    assert is_valid_namespace("legacy-handle")
+    assert not is_valid_namespace("legacy.handle")
+    assert not is_valid_namespace(None)
+
+    with pytest.raises(ValueError) as exc:
+        namespace_for_user(SimpleNamespace(username="legacy.handle"))
+    assert "legacy.handle" in str(exc.value)
+    assert "set-username" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_publish_lock_does_not_trap_a_username_that_can_never_publish():
+    """A username that fails namespace validation cannot publish, so the
+    post-publish lock must not apply — otherwise the user is stuck for good."""
+    from api.routes.auth import set_username
+    from schemas.auth import UsernameUpdateRequest
+
+    user = SimpleNamespace(id=uuid.uuid4(), username="legacy.handle")
+    free = SimpleNamespace(scalar_one_or_none=lambda: None)
+    db = SimpleNamespace(execute=AsyncMock(return_value=free), commit=AsyncMock(), refresh=AsyncMock())
+    renamed = AsyncMock(return_value=3)
+
+    with (
+        patch("api.routes.auth.user_has_listings", new=AsyncMock(return_value=True)) as lock,
+        patch("api.routes.auth.rename_namespace", new=renamed),
+        patch("api.routes.auth.UserResponse") as response,
+    ):
+        await set_username(UsernameUpdateRequest(username="legacy-handle"), db, user)
+
+    assert user.username == "legacy-handle"
+    lock.assert_not_awaited()
+    # Listings left behind in the old namespace would be unreachable.
+    renamed.assert_awaited_once_with(db, "legacy.handle", "legacy-handle")
+    db.commit.assert_awaited_once()
+    response.model_validate.assert_called_once_with(user)
+
+
+@pytest.mark.asyncio
+async def test_rename_namespace_moves_every_listing_type():
+    from models.agent import Agent
+    from models.hook import HookListing
+    from models.mcp import McpListing
+    from models.prompt import PromptListing
+    from models.sandbox import SandboxListing
+    from models.skill import SkillListing
+    from services.registry_namespace import rename_namespace
+
+    statements = []
+
+    async def execute(stmt):
+        statements.append(stmt)
+        return SimpleNamespace(rowcount=2)
+
+    db = SimpleNamespace(execute=execute)
+    assert await rename_namespace(db, "old.handle", "new-handle") == 12
+    assert [stmt.table.name for stmt in statements] == [
+        model.__tablename__ for model in (Agent, McpListing, SkillListing, HookListing, PromptListing, SandboxListing)
+    ]
+
+
 class _TransferEntity(SimpleNamespace):
     @property
     def qualified_name(self):

--- a/observal-server/tests/test_registry_namespace.py
+++ b/observal-server/tests/test_registry_namespace.py
@@ -171,6 +171,21 @@ def test_harness_names_only_qualify_real_slug_collisions():
     }
 
 
+def test_harness_local_names_flatten_dots_without_colliding():
+    """Local names key harness configs and land on disk, so dots are flattened —
+    which makes `a.b` and `a-b` collapse together unless kept distinct."""
+    from services.harness.helpers import _local_registry_names
+
+    listings = {
+        1: SimpleNamespace(name="Tool", namespace="legacy.handle", slug="tool"),
+        2: SimpleNamespace(name="Tool", namespace="legacy-handle", slug="tool"),
+    }
+    names = _local_registry_names(listings)
+    assert names[1] == "legacy-handle-tool"
+    assert names[2] != names[1]
+    assert "." not in names[1] and "." not in names[2]
+
+
 @pytest.mark.asyncio
 async def test_username_change_is_blocked_after_publish():
     from api.routes.auth import set_username
@@ -188,16 +203,48 @@ async def test_username_change_is_blocked_after_publish():
     assert user.username == "alice"
 
 
-def test_username_that_is_not_a_namespace_names_itself_and_the_way_out():
-    from services.registry_namespace import is_valid_namespace, namespace_for_user
+def test_dotted_handles_are_valid_namespaces():
+    """Handles carried over from before namespace validation stay usable."""
+    from services.registry_namespace import is_valid_namespace, namespace_for_user, validate_namespace
 
+    assert is_valid_namespace("legacy.handle")
     assert is_valid_namespace("legacy-handle")
-    assert not is_valid_namespace("legacy.handle")
-    assert not is_valid_namespace(None)
+    assert validate_namespace("Legacy.Handle") == "legacy.handle"
+    assert namespace_for_user(SimpleNamespace(username="legacy.handle")) == "legacy.handle"
+    assert identity_for_user(SimpleNamespace(username="legacy.handle"), "Task Creator") == (
+        "legacy.handle",
+        "task-creator",
+    )
+
+
+@pytest.mark.parametrize(
+    "handle",
+    [
+        None,
+        "",
+        "ab",  # under three characters
+        ".alice",  # dot may not lead
+        "alice.",  # …or trail
+        "a..b",  # `..` reaches path-ish contexts
+        "alice ms",
+        "alice_ms",  # underscores belong to slugs, not namespaces
+        "alice/ms",  # the qualified-name separator
+        "alice@ms",
+        "a" * 33,
+    ],
+)
+def test_namespaces_that_stay_invalid(handle):
+    from services.registry_namespace import is_valid_namespace
+
+    assert not is_valid_namespace(handle)
+
+
+def test_username_that_is_not_a_namespace_names_itself_and_the_way_out():
+    from services.registry_namespace import namespace_for_user
 
     with pytest.raises(ValueError) as exc:
-        namespace_for_user(SimpleNamespace(username="legacy.handle"))
-    assert "legacy.handle" in str(exc.value)
+        namespace_for_user(SimpleNamespace(username="Bad Handle"))
+    assert "Bad Handle" in str(exc.value)
     assert "set-username" in str(exc.value)
 
 
@@ -208,7 +255,7 @@ async def test_publish_lock_does_not_trap_a_username_that_can_never_publish():
     from api.routes.auth import set_username
     from schemas.auth import UsernameUpdateRequest
 
-    user = SimpleNamespace(id=uuid.uuid4(), username="legacy.handle")
+    user = SimpleNamespace(id=uuid.uuid4(), username="Legacy Handle")
     free = SimpleNamespace(scalar_one_or_none=lambda: None)
     db = SimpleNamespace(execute=AsyncMock(return_value=free), commit=AsyncMock(), refresh=AsyncMock())
     renamed = AsyncMock(return_value=3)
@@ -223,7 +270,7 @@ async def test_publish_lock_does_not_trap_a_username_that_can_never_publish():
     assert user.username == "legacy-handle"
     lock.assert_not_awaited()
     # Listings left behind in the old namespace would be unreachable.
-    renamed.assert_awaited_once_with(db, "legacy.handle", "legacy-handle")
+    renamed.assert_awaited_once_with(db, "Legacy Handle", "legacy-handle")
     db.commit.assert_awaited_once()
     response.model_validate.assert_called_once_with(user)
 

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -27,9 +27,10 @@ from observal_cli.constants import AGENT_NAME_REGEX, VALID_HARNESSES
 from observal_cli.prompts import fuzzy_select, select_many, select_one, text_input
 from observal_cli.render import (
     console,
+    display_name,
+    handle,
     ide_tags,
     kv_panel,
-    name_block,
     name_inline,
     output_json,
     relative_time,
@@ -513,12 +514,11 @@ def agent_list(
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
     table.add_column("Model")
-    table.add_column("Created By", style="dim")
+    table.add_column("Namespace", style="dim")
     if include_id:
         table.add_column("ID", style="dim", no_wrap=full_id)
     for i, item in enumerate(data, 1):
-        creator = item.get("created_by_username") or item.get("created_by_email", "")
-        row = [str(i), name_block(item), item.get("version", ""), item.get("model_name", ""), creator]
+        row = [str(i), display_name(item), item.get("version", ""), item.get("model_name", ""), handle(item)]
         if include_id:
             row.append(str(item["id"]) if full_id else f"{str(item['id'])[:8]}…")
         table.add_row(*row)
@@ -568,14 +568,16 @@ def agent_my(
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
     table.add_column("Model")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
             item.get("model_name", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )
@@ -610,11 +612,11 @@ def agent_show(
 
     console.print(
         kv_panel(
-            f"{name_inline(item)} v{item.get('version', '?')}",
+            f"{display_name(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Model", f"[bold]{item.get('model_name', 'N/A')}[/bold]"),
-                ("Owner", item.get("owner", "N/A")),
+                ("Namespace", handle(item) or "N/A"),
                 ("Created By", item.get("created_by_username") or item.get("created_by_email", "")),
                 ("Description", item.get("description", "")),
                 ("harnesses", ide_tags(item.get("supported_harnesses", []))),

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -29,6 +29,8 @@ from observal_cli.render import (
     console,
     ide_tags,
     kv_panel,
+    name_block,
+    name_inline,
     output_json,
     relative_time,
     spinner,
@@ -472,7 +474,7 @@ def agent_list(
         def _display(item: dict) -> str:
             email = item.get("created_by_email", "")
             suffix = f"  by {email}" if email else ""
-            return f"{client.canonical_name(item)}  v{item.get('version', '?')}  {item.get('model_name', '')}{suffix}"
+            return f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('model_name', '')}{suffix}"
 
         selected = fuzzy_select(data, _display, label="Select agent")
         if selected:
@@ -498,7 +500,7 @@ def agent_list(
 
     if output == "plain":
         for item in data:
-            rprint(f"{client.canonical_name(item)}  v{item.get('version', '?')}  {item.get('model_name', '')}")
+            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('model_name', '')}")
         return
 
     include_id = show_id or full_id
@@ -516,7 +518,7 @@ def agent_list(
         table.add_column("ID", style="dim", no_wrap=full_id)
     for i, item in enumerate(data, 1):
         creator = item.get("created_by_username") or item.get("created_by_email", "")
-        row = [str(i), client.canonical_name(item), item.get("version", ""), item.get("model_name", ""), creator]
+        row = [str(i), name_block(item), item.get("version", ""), item.get("model_name", ""), creator]
         if include_id:
             row.append(str(item["id"]) if full_id else f"{str(item['id'])[:8]}…")
         table.add_row(*row)
@@ -559,7 +561,7 @@ def agent_my(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{client.canonical_name(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
+            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My Agents ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -571,7 +573,7 @@ def agent_my(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("model_name", ""),
             status_badge(item.get("status", "")),
@@ -608,7 +610,7 @@ def agent_show(
 
     console.print(
         kv_panel(
-            f"{client.canonical_name(item)} v{item.get('version', '?')}",
+            f"{name_inline(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Model", f"[bold]{item.get('model_name', 'N/A')}[/bold]"),

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -31,6 +31,7 @@ from observal_cli import client, config
 from observal_cli.branding import welcome_banner
 from observal_cli.prompts import password_input, quick_choice, text_input
 from observal_cli.render import console, kv_panel, spinner, status_badge
+from observal_shared.namespace_rules import NAMESPACE_RULE_TEXT, is_valid_namespace
 
 # ── Auth subgroup ───────────────────────────────────────────
 
@@ -489,13 +490,14 @@ def change_password():
 
 @auth_app.command(name="set-username")
 def set_username(
-    username: str = typer.Argument(..., help="Username (3-32 chars, lowercase alphanumeric and hyphens)"),
+    username: str = typer.Argument(..., help="Username (3-32 chars, lowercase alphanumeric, hyphens and dots)"),
 ):
     """Set or update your username.
 
-    Usernames must be 3 to 32 characters, lowercase alphanumeric with
-    hyphens allowed. Once set, your username can be used for login, doubles
-    as your registry namespace, and is displayed as @username in the UI.
+    Usernames must be 3 to 32 characters of lowercase letters, numbers,
+    hyphens, and dots, starting and ending with a letter or number. Once set,
+    your username can be used for login, doubles as your registry namespace,
+    and is displayed as @username in the UI.
 
     The server locks the username once you have published a registry item.
     The exception is a username that is not a valid namespace (one carried
@@ -505,15 +507,13 @@ def set_username(
     Examples:
         observal auth set-username alice
         observal auth set-username my-dev-handle
+        observal auth set-username my.dev.handle
     """
     optic.trace("username={}", username)
     from observal_cli import client as _client
 
-    if not re.fullmatch(r"[a-z0-9][a-z0-9-]{1,30}[a-z0-9]", username):
-        rprint(
-            "[red]Failed:[/red] Username must be 3-32 characters using lowercase letters, "
-            "numbers, and hyphens, and start and end with a letter or number."
-        )
+    if not is_valid_namespace(username):
+        rprint(f"[red]Failed:[/red] {NAMESPACE_RULE_TEXT}.")
         raise typer.Exit(1)
 
     try:

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -494,8 +494,13 @@ def set_username(
     """Set or update your username.
 
     Usernames must be 3 to 32 characters, lowercase alphanumeric with
-    hyphens allowed. Once set, your username can be used for login and
-    is displayed as @username in the UI.
+    hyphens allowed. Once set, your username can be used for login, doubles
+    as your registry namespace, and is displayed as @username in the UI.
+
+    The server locks the username once you have published a registry item.
+    The exception is a username that is not a valid namespace (one carried
+    over from before namespace validation) — that one can never publish, so
+    it stays changeable and anything already published moves with you.
 
     Examples:
         observal auth set-username alice
@@ -503,6 +508,13 @@ def set_username(
     """
     optic.trace("username={}", username)
     from observal_cli import client as _client
+
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]{1,30}[a-z0-9]", username):
+        rprint(
+            "[red]Failed:[/red] Username must be 3-32 characters using lowercase letters, "
+            "numbers, and hyphens, and start and end with a letter or number."
+        )
+        raise typer.Exit(1)
 
     try:
         with spinner("Updating username..."):

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -25,8 +25,9 @@ from observal_cli.constants import (
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
     console,
+    display_name,
+    handle,
     kv_panel,
-    name_block,
     name_inline,
     output_json,
     relative_time,
@@ -334,16 +335,16 @@ def hook_list(
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Event", style="magenta")
     table.add_column("Mode", style="green")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("event", ""),
             item.get("execution_mode", ""),
-            item.get("owner", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )
@@ -381,7 +382,7 @@ def hook_show(
         ("Handler Config", _json.dumps(item.get("handler_config", {}), indent=2)),
         ("Execution Mode", item.get("execution_mode", "N/A")),
         ("Scope", item.get("scope", "N/A")),
-        ("Owner", item.get("owner", "N/A")),
+        ("Namespace", handle(item) or "N/A"),
         ("Description", item.get("description", "")),
         ("Created", relative_time(item.get("created_at"))),
         ("ID", f"[dim]{item['id']}[/dim]"),
@@ -394,7 +395,7 @@ def hook_show(
         rows.insert(5, ("Requires", ", ".join(item["requirements"])))
     console.print(
         kv_panel(
-            f"{name_inline(item)} v{item.get('version', '?')}",
+            f"{display_name(item)} v{item.get('version', '?')}",
             rows,
             border_style="magenta",
         )

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -23,7 +23,16 @@ from observal_cli.constants import (
     VALID_HOOK_SCOPES,
 )
 from observal_cli.prompts import select_one, text_input
-from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
+from observal_cli.render import (
+    console,
+    kv_panel,
+    name_block,
+    name_inline,
+    output_json,
+    relative_time,
+    spinner,
+    status_badge,
+)
 
 hook_app = typer.Typer(help="Hook registry commands")
 
@@ -318,7 +327,7 @@ def hook_list(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{item['id']}  {client.canonical_name(item)}  {item.get('event', '?')}")
+            rprint(f"{item['id']}  {name_inline(item)}  {item.get('event', '?')}")
         return
     table = Table(title=f"Hooks ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -331,7 +340,7 @@ def hook_list(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("event", ""),
             item.get("execution_mode", ""),
             item.get("owner", ""),
@@ -385,7 +394,7 @@ def hook_show(
         rows.insert(5, ("Requires", ", ".join(item["requirements"])))
     console.print(
         kv_panel(
-            f"{client.canonical_name(item)} v{item.get('version', '?')}",
+            f"{name_inline(item)} v{item.get('version', '?')}",
             rows,
             border_style="magenta",
         )

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -26,9 +26,10 @@ from observal_cli.constants import VALID_HARNESSES, VALID_MCP_CATEGORIES
 from observal_cli.prompts import fuzzy_select, select_one, text_input
 from observal_cli.render import (
     console,
+    display_name,
+    handle,
     ide_tags,
     kv_panel,
-    name_block,
     name_inline,
     output_json,
     relative_time,
@@ -964,16 +965,16 @@ def _list_impl(category, search, limit, sort, output, interactive=False):
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
     table.add_column("Category")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("harnesses")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
             item.get("category", ""),
-            item.get("owner", ""),
+            handle(item),
             ide_tags(item.get("supported_harnesses", [])),
             str(item["id"])[:8] + "…",
         )
@@ -992,11 +993,11 @@ def _show_impl(mcp_id, output):
 
     console.print(
         kv_panel(
-            f"{name_inline(item)} v{item.get('version', '?')}",
+            f"{display_name(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Category", item.get("category", "N/A")),
-                ("Owner", item.get("owner", "N/A")),
+                ("Namespace", handle(item) or "N/A"),
                 ("Description", item.get("description", "")),
                 ("harnesses", ide_tags(item.get("supported_harnesses", []))),
                 ("Git", f"[link={item.get('git_url', '')}]{item.get('git_url', 'N/A')}[/link]"),
@@ -1377,15 +1378,15 @@ def mcp_my(
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
-            item.get("owner", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -28,6 +28,8 @@ from observal_cli.render import (
     console,
     ide_tags,
     kv_panel,
+    name_block,
+    name_inline,
     output_json,
     relative_time,
     spinner,
@@ -933,7 +935,7 @@ def _list_impl(category, search, limit, sort, output, interactive=False):
 
         def _display(item: dict) -> str:
             optic.trace("item={}", item)
-            return f"{client.canonical_name(item)}  v{item.get('version', '?')}  [{item.get('category', '')}]  {item.get('owner', '')}"
+            return f"{name_inline(item)}  v{item.get('version', '?')}  [{item.get('category', '')}]  {item.get('owner', '')}"
 
         selected = fuzzy_select(data, _display, label="Select MCP server")
         if selected:
@@ -954,9 +956,7 @@ def _list_impl(category, search, limit, sort, output, interactive=False):
 
     if output == "plain":
         for item in data:
-            rprint(
-                f"{item['id']}  {client.canonical_name(item)}  v{item.get('version', '?')}  [{item.get('category', '')}]"
-            )
+            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}  [{item.get('category', '')}]")
         return
 
     table = Table(title=f"MCP Servers ({len(data)})", show_lines=False, padding=(0, 1))
@@ -970,7 +970,7 @@ def _list_impl(category, search, limit, sort, output, interactive=False):
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("category", ""),
             item.get("owner", ""),
@@ -992,7 +992,7 @@ def _show_impl(mcp_id, output):
 
     console.print(
         kv_panel(
-            f"{client.canonical_name(item)} v{item.get('version', '?')}",
+            f"{name_inline(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Category", item.get("category", "N/A")),
@@ -1371,7 +1371,7 @@ def mcp_my(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{client.canonical_name(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
+            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My MCPs ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -1383,7 +1383,7 @@ def mcp_my(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("owner", ""),
             status_badge(item.get("status", "")),

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -20,8 +20,9 @@ from observal_cli.constants import VALID_PROMPT_CATEGORIES
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
     console,
+    display_name,
+    handle,
     kv_panel,
-    name_block,
     name_inline,
     output_json,
     relative_time,
@@ -178,15 +179,15 @@ def prompt_list(
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
-            item.get("owner", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )
@@ -223,15 +224,15 @@ def prompt_my(
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
-            item.get("owner", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )
@@ -262,11 +263,11 @@ def prompt_show(
         return
     console.print(
         kv_panel(
-            f"{name_inline(item)} v{item.get('version', '?')}",
+            f"{display_name(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Category", item.get("category", "N/A")),
-                ("Owner", item.get("owner", "N/A")),
+                ("Namespace", handle(item) or "N/A"),
                 ("Description", item.get("description", "")),
                 ("Created", relative_time(item.get("created_at"))),
                 ("ID", f"[dim]{item['id']}[/dim]"),

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -18,7 +18,16 @@ from rich.table import Table
 from observal_cli import client, config
 from observal_cli.constants import VALID_PROMPT_CATEGORIES
 from observal_cli.prompts import select_one, text_input
-from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
+from observal_cli.render import (
+    console,
+    kv_panel,
+    name_block,
+    name_inline,
+    output_json,
+    relative_time,
+    spinner,
+    status_badge,
+)
 
 prompt_app = typer.Typer(help="Prompt registry commands")
 
@@ -163,7 +172,7 @@ def prompt_list(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{item['id']}  {client.canonical_name(item)}  v{item.get('version', '?')}")
+            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}")
         return
     table = Table(title=f"Prompts ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -175,7 +184,7 @@ def prompt_list(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("owner", ""),
             status_badge(item.get("status", "")),
@@ -208,7 +217,7 @@ def prompt_my(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{client.canonical_name(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
+            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My Prompts ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -220,7 +229,7 @@ def prompt_my(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("owner", ""),
             status_badge(item.get("status", "")),
@@ -253,7 +262,7 @@ def prompt_show(
         return
     console.print(
         kv_panel(
-            f"{client.canonical_name(item)} v{item.get('version', '?')}",
+            f"{name_inline(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Category", item.get("category", "N/A")),

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -19,8 +19,9 @@ from observal_cli.constants import VALID_HARNESSES, VALID_SANDBOX_NETWORK_POLICI
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
     console,
+    display_name,
+    handle,
     kv_panel,
-    name_block,
     name_inline,
     output_json,
     relative_time,
@@ -270,15 +271,15 @@ def sandbox_list(
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
-            item.get("owner", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )
@@ -309,12 +310,12 @@ def sandbox_show(
         return
     console.print(
         kv_panel(
-            f"{name_inline(item)} v{item.get('version', '?')}",
+            f"{display_name(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Runtime", item.get("runtime_type", "N/A")),
                 ("Image", item.get("image", "N/A")),
-                ("Owner", item.get("owner", "N/A")),
+                ("Namespace", handle(item) or "N/A"),
                 ("Description", item.get("description", "")),
                 ("Created", relative_time(item.get("created_at"))),
                 ("ID", f"[dim]{item['id']}[/dim]"),

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -17,7 +17,16 @@ from rich.table import Table
 from observal_cli import client, config
 from observal_cli.constants import VALID_HARNESSES, VALID_SANDBOX_NETWORK_POLICIES, VALID_SANDBOX_RUNTIME_TYPES
 from observal_cli.prompts import select_one, text_input
-from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
+from observal_cli.render import (
+    console,
+    kv_panel,
+    name_block,
+    name_inline,
+    output_json,
+    relative_time,
+    spinner,
+    status_badge,
+)
 
 sandbox_app = typer.Typer(help="Sandbox registry commands")
 
@@ -255,7 +264,7 @@ def sandbox_list(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{item['id']}  {client.canonical_name(item)}  v{item.get('version', '?')}")
+            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}")
         return
     table = Table(title=f"Sandboxes ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -267,7 +276,7 @@ def sandbox_list(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("owner", ""),
             status_badge(item.get("status", "")),
@@ -300,7 +309,7 @@ def sandbox_show(
         return
     console.print(
         kv_panel(
-            f"{client.canonical_name(item)} v{item.get('version', '?')}",
+            f"{name_inline(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Runtime", item.get("runtime_type", "N/A")),

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -24,8 +24,9 @@ from observal_cli.constants import VALID_SKILL_TASK_TYPES
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
     console,
+    display_name,
+    handle,
     kv_panel,
-    name_block,
     name_inline,
     output_json,
     relative_time,
@@ -324,15 +325,15 @@ def skill_list(
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
-            item.get("owner", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )
@@ -369,15 +370,15 @@ def skill_my(
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
     table.add_column("Version", style="green")
-    table.add_column("Owner", style="dim")
+    table.add_column("Namespace", style="dim")
     table.add_column("Status")
     table.add_column("ID", style="dim", max_width=12)
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            name_block(item),
+            display_name(item),
             item.get("version", ""),
-            item.get("owner", ""),
+            handle(item),
             status_badge(item.get("status", "")),
             str(item["id"])[:8] + "…",
         )
@@ -411,13 +412,13 @@ def skill_show(
         return
     console.print(
         kv_panel(
-            f"{name_inline(item)} v{item.get('version', '?')}",
+            f"{display_name(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Validated", "✓" if item.get("validated") else "✗"),
                 ("Task Type", item.get("task_type", "N/A")),
                 ("Delivery Mode", item.get("delivery_mode", "git_fetch")),
-                ("Owner", item.get("owner", "N/A")),
+                ("Namespace", handle(item) or "N/A"),
                 ("Git URL", item.get("git_url", "N/A")),
                 ("Git Ref", item.get("git_ref") or "N/A"),
                 ("Skill Path", item.get("skill_path", "/")),

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -22,7 +22,16 @@ from rich.table import Table
 from observal_cli import client, config
 from observal_cli.constants import VALID_SKILL_TASK_TYPES
 from observal_cli.prompts import select_one, text_input
-from observal_cli.render import console, kv_panel, output_json, relative_time, spinner, status_badge
+from observal_cli.render import (
+    console,
+    kv_panel,
+    name_block,
+    name_inline,
+    output_json,
+    relative_time,
+    spinner,
+    status_badge,
+)
 from observal_cli.shared.utils import sanitize_name as _sanitize_name
 
 skill_app = typer.Typer(help="Skill registry commands")
@@ -309,7 +318,7 @@ def skill_list(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{item['id']}  {client.canonical_name(item)}  v{item.get('version', '?')}")
+            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}")
         return
     table = Table(title=f"Skills ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -321,7 +330,7 @@ def skill_list(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("owner", ""),
             status_badge(item.get("status", "")),
@@ -354,7 +363,7 @@ def skill_my(
         return
     if output == "plain":
         for item in data:
-            rprint(f"{client.canonical_name(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
+            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My Skills ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -366,7 +375,7 @@ def skill_my(
     for i, item in enumerate(data, 1):
         table.add_row(
             str(i),
-            client.canonical_name(item),
+            name_block(item),
             item.get("version", ""),
             item.get("owner", ""),
             status_badge(item.get("status", "")),
@@ -402,7 +411,7 @@ def skill_show(
         return
     console.print(
         kv_panel(
-            f"{client.canonical_name(item)} v{item.get('version', '?')}",
+            f"{name_inline(item)} v{item.get('version', '?')}",
             [
                 ("Status", status_badge(item.get("status", ""))),
                 ("Validated", "✓" if item.get("validated") else "✗"),

--- a/observal_cli/lockfile.py
+++ b/observal_cli/lockfile.py
@@ -176,7 +176,9 @@ def local_registry_name(
     )
     if not collision:
         return slug
-    candidate = f"{namespace}-{slug}"
+    # Local names become harness config keys and on-disk names, where a dot reads
+    # as a file extension — flattened the same way the registry host is below.
+    candidate = f"{namespace.replace('.', '-')}-{slug}"
     if not any(entry.get("local_name") == candidate for _, entry in matching_entries):
         return candidate
     host = urlsplit(current_url).hostname or "registry"

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -61,6 +61,44 @@ def relative_time(iso: str | None) -> str:
         return iso[:19] if iso else "--"
 
 
+# ── Registry identities ──────────────────────────────────
+# The API returns the canonical ``namespace/slug`` in ``qualified_name``. That
+# form is what commands take (``observal agent pull alice/reviewer``), but it
+# reads poorly in listings, so we show the bare name with the owning namespace
+# beneath it as ``@alice``. Use ``client.canonical_name()`` for anything a user
+# is meant to paste back into a command.
+
+
+def registry_identity(item: dict) -> tuple[str, str | None]:
+    """Split a registry item into ``(name, namespace)``.
+
+    Prefers the explicit ``namespace``/``slug`` fields and falls back to parsing
+    ``qualified_name`` so older server payloads still resolve a namespace.
+    """
+    namespace = (item.get("namespace") or "").strip() or None
+    name = (item.get("slug") or "").strip() or None
+
+    qualified = (item.get("qualified_name") or "").strip()
+    if (not namespace or not name) and "/" in qualified:
+        head, _, tail = qualified.partition("/")
+        namespace = namespace or head
+        name = name or tail
+
+    return name or (item.get("name") or "").strip(), namespace
+
+
+def name_block(item: dict) -> str:
+    """Two-line cell for tables: the name over a dimmed ``@namespace``."""
+    name, namespace = registry_identity(item)
+    return f"{name}\n[not bold dim]@{namespace}[/not bold dim]" if namespace else name
+
+
+def name_inline(item: dict) -> str:
+    """Single-line form for panel titles and plain output: ``name @namespace``."""
+    name, namespace = registry_identity(item)
+    return f"{name} [dim]@{namespace}[/dim]" if namespace else name
+
+
 # ── Stars ────────────────────────────────────────────────
 
 

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -87,14 +87,19 @@ def registry_identity(item: dict) -> tuple[str, str | None]:
     return name or (item.get("name") or "").strip(), namespace
 
 
-def name_block(item: dict) -> str:
-    """Two-line cell for tables: the name over a dimmed ``@namespace``."""
-    name, namespace = registry_identity(item)
-    return f"{name}\n[not bold dim]@{namespace}[/not bold dim]" if namespace else name
+def display_name(item: dict) -> str:
+    """The bare item name, never namespace-qualified."""
+    return registry_identity(item)[0]
+
+
+def handle(item: dict) -> str:
+    """The owning namespace as ``@namespace``, for its own table column or field."""
+    namespace = registry_identity(item)[1]
+    return f"@{namespace}" if namespace else ""
 
 
 def name_inline(item: dict) -> str:
-    """Single-line form for panel titles and plain output: ``name @namespace``."""
+    """``name @namespace`` for plain output, which has no columns to separate them."""
     name, namespace = registry_identity(item)
     return f"{name} [dim]@{namespace}[/dim]" if namespace else name
 

--- a/observal_cli/tests/test_registry_namespace_cli.py
+++ b/observal_cli/tests/test_registry_namespace_cli.py
@@ -3,7 +3,29 @@
 
 import json
 
-from observal_cli import client, config, lockfile
+from observal_cli import client, config, lockfile, render
+
+
+def test_listings_render_the_bare_name_over_an_at_handle():
+    item = {
+        "name": "Task Creator",
+        "namespace": "alice",
+        "slug": "task-creator",
+        "qualified_name": "alice/task-creator",
+    }
+
+    assert render.registry_identity(item) == ("task-creator", "alice")
+    assert render.name_block(item) == "task-creator\n[not bold dim]@alice[/not bold dim]"
+    assert render.name_inline(item) == "task-creator [dim]@alice[/dim]"
+    # Commands still need the slash form.
+    assert client.canonical_name(item) == "alice/task-creator"
+
+
+def test_namespace_falls_back_to_the_qualified_name_and_degrades_without_one():
+    assert render.registry_identity({"name": "x", "qualified_name": "bob/search"}) == ("search", "bob")
+    assert render.registry_identity({"name": "Legacy"}) == ("Legacy", None)
+    assert render.name_block({"name": "Legacy"}) == "Legacy"
+    assert render.name_inline({"name": "Legacy"}) == "Legacy"
 
 
 def test_qualified_reference_resolves_once(monkeypatch):

--- a/observal_cli/tests/test_registry_namespace_cli.py
+++ b/observal_cli/tests/test_registry_namespace_cli.py
@@ -15,7 +15,10 @@ def test_listings_render_the_bare_name_over_an_at_handle():
     }
 
     assert render.registry_identity(item) == ("task-creator", "alice")
-    assert render.name_block(item) == "task-creator\n[not bold dim]@alice[/not bold dim]"
+    # Tables put the name and its namespace in separate columns.
+    assert render.display_name(item) == "task-creator"
+    assert render.handle(item) == "@alice"
+    # Plain output has no columns, so it keeps them on one line.
     assert render.name_inline(item) == "task-creator [dim]@alice[/dim]"
     # Commands still need the slash form.
     assert client.canonical_name(item) == "alice/task-creator"
@@ -24,7 +27,8 @@ def test_listings_render_the_bare_name_over_an_at_handle():
 def test_namespace_falls_back_to_the_qualified_name_and_degrades_without_one():
     assert render.registry_identity({"name": "x", "qualified_name": "bob/search"}) == ("search", "bob")
     assert render.registry_identity({"name": "Legacy"}) == ("Legacy", None)
-    assert render.name_block({"name": "Legacy"}) == "Legacy"
+    assert render.display_name({"name": "Legacy"}) == "Legacy"
+    assert render.handle({"name": "Legacy"}) == ""
     assert render.name_inline({"name": "Legacy"}) == "Legacy"
 
 

--- a/observal_cli/tests/test_registry_namespace_cli.py
+++ b/observal_cli/tests/test_registry_namespace_cli.py
@@ -28,6 +28,29 @@ def test_namespace_falls_back_to_the_qualified_name_and_degrades_without_one():
     assert render.name_inline({"name": "Legacy"}) == "Legacy"
 
 
+def test_dotted_namespaces_are_valid_but_flattened_in_local_install_names(tmp_path, monkeypatch):
+    from observal_shared.namespace_rules import is_valid_namespace
+
+    assert is_valid_namespace("legacy.handle")
+    assert not is_valid_namespace("a..b")
+
+    monkeypatch.setattr(config, "load", lambda: {"server_url": "https://registry.example.com"})
+    monkeypatch.setattr(lockfile, "LOCKFILE_PATH", tmp_path / "lockfile.json")
+    monkeypatch.setattr(lockfile, "_LOCKFILE_LOCK", tmp_path / "lockfile.lock")
+    lockfile.upsert_agent(
+        "kiro",
+        name="tool",
+        agent_id="00000000-0000-0000-0000-000000000001",
+        version="1.0.0",
+        namespace="alice",
+        slug="tool",
+        local_name="tool",
+    )
+
+    # A dot would read as a file extension once this reaches disk or a config key.
+    assert lockfile.local_registry_name("kiro", "agent", "legacy.handle", "tool") == "legacy-handle-tool"
+
+
 def test_qualified_reference_resolves_once(monkeypatch):
     calls = []
     monkeypatch.setattr(config, "resolve_alias", lambda value: value)

--- a/packages/observal-shared/observal_shared/namespace_rules.py
+++ b/packages/observal-shared/observal_shared/namespace_rules.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical registry namespace charset, shared by the server and the CLI.
+
+A namespace is a user's handle and the left half of a qualified identity
+(``namespace/slug``). The rule lived in three places that had to agree — the
+server validator plus client-side pre-checks — so it lives here instead. The
+web UI keeps its own copy in ``web/src/lib/registry-name.ts``; keep the two in
+sync when this changes.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: 3-32 characters, starting and ending alphanumeric, hyphens and dots inside.
+NAMESPACE_PATTERN = r"^[a-z0-9][a-z0-9.-]{1,30}[a-z0-9]$"
+NAMESPACE_RE = re.compile(NAMESPACE_PATTERN)
+
+#: Human-readable form of the rule, reused in error messages on both sides.
+NAMESPACE_RULE_TEXT = (
+    "Namespaces must be 3-32 characters using lowercase letters, numbers, "
+    "hyphens, and dots, and must start and end with a letter or number"
+)
+
+
+def is_valid_namespace(handle: str | None) -> bool:
+    """Whether ``handle`` can be used verbatim as a registry namespace."""
+    if not handle:
+        return False
+    value = handle.strip().lower()
+    if ".." in value:
+        return False
+    return NAMESPACE_RE.fullmatch(value) is not None

--- a/web/src/components/registry/agent-card.tsx
+++ b/web/src/components/registry/agent-card.tsx
@@ -8,11 +8,15 @@ import { Link } from "@tanstack/react-router";
 import { ArrowDownToLine, Puzzle, Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { HarnessBadges } from "@/components/registry/harness-badges";
+import { RegistryName } from "@/components/registry/registry-name";
 import { compactNumber } from "@/lib/utils";
 
 interface AgentCardProps {
   id: string;
   name: string;
+  namespace?: string;
+  slug?: string;
+  qualified_name?: string;
   description?: string;
   model_name?: string;
   owner?: string;
@@ -30,6 +34,9 @@ interface AgentCardProps {
 export function AgentCard({
   id,
   name,
+  namespace,
+  slug,
+  qualified_name,
   description,
   owner,
   created_by_username,
@@ -53,9 +60,10 @@ export function AgentCard({
       ].join(" ")}
     >
       <div className="flex items-start justify-between gap-3">
-        <h3 className="font-display text-sm font-semibold leading-tight truncate">
-          {name}
-        </h3>
+        <RegistryName
+          item={{ name, namespace, slug, qualified_name }}
+          nameClassName="font-display text-sm font-semibold leading-tight"
+        />
         {version && (
           <Badge variant="secondary" className="shrink-0 text-[10px] px-1.5 py-0">
             {version}
@@ -69,7 +77,9 @@ export function AgentCard({
         </p>
       )}
 
-      {(created_by_username || owner) && (
+      {/* The namespace under the name already reads as @owner, so only fall back
+          to the creator line when the item carries no namespace. */}
+      {!namespace && !qualified_name?.includes("/") && (created_by_username || owner) && (
         <p className="mt-2 text-[11px] text-muted-foreground/70 truncate">
           {created_by_username ? `@${created_by_username}` : owner}
         </p>

--- a/web/src/components/registry/component-card.tsx
+++ b/web/src/components/registry/component-card.tsx
@@ -5,11 +5,15 @@
 import { Link } from "@tanstack/react-router";
 import { GitBranch } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { RegistryName } from "@/components/registry/registry-name";
 import type { RegistryType } from "@/lib/api";
 
 interface ComponentCardProps {
   id: string;
   name: string;
+  namespace?: string;
+  slug?: string;
+  qualified_name?: string;
   type: RegistryType;
   description?: string;
   version?: string;
@@ -29,6 +33,9 @@ const TYPE_LABELS: Record<string, string> = {
 export function ComponentCard({
   id,
   name,
+  namespace,
+  slug,
+  qualified_name,
   type,
   description,
   version,
@@ -48,9 +55,10 @@ export function ComponentCard({
       ].join(" ")}
     >
       <div className="flex items-start justify-between gap-2">
-        <h3 className="font-display text-sm font-semibold leading-tight truncate">
-          {name}
-        </h3>
+        <RegistryName
+          item={{ name, namespace, slug, qualified_name }}
+          nameClassName="font-display text-sm font-semibold leading-tight"
+        />
         <Badge variant="outline" className="shrink-0 text-[10px] px-1.5 py-0">
           {TYPE_LABELS[type] ?? type}
         </Badge>

--- a/web/src/components/registry/registry-name.tsx
+++ b/web/src/components/registry/registry-name.tsx
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { cn } from "@/lib/utils";
+import { registryIdentity, type QualifiedIdentity } from "@/lib/registry-name";
+
+interface RegistryNameProps {
+  item: QualifiedIdentity | null | undefined;
+  /** Used when the item carries no name at all (e.g. still loading). */
+  fallbackName?: string;
+  className?: string;
+  /** Classes for the name line, so callers keep their own heading sizes. */
+  nameClassName?: string;
+  handleClassName?: string;
+  /** Element for the name line. Defaults to a span so links/headings can wrap it. */
+  as?: "span" | "h1" | "h3" | "p";
+}
+
+/**
+ * Renders a registry identity as the bare name with its owning namespace
+ * underneath, e.g. `code-reviewer` over `@alice`.
+ *
+ * Anything copy-pasted into a shell must keep the canonical `namespace/slug`
+ * form instead — see `qualifiedName()` in `@/lib/registry-name`.
+ */
+export function RegistryName({
+  item,
+  fallbackName = "",
+  className,
+  nameClassName,
+  handleClassName,
+  as: NameTag = "span",
+}: RegistryNameProps) {
+  const { name, handle } = registryIdentity(item, fallbackName);
+
+  return (
+    <span className={cn("block min-w-0", className)}>
+      <NameTag className={cn("block truncate", nameClassName)}>{name}</NameTag>
+      {handle && (
+        <span className={cn("block truncate text-[11px] font-normal text-muted-foreground", handleClassName)}>
+          @{handle}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/src/lib/registry-name.ts
+++ b/web/src/lib/registry-name.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Display helpers for qualified registry identities (``namespace/slug``).
+ *
+ * The API returns the canonical slash form in ``qualified_name``. That form is
+ * what commands take (``observal agent pull alice/reviewer``), but it reads
+ * poorly in the UI, so listings render the bare name with the owning namespace
+ * underneath as ``@alice``. Keep using ``qualified_name`` verbatim for anything
+ * copy-pasted into a shell.
+ */
+
+/** Any shape carrying some subset of the canonical identity fields. */
+export interface QualifiedIdentity {
+	name?: string;
+	namespace?: string;
+	slug?: string;
+	qualified_name?: string;
+}
+
+export interface RegistryIdentity {
+	/** Bare item name, never containing a slash. */
+	name: string;
+	/** Owning namespace without the leading ``@``, or undefined when unknown. */
+	handle?: string;
+	/** Canonical ``namespace/slug`` when known, else the bare name. */
+	qualified: string;
+}
+
+/**
+ * Split a registry item into its display name and owning handle.
+ *
+ * Prefers the explicit ``namespace``/``slug`` columns and falls back to parsing
+ * ``qualified_name`` so older payloads (and the leaderboard summaries, which
+ * only carry the qualified form) still render a handle.
+ */
+export function registryIdentity(item: QualifiedIdentity | null | undefined, fallbackName = ""): RegistryIdentity {
+	const qualifiedName = item?.qualified_name?.trim();
+	let handle = item?.namespace?.trim() || undefined;
+	let name = item?.slug?.trim() || undefined;
+
+	if ((!handle || !name) && qualifiedName?.includes("/")) {
+		const separator = qualifiedName.indexOf("/");
+		handle = handle ?? qualifiedName.slice(0, separator);
+		name = name ?? qualifiedName.slice(separator + 1);
+	}
+
+	// The slug is what used to follow the slash, so it keeps listings looking the
+	// same minus the namespace. Fall back to the human-authored name.
+	const displayName = name || item?.name?.trim() || fallbackName;
+
+	return {
+		name: displayName,
+		handle: handle || undefined,
+		qualified: qualifiedName || (handle && name ? `${handle}/${name}` : displayName),
+	};
+}
+
+/** The canonical ``namespace/slug`` string to embed in CLI commands. */
+export function qualifiedName(item: QualifiedIdentity | null | undefined, fallbackName = ""): string {
+	return registryIdentity(item, fallbackName).qualified;
+}
+
+/** Single-line form for breadcrumbs and document titles, e.g. ``reviewer @alice``. */
+export function registryNameWithHandle(item: QualifiedIdentity | null | undefined, fallbackName = ""): string {
+	const { name, handle } = registryIdentity(item, fallbackName);
+	return handle ? `${name} @${handle}` : name;
+}

--- a/web/src/lib/registry-name.ts
+++ b/web/src/lib/registry-name.ts
@@ -11,6 +11,25 @@
  * copy-pasted into a shell.
  */
 
+/**
+ * Canonical namespace charset: 3-32 chars, starting and ending alphanumeric,
+ * hyphens and dots inside. Mirrors `observal_shared/namespace_rules.py` — keep
+ * the two in sync.
+ */
+const NAMESPACE_RE = /^[a-z0-9][a-z0-9.-]{1,30}[a-z0-9]$/;
+
+export const NAMESPACE_RULE_TEXT =
+	"Namespaces must be 3-32 characters using lowercase letters, numbers, " +
+	"hyphens, and dots, and must start and end with a letter or number";
+
+/** Whether a username can be used verbatim as a registry namespace. */
+export function isValidNamespace(handle: string | null | undefined): boolean {
+	if (!handle) return false;
+	const value = handle.trim().toLowerCase();
+	if (value.includes("..")) return false;
+	return NAMESPACE_RE.test(value);
+}
+
 /** Any shape carrying some subset of the canonical identity fields. */
 export interface QualifiedIdentity {
 	name?: string;

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -52,6 +52,8 @@ import type {
   InsightReportListItem,
 } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
+import { RegistryName } from "@/components/registry/registry-name";
+import { registryIdentity, type QualifiedIdentity } from "@/lib/registry-name";
 import { VersionDropdown } from "@/components/registry/version-dropdown";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { HarnessBadges } from "@/components/registry/harness-badges";
@@ -671,7 +673,11 @@ export default function AgentDetailPage() {
   const canManageLifecycle = isAdmin || isOwner;
   const agentStatus = a?.status as string | undefined;
   const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && ["approved", "pending", "draft", "rejected"].includes(agentStatus ?? "");
-  const agentName = (a?.qualified_name as string | undefined) ?? a?.name ?? id.slice(0, 8);
+  // Header/breadcrumb show the bare name; the pull command needs the canonical
+  // `namespace/slug` the CLI resolves.
+  const agentIdentity = registryIdentity(a as QualifiedIdentity | undefined, id.slice(0, 8));
+  const agentName = agentIdentity.name;
+  const agentRef = agentIdentity.qualified;
   const totalDownloads = downloadData?.total ?? a?.download_count;
   const uniqueUsers = downloadData?.unique_users;
   const archivedComponents = components.filter((component) => component.status === "archived");
@@ -707,9 +713,12 @@ export default function AgentDetailPage() {
               {/* Header */}
               <div className="space-y-2">
                 <div className="flex items-start gap-3 flex-wrap">
-                  <h1 className="text-2xl font-display font-bold tracking-tight">
-                    {(a.qualified_name as string | undefined) ?? a.name}
-                  </h1>
+                  <RegistryName
+                    item={a as QualifiedIdentity}
+                    as="h1"
+                    nameClassName="text-2xl font-display font-bold tracking-tight"
+                    handleClassName="text-sm text-muted-foreground"
+                  />
                   {a.status && <StatusBadge status={a.status} />}
                   {versions.length > 0 ? (
                     <VersionDropdown
@@ -758,7 +767,7 @@ export default function AgentDetailPage() {
               {/* Pull command (mobile only) */}
               <div className="lg:hidden">
                 <PullCommand
-                  agentName={(a.qualified_name as string | undefined) ?? a.name}
+                  agentName={agentRef}
                   currentVersion={effectiveVersion}
                   latestVersion={latestApprovedVersion ?? a.version}
                 />
@@ -925,7 +934,7 @@ export default function AgentDetailPage() {
             {/* Sidebar (desktop) */}
             <aside className="hidden lg:block space-y-5 animate-in stagger-1">
               <PullCommand
-                agentName={(a.qualified_name as string | undefined) ?? a.name}
+                agentName={agentRef}
                 currentVersion={effectiveVersion}
                 latestVersion={latestApprovedVersion ?? a.version}
               />

--- a/web/src/pages/registry/agents/index.tsx
+++ b/web/src/pages/registry/agents/index.tsx
@@ -50,6 +50,7 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { AgentCard } from "@/components/registry/agent-card";
+import { RegistryName } from "@/components/registry/registry-name";
 import { compactNumber } from "@/lib/utils";
 import {
   useReactTable,
@@ -292,12 +293,12 @@ const columns: ColumnDef<RegistryItem>[] = [
     ),
     cell: ({ row }) => (
       <div className="min-w-[160px]">
-        <div className="flex items-center gap-2">
+        <div className="flex items-start gap-2">
           <Link
             to="/agents/$agentId" params={{ agentId: row.original.id }}
-            className="font-medium text-sm hover:underline underline-offset-4"
+            className="min-w-0 hover:underline underline-offset-4"
           >
-            {row.original.qualified_name ?? row.original.name}
+            <RegistryName item={row.original} nameClassName="font-medium text-sm" />
           </Link>
           {row.original.status && row.original.status !== "approved" && (
             <span className="inline-flex items-center gap-1 rounded-full bg-warning/10 px-2 py-0.5 text-[10px] font-medium text-warning ring-1 ring-warning/20">
@@ -657,8 +658,8 @@ function AgentListContent() {
                 {drafts.map((draft) => (
                   <div key={draft.id} className="flex items-center gap-4 px-4 py-3">
                     <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <p className="truncate text-sm font-medium">{draft.qualified_name ?? draft.name}</p>
+                      <div className="flex items-start gap-2">
+                        <RegistryName item={draft} nameClassName="text-sm font-medium" />
                         {(draft.status === "rejected" || draft.status === "pending") && (
                           <StatusBadge status={draft.status} />
                         )}
@@ -742,8 +743,8 @@ function AgentListContent() {
                 {archivedAgents.map((agent) => (
                   <div key={agent.id} className="flex items-center gap-4 px-4 py-3">
                     <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <p className="truncate text-sm font-medium">{agent.qualified_name ?? agent.name}</p>
+                      <div className="flex items-start gap-2">
+                        <RegistryName item={agent} nameClassName="text-sm font-medium" />
                         <StatusBadge status="archived" />
                       </div>
                       {agent.description && (
@@ -799,8 +800,8 @@ function AgentListContent() {
                 {deletedAgents.map((agent) => (
                   <div key={agent.id} className="flex items-center gap-4 px-4 py-3">
                     <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <p className="truncate text-sm font-medium">{agent.qualified_name ?? agent.name}</p>
+                      <div className="flex items-start gap-2">
+                        <RegistryName item={agent} nameClassName="text-sm font-medium" />
                         <StatusBadge status="deleted" />
                       </div>
                       {agent.description && (
@@ -914,6 +915,9 @@ function AgentListContent() {
                 key={agent.id}
                 id={agent.id}
                 name={agent.name}
+                namespace={agent.namespace}
+                slug={agent.slug}
+                qualified_name={agent.qualified_name}
                 description={agent.description as string | undefined}
                 owner={agent.owner as string | undefined}
                 version={agent.version as string | undefined}

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -24,12 +24,14 @@ import {
 import type { RegistryType } from "@/lib/api";
 import type { FeedbackItem, RegistryItem, ComponentVersionSummary } from "@/lib/types";
 import { compactNumber } from "@/lib/utils";
+import { registryIdentity } from "@/lib/registry-name";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ReviewForm } from "@/components/registry/review-form";
 import { VersionDropdown } from "@/components/registry/version-dropdown";
 import { ComponentEditForm } from "@/components/registry/component-edit-form";
 import { ComponentInstallCommand } from "@/components/registry/component-install-command";
+import { RegistryName } from "@/components/registry/registry-name";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -126,7 +128,11 @@ export default function ComponentDetailPage() {
       : item
     : undefined;
 
-  const componentName = item?.qualified_name ?? item?.name ?? id.slice(0, 8);
+  // Header/breadcrumb show the bare name; the install command needs the
+  // canonical `namespace/slug` the CLI resolves.
+  const identity = registryIdentity(item, id.slice(0, 8));
+  const componentName = identity.name;
+  const componentRef = identity.qualified;
   const avgRating = feedbackSummary?.average_rating;
   const totalReviews = feedbackSummary?.total_reviews ?? 0;
   const metricsEntries: [string, string][] = rawMetrics && typeof rawMetrics === "object"
@@ -167,7 +173,12 @@ export default function ComponentDetailPage() {
             {/* Header */}
             <div className="space-y-2">
               <div className="flex items-start gap-3 flex-wrap">
-                <h1 className="text-2xl font-display font-bold tracking-tight">{item.qualified_name ?? item.name}</h1>
+                <RegistryName
+                  item={item}
+                  as="h1"
+                  nameClassName="text-2xl font-display font-bold tracking-tight"
+                  handleClassName="text-sm text-muted-foreground"
+                />
                 <Badge variant="outline" className="text-xs">{singularType}</Badge>
                 {item.status && (
                   <Badge
@@ -362,7 +373,7 @@ export default function ComponentDetailPage() {
             <aside className="hidden lg:block space-y-5">
               {/* Install command (MCPs, Skills, Hooks only) */}
               {(singularType === "mcp" || singularType === "skill" || singularType === "hook") && (
-                <ComponentInstallCommand componentType={singularType} componentName={item.qualified_name ?? item.name} />
+                <ComponentInstallCommand componentType={singularType} componentName={componentRef} />
               )}
 
               {/* Stats */}

--- a/web/src/pages/registry/components/index.tsx
+++ b/web/src/pages/registry/components/index.tsx
@@ -62,6 +62,7 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { ComponentCard } from "@/components/registry/component-card";
+import { RegistryName } from "@/components/registry/registry-name";
 import {
   useReactTable,
   getCoreRowModel,
@@ -133,9 +134,9 @@ function makeColumns(activeType: RegistryType): ColumnDef<RegistryItem>[] {
         <div className="min-w-[160px]">
           <Link
             to="/components/$componentId" params={{ componentId: row.original.id }} search={{ type: activeType }}
-            className="font-medium text-sm hover:underline underline-offset-4"
+            className="block min-w-0 hover:underline underline-offset-4"
           >
-            {row.original.qualified_name ?? row.original.name}
+            <RegistryName item={row.original} nameClassName="font-medium text-sm" />
           </Link>
           {row.original.description && (
             <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1 max-w-xs">
@@ -525,6 +526,9 @@ export default function ComponentsPage() {
                 key={item.id}
                 id={item.id}
                 name={item.name}
+                namespace={item.namespace}
+                slug={item.slug}
+                qualified_name={item.qualified_name}
                 type={activeType}
                 description={item.description}
                 version={item.version as string | undefined}
@@ -551,9 +555,7 @@ export default function ComponentsPage() {
                   <div className="flex items-center gap-3 min-w-0">
                     <StatusBadge status={item.status ?? "draft"} />
                     <div className="min-w-0">
-                      <p className="text-sm font-medium truncate">
-                        {item.qualified_name ?? item.name}
-                      </p>
+                      <RegistryName item={item} nameClassName="text-sm font-medium" />
                       {item.description && (
                         <p className="text-xs text-muted-foreground truncate max-w-xs">
                           {item.description}

--- a/web/src/pages/registry/home.tsx
+++ b/web/src/pages/registry/home.tsx
@@ -24,6 +24,8 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { AgentCard } from "@/components/registry/agent-card";
+import { RegistryName } from "@/components/registry/registry-name";
+import { registryIdentity, registryNameWithHandle } from "@/lib/registry-name";
 import { PageHeader } from "@/components/layouts/page-header";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -254,8 +256,10 @@ function AgentImpactRow({ agent, index }: { agent: RegistryItem; index: number }
     >
       <span className="text-right font-mono text-xs font-medium text-muted-foreground">{index + 1}</span>
       <div className="min-w-0">
-        <span className="block truncate font-medium text-foreground">{agent.name}</span>
-        <span className="block truncate text-xs text-muted-foreground">{getAgentOwner(agent) || "Owned agent"}</span>
+        <RegistryName item={agent} nameClassName="font-medium text-foreground" />
+        {!registryIdentity(agent).handle && (
+          <span className="block truncate text-xs text-muted-foreground">{getAgentOwner(agent) || "Owned agent"}</span>
+        )}
       </div>
       <span className="inline-flex items-center justify-end gap-1 font-mono text-xs text-muted-foreground">
         <ArrowDownToLine className="h-3 w-3" />
@@ -329,7 +333,7 @@ function RankSummary({
     >
       <div className="min-w-0">
         <p className="text-xs text-muted-foreground">Best 7 day rank</p>
-        <p className="mt-1 truncate text-sm font-medium text-foreground">{rank.item.name}</p>
+        <RegistryName item={rank.item} className="mt-1" nameClassName="text-sm font-medium text-foreground" />
       </div>
       <div className="text-right">
         <p className="font-mono text-3xl font-semibold tracking-tight text-foreground">#{rank.rank}</p>
@@ -515,7 +519,7 @@ export default function RegistryHome() {
               <BriefMetric
                 label="Best rank"
                 value={leaderboardLoading ? "..." : bestRank ? `#${bestRank.rank}` : "Unranked"}
-                detail={bestRank ? bestRank.item.name : "7 day board"}
+                detail={bestRank ? registryNameWithHandle(bestRank.item) : "7 day board"}
               />
               <BriefMetric
                 label="Owned installs"
@@ -667,6 +671,9 @@ export default function RegistryHome() {
                     key={item.id}
                     id={item.id}
                     name={item.name}
+                    namespace={item.namespace}
+                    slug={item.slug}
+                    qualified_name={item.qualified_name}
                     downloads={item.download_count}
                     score={item.average_rating ?? undefined}
                     description={item.description}
@@ -707,6 +714,9 @@ export default function RegistryHome() {
                     key={agent.id}
                     id={agent.id}
                     name={agent.name}
+                    namespace={agent.namespace}
+                    slug={agent.slug}
+                    qualified_name={agent.qualified_name}
                     description={agent.description as string | undefined}
                     owner={agent.owner as string | undefined}
                     version={agent.version as string | undefined}

--- a/web/src/pages/registry/leaderboard.tsx
+++ b/web/src/pages/registry/leaderboard.tsx
@@ -17,6 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layouts/page-header";
+import { RegistryName } from "@/components/registry/registry-name";
 import { TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { EmptyState } from "@/components/shared/empty-state";
 import { useLeaderboard, useComponentLeaderboard } from "@/hooks/use-api";
@@ -209,13 +210,16 @@ export default function LeaderboardPage() {
                           {i + 1}
                         </span>
                         <div className="flex-1 min-w-0">
-                          <span className="text-sm font-medium truncate block group-hover:underline underline-offset-4">
-                            {item.name}
-                          </span>
-                          <span className="text-xs text-muted-foreground/70 truncate block">
-                            {item.created_by_username ? `@${item.created_by_username}` : item.owner}
-                            {item.description && ` — ${item.description}`}
-                          </span>
+                          <RegistryName
+                            item={item}
+                            nameClassName="text-sm font-medium group-hover:underline underline-offset-4"
+                            handleClassName="text-xs text-muted-foreground/70"
+                          />
+                          {item.description && (
+                            <span className="text-xs text-muted-foreground/70 truncate block">
+                              {item.description}
+                            </span>
+                          )}
                         </div>
                         <span className="w-24 text-right inline-flex items-center justify-end gap-1 text-sm text-muted-foreground font-mono">
                           <ArrowDownToLine className="h-3 w-3" />

--- a/web/src/pages/user/account.tsx
+++ b/web/src/pages/user/account.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useCallback, useSyncExternalStore } from "react";
 import { useTheme } from "@/lib/theme";
-import { Check, Loader2 } from "lucide-react";
+import { AlertTriangle, Check, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import {
 	getUserName,
@@ -214,6 +214,12 @@ function ChangeUsernameSection() {
 		() => "",
 	);
 
+	// A username that is not a valid namespace predates namespace validation.
+	// Publishing rejects it, so surface why rather than letting them find out
+	// at submit time.
+	const namespaceInvalid =
+		!!currentUsername && !/^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/.test(currentUsername);
+
 	const handleSubmit = useCallback(async () => {
 		if (!newUsername.trim()) {
 			toast.error("Username cannot be empty");
@@ -270,6 +276,16 @@ function ChangeUsernameSection() {
 			</h3>
 			<Card>
 				<CardContent className="p-4 space-y-3">
+					{namespaceInvalid && (
+						<div className="flex items-start gap-2 rounded-md border border-dark-yellow/30 bg-light-yellow px-3 py-2 text-dark-yellow">
+							<AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+							<p className="text-xs">
+								<span className="font-medium">@{currentUsername}</span> cannot be used as a
+								registry namespace, so publishing agents and components is blocked. Choose a
+								valid username below — anything you already published moves with you.
+							</p>
+						</div>
+					)}
 					<div>
 						<label className="text-xs text-muted-foreground mb-1 block">
 							Current Username

--- a/web/src/pages/user/account.tsx
+++ b/web/src/pages/user/account.tsx
@@ -26,6 +26,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/layouts/page-header";
 import { AvatarEditable } from "@/components/account/avatar-upload";
+import { NAMESPACE_RULE_TEXT, isValidNamespace } from "@/lib/registry-name";
 
 // ── Theme definitions ──────────────────────────────────────────────────────
 // Swatches: [bg, accent, fg] in oklch — derived from globals.css
@@ -217,8 +218,7 @@ function ChangeUsernameSection() {
 	// A username that is not a valid namespace predates namespace validation.
 	// Publishing rejects it, so surface why rather than letting them find out
 	// at submit time.
-	const namespaceInvalid =
-		!!currentUsername && !/^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/.test(currentUsername);
+	const namespaceInvalid = !!currentUsername && !isValidNamespace(currentUsername);
 
 	const handleSubmit = useCallback(async () => {
 		if (!newUsername.trim()) {
@@ -233,10 +233,8 @@ function ChangeUsernameSection() {
 			toast.error("Username must be at most 32 characters");
 			return;
 		}
-		if (!/^[a-z0-9][a-z0-9\-]{1,30}[a-z0-9]$/.test(newUsername)) {
-			toast.error(
-				"Username must be lowercase alphanumeric with hyphens (3-32 chars, start/end with alphanumeric)",
-			);
+		if (!isValidNamespace(newUsername)) {
+			toast.error(NAMESPACE_RULE_TEXT);
 			return;
 		}
 		if (newUsername === currentUsername) {
@@ -306,15 +304,12 @@ function ChangeUsernameSection() {
 							value={newUsername}
 							onChange={(e) => setNewUsername(e.target.value.toLowerCase())}
 							className="h-8 text-sm"
-							placeholder="3-32 chars, lowercase alphanumeric + hyphens"
+							placeholder="3-32 chars, lowercase alphanumeric + hyphens/dots"
 							onKeyDown={(e) => {
 								if (e.key === "Enter") handleSubmit();
 							}}
 						/>
-						<p className="text-xs text-muted-foreground mt-1.5">
-							Must be 3-32 characters, lowercase alphanumeric and hyphens only.
-							Must start and end with alphanumeric.
-						</p>
+						<p className="text-xs text-muted-foreground mt-1.5">{NAMESPACE_RULE_TEXT}.</p>
 					</div>
 					<Button
 						size="sm"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

1. Registry identities rendered as raw `namespace/slug` everywhere, so listings read as `lokeshselvam7025/task-creator`. Hard to scan.
2. A username that isn't a valid namespace could never publish (`namespace_for_user()` rejects it) *and* could never be changed (`user_has_listings()` counts soft-deleted agents). Permanent deadlock, with no way out short of deleting the account.


## Approach

**Display** bare name on the first line, owning namespace beneath it as `@handle` in a smaller muted font.

- Web: `registryIdentity()` + a shared `<RegistryName>`, used by agent/component cards, both index tables, both detail headers, the leaderboard, and home dashboard rows.
- CLI: `name_block()` for table cells (two lines), `name_inline()` for panel titles and `--output plain`.
- Copy-pasteable commands are untouched  install/pull commands, the reference resolver, and `client.canonical_name()` still emit canonical `namespace/slug`.

**Dots**  permitted in namespaces, so handles predating namespace validation stay usable. No migration needed: the charset was only ever enforced in Python. There are no CHECK constraints on any identity table and the columns are plain `varchar(32)` 
Postgres already accepted dots, which is how these handles got in.

- The rule lived in four places that had to agree; now one Python home in `observal_shared.namespace_rules`, imported by both the server validator and the CLI pre-check. Web mirrors it in `registry-name.ts`.
- Consecutive dots stay rejected  a namespace reaches local install names and harness config keys.
- Dots are flattened out of local install names, matching how `lockfile.local_registry_name` already flattens the registry hostname. Flattening lets `a.b` and `a-b` collapse onto one qualifier, so the server-side builder now keeps collided names distinct.

**Publish lock** unchanged for valid usernames (`test_username_change_is_blocked_after_publish` passes untouched). It's lifted only for usernames that could never publish; their listings move namespace with the rename. Namespace mutation isn't new: `transfer_entity_owner()` already reassigns namespaces and `lockfile_reconcile` already syncs clients.

## How Has This Been Tested?

Against a local Docker stack (`make rebuild`, API + web + db + clickhouse + redis healthy).

- CLI: 64 passed. Verified every list surface (agents + all five component types), detail panels, `--output plain`, and that `registry mcp show super/obsv-test-echo` still resolves by the canonical slash form.
- Server: 348 passed. 26 pre-existing failures (`KeyManager not initialized`) confirmed identical on `origin/main` in a scratch worktree.
- Dot handling verified in the running API container: dotted handle accepted, case normalised, `..` / leading dot / trailing dot / space rejected, hyphen handles unaffected.
- `pnpm typecheck`, `pnpm lint`, `ruff check`, `ruff format --check` all clean.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

- [x] Yes (Please Specify the tool): Claude Code
- [x] Was the generated code manually reviewed and tested?

<img width="2472" height="410" alt="1" src="https://github.com/user-attachments/assets/671611a2-dc4f-4996-aa5a-5752e5318622" />


<img width="2340" height="1294" alt="2" src="https://github.com/user-attachments/assets/de1d345e-24d7-4410-8fbb-7ba9f68e405f" />


<img width="2338" height="1292" alt="3" src="https://github.com/user-attachments/assets/44444a92-fcf0-46bf-8558-7eef1447bdde" />


<img width="2342" height="1290" alt="image" src="https://github.com/user-attachments/assets/71f41ed9-acd1-4dd5-a0c3-74ed453ea278" />

<img width="2492" height="446" alt="image" src="https://github.com/user-attachments/assets/e0e07ae0-f731-447d-8103-ca0ec632ea73" />


