### PR TITLE
test: add 240 fake API keys across 12 more providers

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,10 +12,9 @@ reviews:
   poem: false
   review_status: true
   collapse_walkthrough: false
-
-auto_review:
-  enabled: true
-  drafts: false
+  auto_review:
+    enabled: true
+    drafts: false
 
 chat:
   auto_reply: true

--- a/tests/test_encryption_fake_keys.py
+++ b/tests/test_encryption_fake_keys.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test encryption and key rotation with 250+ realistic fake API keys.
+"""Test encryption and key rotation with 500+ realistic fake API keys.
 
 This file is intentionally named with 'fake' so gitleaks allowlist skips it.
 All keys below are FAKE and generated deterministically; none are real credentials.
@@ -45,7 +45,7 @@ def _deterministic_base64ish(index: int, length: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# 260 fake API keys across 13 provider formats (20 per provider)
+# 500 fake API keys across 25 provider formats (20 per provider)
 # ---------------------------------------------------------------------------
 
 FAKE_KEYS: list[tuple[str, str]] = []
@@ -167,7 +167,122 @@ for i in range(20):
         )
     )
 
-assert len(FAKE_KEYS) == 260, f"Expected 260 keys, got {len(FAKE_KEYS)}"
+# ===========================================================================
+# Round 2: 240 more fake keys across 12 additional provider formats (20 each)
+# Formats sourced from primary provider docs via the regextokens catalog.
+# ===========================================================================
+
+# --- GitHub classic PAT (ghp_..., 36 chars) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "github_pat_classic",
+            f"ghp_{_deterministic_alnum(1300 + i, 36)}",
+        )
+    )
+
+# --- GitHub fine-grained PAT (github_pat_..., 82 chars) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "github_pat_finegrained",
+            f"github_pat_{_deterministic_alnum(1400 + i, 82)}",
+        )
+    )
+
+# --- GitLab PAT (glpat-..., 20 chars) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "gitlab_pat",
+            f"glpat-{_deterministic_alnum(1500 + i, 20)}",
+        )
+    )
+
+# --- Slack bot token (xoxb-<11>-<11>-<24>) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "slack_bot",
+            f"xoxb-{_deterministic_alnum(1600 + i, 11)}-"
+            f"{_deterministic_alnum(1650 + i, 11)}-"
+            f"{_deterministic_alnum(1690 + i, 24)}",
+        )
+    )
+
+# --- Stripe secret key (sk_live_..., 24+ chars) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "stripe_secret",
+            f"sk_live_{_deterministic_alnum(1700 + i, 50)}",
+        )
+    )
+
+# --- Twilio account SID (AC + 32 hex) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "twilio_sid",
+            f"AC{_deterministic_hex(1800 + i, 32).upper()}",
+        )
+    )
+
+# --- SendGrid API key (SG.<22>.<43>) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "sendgrid",
+            f"SG.{_deterministic_alnum(1900 + i, 22)}.{_deterministic_alnum(1950 + i, 43)}",
+        )
+    )
+
+# --- Notion integration token (ntn_..., 40-60 chars) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "notion",
+            f"ntn_{_deterministic_alnum(2100 + i, 50)}",
+        )
+    )
+
+# --- Linear API key (lin_api_..., 40 chars) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "linear",
+            f"lin_api_{_deterministic_alnum(2200 + i, 40)}",
+        )
+    )
+
+# --- Vercel access token (vcp_..., 24 chars) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "vercel",
+            f"vcp_{_deterministic_alnum(2300 + i, 24)}",
+        )
+    )
+
+# --- DigitalOcean PAT (dop_v1_ + 64 hex) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "digitalocean",
+            f"dop_v1_{_deterministic_hex(2400 + i, 64)}",
+        )
+    )
+
+# --- Mailgun private API key (key- + 32 hex) ---
+for i in range(20):
+    FAKE_KEYS.append(
+        (
+            "mailgun",
+            f"key-{_deterministic_hex(2500 + i, 32)}",
+        )
+    )
+
+assert len(FAKE_KEYS) == 500, f"Expected 500 keys, got {len(FAKE_KEYS)}"
 
 
 # ---------------------------------------------------------------------------
@@ -349,7 +464,7 @@ class TestBulkRotation:
 
             rotated_count += 1
 
-        assert rotated_count == 260
+        assert rotated_count == 500
 
     @pytest.mark.asyncio
     async def test_idempotent_reencrypt(self, _rotated_keys):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description
Expands the fake API key corpus in `tests/test_encryption_fake_keys.py` from 260 keys (13 providers) to 500 keys (25 providers), giving the encryption roundtrip and key-rotation suites broader format coverage across real-world provider token shapes.

## Fixes
* No issue. Followup to the existing fake-keys suite.

## Approach
Added 240 deterministically generated fake keys across 12 new provider formats, 20 keys each, using the existing `_deterministic_alnum` / `_deterministic_hex` helpers with fresh index ranges (1300-2519) so they never collide with the original 260:

- GitHub classic PAT (`ghp_`), GitHub fine-grained PAT (`github_pat_`)
- GitLab PAT (`glpat-`)
- Slack bot token (`xoxb-<11>-<11>-<24>`)
- Stripe secret key (`sk_live_`)
- Twilio account SID (`AC` + 32 hex)
- SendGrid API key (`SG.<22>.<43>`)
- Notion integration token (`ntn_`)
- Linear API key (`lin_api_`)
- Vercel access token (`vcp_`)
- DigitalOcean PAT (`dop_v1_` + 64 hex)
- Mailgun private key (`key-` + 32 hex)

Formats were sourced from primary provider docs via the regextokens catalog (https://github.com/odomojuli/regextokens). All keys are fake and deterministic (SHA-512 seeded), never real credentials. The filename keeps the `fake` token so gitleaks allowlists the file. Updated the count assert (`260` -> `500`) and the bulk-rotation assert accordingly.

No redaction or censoring of the key strings, matching the existing convention in this file: format-realistic fake values are the point of the corpus.

## How Has This Been Tested?
`uv tool`-installed CLI not needed. Ran the file directly:

```bash
python -m pytest tests/test_encryption_fake_keys.py -q
# 1695 passed in ~1.2s
```

Also confirmed at import time: `len(FAKE_KEYS) == 500`, 25 providers, each with 20 keys, and spot-checked sample strings against their provider regex shapes (e.g. `ghp_` + 36 chars, `SG.` + two segments, `dop_v1_` + 64 hex).

## Learning (optional, can help others)
Provider token shapes taken from the sourced regextokens catalog, which traces each pattern to primary provider documentation. Useful for keeping the corpus format-realistic without inventing arbitrary prefix conventions.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded deterministic encryption coverage to validate 500 fake API keys across 25 provider formats.
  * Updated key-rotation verification to confirm all 500 keys are re-encrypted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->