### PR TITLE
fix(actions): skip GHCR badge workflow in forks

### DIFF
--- a/.github/workflows/badge-ghcr-pulls.yml
+++ b/.github/workflows/badge-ghcr-pulls.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 Faatih <22oo1cso41faatih@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 # Fetches combined GHCR pull counts for observal-api and observal-web by
@@ -26,6 +27,7 @@ permissions: {}
 jobs:
   update:
     name: Fetch counts and update Gist
+    if: github.repository == 'Observal/Observal'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Purpose / Description

Fixes the GHCR pulls badge workflow failing when executed from repository forks.

The workflow currently scrapes hardcoded GHCR package pages from the canonical `Observal/Observal` repository and updates an upstream-only Gist. When triggered from a fork, these upstream-only resources can cause the workflow to fail with a `404 Not Found` error.

## Fixes

Fixes #1611

## Approach

Added a repository guard to the `update` job in
`.github/workflows/badge-ghcr-pulls.yml`:

```yaml
if: github.repository == 'Observal/Observal'
```

This ensures that the GHCR pulls badge workflow only runs in the canonical upstream repository and is skipped in forks.

This is intentionally a minimal one-line code change. The existing GHCR scraping and Gist update logic remains unchanged.

## How Has This Been Tested?

Verified manually that the repository guard is applied at the job level, causing the complete badge update job to be skipped when the workflow runs in a fork.

No other workflow logic was modified.

## Checklist

Please, go through these checks before submitting the PR.

- [x] Descriptive Commit Message
- [x]  Tests Run for affected areas
- [x]  Self-review completed
- [x]  UI changes: N/A (workflow-only change)

## AI Assistance

Was generative AI tooling used to co-author this PR?

- [x] Yes (Please Specify the tool): ChatGPT (OpenAI GPT-5.5)
- [x]  Was the generated code manually reviewed and tested?