### PR TITLE
docs(readme): add CLA assistant badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   <a href="https://discord.gg/SFPjnTWddk"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FSFPjnTWddk%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&label=Discord&logo=discord&color=5865F2&style=flat-square" alt="Discord Server"></a>
   <a href="https://github.com/orgs/Observal/packages?repo_name=Observal"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Haz3-jolt/b28aba6d0efebb0b430d43c8068feb91/raw/ghcr-pulls.json&style=flat-square" alt="GHCR pulls"></a>
   <a href="https://artifacthub.io/packages/search?repo=observal"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/observal" alt="Artifact Hub"></a>
+  <a href="https://cla-assistant.io/Observal/Observal"><img src="https://cla-assistant.io/readme/badge/Observal/Observal" alt="CLA assistant" /></a>
 </p>
 
 > If you find Observal useful, please consider giving it a star. It helps others discover the project and keeps development going.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

Add the [CLA assistant](https://cla-assistant.io) badge to the README badge row so contributors can see the CLA status and reach the signing page directly from the repository.

## Fixes

* Fixes #<!-- no tracking issue -->

## Approach

- Insert the CLA assistant badge HTML after the Artifact Hub badge in the existing `<p>` badge block in `README.md`:
  ```html
  <a href="https://cla-assistant.io/Observal/Observal"><img src="https://cla-assistant.io/readme/badge/Observal/Observal" alt="CLA assistant" /></a>
  ```
- No other content touched; one line added inside the existing badge row.

## How Has This Been Tested?

- Verified the rendered README badge block locally: the new line sits inside the `<p>` block, after the Artifact Hub badge, before `</p>`.
- Badge URL form `https://cla-assistant.io/readme/badge/<owner>/<repo>` is the documented CLA assistant badge endpoint, and the link target `https://cla-assistant.io/Observal/Observal` is the project's CLA page.

## Learning (optional, can help others)

- CLA assistant exposes a per-repo badge at `https://cla-assistant.io/readme/badge/<owner>/<repo>` that reflects the current CLA signee status, intended to be embedded in the README.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - README-only change; the user will add a screenshot of the rendered badge row if needed.

## AI Assistance

- [x] Yes (Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?
  - Diff reviewed; badge placement verified against the existing README block.
