### PR TITLE
ci(cla): migrate from CLA Assistant hosted to lite GitHub Action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://gist.github.com/Haz3-jolt/c8f990d62dbf2a67359e75848ae79290'
+          branch: 'main'
+          allowlist: 'renovate[bot],dependabot[bot],github-actions[bot],bot*'
+          lock-pullrequest-aftermerge: true

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,0 +1,508 @@
+{
+  "signedContributors": [
+    {
+      "name": "0xSHSH",
+      "id": 156781261,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-15T05:55:34.596Z",
+      "repoId": ""
+    },
+    {
+      "name": "Abfa41",
+      "id": 157041964,
+      "pullRequestNo": 0,
+      "created_at": "2026-07-02T01:26:42.978Z",
+      "repoId": ""
+    },
+    {
+      "name": "abir2907",
+      "id": 111883606,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-10T13:26:14.881Z",
+      "repoId": ""
+    },
+    {
+      "name": "adityaraut649",
+      "id": 95859957,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-06T15:12:13.113Z",
+      "repoId": ""
+    },
+    {
+      "name": "Ai-chan-0411",
+      "id": 275152799,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-27T10:01:47.281Z",
+      "repoId": ""
+    },
+    {
+      "name": "amh1k",
+      "id": 175481884,
+      "pullRequestNo": 0,
+      "created_at": "2026-07-24T16:28:46.964Z",
+      "repoId": ""
+    },
+    {
+      "name": "aminehd",
+      "id": 43146526,
+      "pullRequestNo": 0,
+      "created_at": "2026-07-19T23:24:19.808Z",
+      "repoId": ""
+    },
+    {
+      "name": "amogh-dongre",
+      "id": 76813462,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-31T12:07:56.822Z",
+      "repoId": ""
+    },
+    {
+      "name": "anniechiang-yn",
+      "id": 268522201,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-11T10:06:07.608Z",
+      "repoId": ""
+    },
+    {
+      "name": "AnuGuin",
+      "id": 141846655,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-28T12:55:59.127Z",
+      "repoId": ""
+    },
+    {
+      "name": "AnupamKumar-1",
+      "id": 127655166,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-06T17:12:49.138Z",
+      "repoId": ""
+    },
+    {
+      "name": "Apoorvgarg-creator",
+      "id": 57873504,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-16T22:39:32.824Z",
+      "repoId": ""
+    },
+    {
+      "name": "aryaniyaps",
+      "id": 69184573,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-11T06:04:31.664Z",
+      "repoId": ""
+    },
+    {
+      "name": "BALLOON005",
+      "id": 215249647,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-06T07:41:33.997Z",
+      "repoId": ""
+    },
+    {
+      "name": "Berserk-hub150",
+      "id": 89993099,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-28T17:05:37.432Z",
+      "repoId": ""
+    },
+    {
+      "name": "BhavanaHadagal",
+      "id": 156443073,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-07T15:44:07.326Z",
+      "repoId": ""
+    },
+    {
+      "name": "Chandhini03",
+      "id": 196933400,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-26T12:08:23.134Z",
+      "repoId": ""
+    },
+    {
+      "name": "d-kavinraja",
+      "id": 119875375,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-18T13:57:34.063Z",
+      "repoId": ""
+    },
+    {
+      "name": "DEEPIKA-217M",
+      "id": 198882994,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-11T09:40:31.355Z",
+      "repoId": ""
+    },
+    {
+      "name": "DEVAANSH001",
+      "id": 147277492,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-27T12:14:08.754Z",
+      "repoId": ""
+    },
+    {
+      "name": "dexterhere-2k",
+      "id": 193331771,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-11T06:50:44.041Z",
+      "repoId": ""
+    },
+    {
+      "name": "dhanpraja231",
+      "id": 66559537,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-02T14:03:16.905Z",
+      "repoId": ""
+    },
+    {
+      "name": "DumbTempest",
+      "id": 180581699,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-13T12:42:12.542Z",
+      "repoId": ""
+    },
+    {
+      "name": "GodHad",
+      "id": 155072724,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-15T14:15:28.213Z",
+      "repoId": ""
+    },
+    {
+      "name": "gokul000410",
+      "id": 180684716,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-18T13:52:37.306Z",
+      "repoId": ""
+    },
+    {
+      "name": "harishankar0301",
+      "id": 54937238,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-19T07:24:31.699Z",
+      "repoId": ""
+    },
+    {
+      "name": "harshhhhd",
+      "id": 134729068,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-30T12:54:30.179Z",
+      "repoId": ""
+    },
+    {
+      "name": "Harshith1702",
+      "id": 190260990,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-18T19:14:08.722Z",
+      "repoId": ""
+    },
+    {
+      "name": "Haz3-jolt",
+      "id": 79502699,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-10T12:53:11.869Z",
+      "repoId": ""
+    },
+    {
+      "name": "HemalathaMadeswaran18",
+      "id": 68108417,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-16T10:25:45.220Z",
+      "repoId": ""
+    },
+    {
+      "name": "ign-ite",
+      "id": 67059001,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-06T17:51:24.274Z",
+      "repoId": ""
+    },
+    {
+      "name": "JARUS-5",
+      "id": 45332004,
+      "pullRequestNo": 0,
+      "created_at": "2026-07-01T18:55:33.433Z",
+      "repoId": ""
+    },
+    {
+      "name": "Joaquinriosheredia",
+      "id": 265845774,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-10T14:57:03.532Z",
+      "repoId": ""
+    },
+    {
+      "name": "KanakReshi",
+      "id": 126339409,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-07T10:49:16.533Z",
+      "repoId": ""
+    },
+    {
+      "name": "Kaushik-Kumar-CEG",
+      "id": 204324702,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-10T20:17:29.507Z",
+      "repoId": ""
+    },
+    {
+      "name": "kilqwe",
+      "id": 187292275,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-15T12:27:30.783Z",
+      "repoId": ""
+    },
+    {
+      "name": "Lokesh7025",
+      "id": 196922098,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-10T18:04:15.704Z",
+      "repoId": ""
+    },
+    {
+      "name": "Madhumidha-S",
+      "id": 89202890,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-14T19:26:24.129Z",
+      "repoId": ""
+    },
+    {
+      "name": "ManoharKonala",
+      "id": 171902363,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-25T06:20:44.284Z",
+      "repoId": ""
+    },
+    {
+      "name": "monica-r56",
+      "id": 138276052,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-24T14:07:10.057Z",
+      "repoId": ""
+    },
+    {
+      "name": "naraen-ram",
+      "id": 224116958,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-10T16:42:41.763Z",
+      "repoId": ""
+    },
+    {
+      "name": "Nav-Prak",
+      "id": 54226343,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-23T09:00:31.709Z",
+      "repoId": ""
+    },
+    {
+      "name": "Nithin-Bhargav-07",
+      "id": 145005640,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-24T12:28:01.552Z",
+      "repoId": ""
+    },
+    {
+      "name": "Nithin0620",
+      "id": 177396649,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-14T09:28:37.224Z",
+      "repoId": ""
+    },
+    {
+      "name": "OnePunchMonk",
+      "id": 119044997,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-23T16:36:44.514Z",
+      "repoId": ""
+    },
+    {
+      "name": "Preethi12106",
+      "id": 220234575,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-09T14:11:35.398Z",
+      "repoId": ""
+    },
+    {
+      "name": "Pyasma",
+      "id": 94688939,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-15T16:44:20.671Z",
+      "repoId": ""
+    },
+    {
+      "name": "Raghavhari",
+      "id": 100750885,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-09T17:12:37.894Z",
+      "repoId": ""
+    },
+    {
+      "name": "ravichopra0107",
+      "id": 56033256,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-27T13:56:09.356Z",
+      "repoId": ""
+    },
+    {
+      "name": "RishiiGamer2201",
+      "id": 148001782,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-18T15:31:36.585Z",
+      "repoId": ""
+    },
+    {
+      "name": "rithvik-p",
+      "id": 69391712,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-12T08:45:41.211Z",
+      "repoId": ""
+    },
+    {
+      "name": "riyacore404",
+      "id": 217973944,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-23T13:34:47.239Z",
+      "repoId": ""
+    },
+    {
+      "name": "Sampai28",
+      "id": 59393128,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-25T01:31:42.820Z",
+      "repoId": ""
+    },
+    {
+      "name": "sanatmehrotra",
+      "id": 141352985,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-02T21:56:28.276Z",
+      "repoId": ""
+    },
+    {
+      "name": "Sanjay-VK07",
+      "id": 181737073,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-13T05:26:15.661Z",
+      "repoId": ""
+    },
+    {
+      "name": "santhoshalpha",
+      "id": 100134551,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-27T10:43:47.913Z",
+      "repoId": ""
+    },
+    {
+      "name": "Satej-More",
+      "id": 200403706,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-12T09:50:59.859Z",
+      "repoId": ""
+    },
+    {
+      "name": "ShaanNarendran",
+      "id": 194644247,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-10T23:42:05.154Z",
+      "repoId": ""
+    },
+    {
+      "name": "shashwatkarna",
+      "id": 210532901,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-14T17:57:01.213Z",
+      "repoId": ""
+    },
+    {
+      "name": "Shaun-Solomon33",
+      "id": 193730036,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-29T17:35:14.956Z",
+      "repoId": ""
+    },
+    {
+      "name": "shreem26",
+      "id": 198778624,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-11T11:20:15.189Z",
+      "repoId": ""
+    },
+    {
+      "name": "shreyansh232",
+      "id": 87061814,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-30T08:08:24.873Z",
+      "repoId": ""
+    },
+    {
+      "name": "snoopuppy582",
+      "id": 202944707,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-12T17:27:34.378Z",
+      "repoId": ""
+    },
+    {
+      "name": "spandanareddib",
+      "id": 273537638,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-25T05:07:44.170Z",
+      "repoId": ""
+    },
+    {
+      "name": "SrihariLegend",
+      "id": 119381156,
+      "pullRequestNo": 0,
+      "created_at": "2026-07-27T17:57:27.131Z",
+      "repoId": ""
+    },
+    {
+      "name": "sujaan-iqbal",
+      "id": 174215778,
+      "pullRequestNo": 0,
+      "created_at": "2026-06-21T18:22:32.331Z",
+      "repoId": ""
+    },
+    {
+      "name": "swathisaravananan",
+      "id": 66671402,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-13T21:02:57.028Z",
+      "repoId": ""
+    },
+    {
+      "name": "tanvi-red",
+      "id": 217571089,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-17T06:10:35.375Z",
+      "repoId": ""
+    },
+    {
+      "name": "tsitu0",
+      "id": 138181396,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-18T19:39:18.303Z",
+      "repoId": ""
+    },
+    {
+      "name": "Varadraj75",
+      "id": 67114314,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-18T22:50:28.463Z",
+      "repoId": ""
+    },
+    {
+      "name": "VishnuM049",
+      "id": 232172870,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-11T02:33:50.550Z",
+      "repoId": ""
+    },
+    {
+      "name": "yash-gadgil",
+      "id": 102785510,
+      "pullRequestNo": 0,
+      "created_at": "2026-05-25T22:04:50.727Z",
+      "repoId": ""
+    }
+  ]
+}


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

Migrate the project's Contributor License Agreement enforcement off the hosted [cla-assistant.io](https://cla-assistant.io) service onto the self-contained [CLA Assistant GitHub Action](https://github.com/contributor-assistant/github-action) (the "lite" version). The hosted service stores signatures in a Cosmos DB we cannot write to, which made it impossible to record contributors who signed the CLA offline (by mail or in person) and cannot go through the GitHub OAuth flow. The lite Action stores signatures as a plain JSON file inside this repository, so offline signers can be recorded directly.

## Fixes

* Fixes #<!-- no tracking issue; infra migration -->

## Approach

- Add `.github/workflows/cla.yml` that runs `contributor-assistant/github-action@v2.6.1` on `pull_request_target` (opened, synchronize, closed) and on `issue_comment` (created). It uses the built-in `GITHUB_TOKEN`, so **no GitHub App install is required**.
- The CLA document remains the existing gist: https://gist.github.com/Haz3-jolt/c8f990d62dbf2a67359e75848ae79290
- Seed `signatures/version1/cla.json` with the 72 existing signers, matched by **GitHub numeric ID** (the field the Action actually checks against). This includes four offline/mail signers who could not sign through the hosted flow: `DEVAANSH001`, `Berserk-hub150`, `Ai-chan-0411`, `santhoshalpha`.
- Allowlist covers bots that cannot sign: `renovate[bot]`, `dependabot[bot]`, `github-actions[bot]`, plus the `bot*` wildcard.

Notable behavioral differences from the hosted service:

- The lite Action matches signers by GitHub ID only and **does not track the CLA document version**, so editing the gist no longer forces existing signers to re-sign.
- New signatures are appended to `signatures/version1/cla.json` by the Action via a commit on `main`. **`main` must permit pushes from `GITHUB_TOKEN`** (branch protection that blocks token pushes will break signature storage). If branch protection blocks this, move signatures to a dedicated unprotected branch or remote repo via the Action's `remote-*` inputs.

Follow-up required outside this PR:

1. Unlink the repo from cla-assistant.io (sign in there, remove the `Observal/Observal` link) so the old bot stops commenting on PRs.
2. If a CLA assistant GitHub App was installed on the org, revoke it under GitHub Settings → Applications.

## How Has This Been Tested?

- Verified the lite Action source (`contributor-assistant/github-action@v2.6.1`): signature matching is by `committer.databaseId` against `signedContributors[].id` in `cla.json`; no CLA version hash is stored, confirming the re-sign behavior changed.
- Validated the seeded `cla.json`: 72 entries, each with `name`, `id`, `pullRequestNo`, `created_at`, `repoId`. IDs resolved via `gh api users/<login>`.
- One signer (`GoesEduardo`) was dropped: account returns HTTP 404 (deleted) and has zero `git blame` lines in the repo, so no matching ID exists and no current contribution depends on them.
- E2E test to run after merge: open a throwaway PR from a seeded account, expect the check to pass; open one from an unseeded account, expect the sign-request comment.

## Learning (optional, can help others)

- Hosted cla-assistant.io FAQ confirms export-only, no import for human signers (bot allowlist is the only "import").
- The lite Action repo is archived (March 2026, maintainer stepped down) but existing tagged releases remain functional. Pinned to `v2.6.1`.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - N/A, no UI changes.

## AI Assistance

- [x] Yes (Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?
  - Workflow file reviewed against the Action's documented inputs; seed file validated structurally. Full runtime validation pending a real PR after merge.
