### PR TITLE
test: static fake API keys fixture with regenerator

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Secret scanning exclusions.
+# See https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files
+#
+# The following paths contain ONLY deterministically-generated FAKE credentials
+# (SHA-512 off a fixed seed) used by the encryption test suite. None are real.
+# Excluded so push protection does not block the fixture and its regenerator.
+paths-ignore:
+  - "tests/fixtures/fake_api_keys.json"
+  - "tests/fixtures/generate_fake_keys.py"
+  - "tests/test_encryption_fake_keys.py"

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "email-validator",
     "alembic",
     "httpx",
-    "gitpython>=3.1.51",
+    "gitpython>=3.1.55",
     "boto3",
     "litellm>=1.80.0,<1.90.0",
     "redis[hiredis]>=5.0",

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -839,14 +839,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.54"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/d5/3da0b92033887033f4c27f2dd109a303c4ca62813c7b3bb2511edb4777de/gitpython-3.1.54.tar.gz", hash = "sha256:53f2085e24a2cda300eed7c3fc5f1559ae289634b725e98acaf4791940247aa0", size = 225076, upload-time = "2026-07-22T04:08:51.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b9/876f442a28df5c068ca69b0122d5c35e65fd2d2fa9992ea5cb5944ea00a6/gitpython-3.1.54-py3-none-any.whl", hash = "sha256:b90d7b3d9bc0238681d24369130826f0dcdb0ceaa45db67cf1d4ffa4c302dedf", size = 216575, upload-time = "2026-07-22T04:08:50.05Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]
@@ -1750,7 +1750,7 @@ requires-dist = [
     { name = "email-validator" },
     { name = "fastapi", specifier = ">=0.136.0,!=0.136.3" },
     { name = "fastapi-cache2", specifier = ">=0.2.2" },
-    { name = "gitpython", specifier = ">=3.1.51" },
+    { name = "gitpython", specifier = ">=3.1.55" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },

--- a/tests/fixtures/fake_api_keys.json
+++ b/tests/fixtures/fake_api_keys.json
@@ -1,0 +1,2002 @@
+[
+  {
+    "provider": "openai",
+    "key": "sk-4BhS07qso9pVhcsmtU3tyK8zkSbrFKgre4rHtDCWem7VZKYk"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-zxsbug9Wgd0AzMaeBncjVqo3lXoGTLR30rF9Gupjqoj0cj2S"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-eN5jbcB6R75q8QuJm8IF5s9hBeb5dW6aOaflde8njrrWu1f6"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-ULQyOIV8ZbWQG7VOgAcVRpl9PnYPFf01Is1ZiIszB28cEFjt"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-4VRealSEVD69u5AqKOTauzjTdwZBzUSPA8R6KnMRhH75LMmE"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-nn1mjrPc2x6LaE4Od2pWVHytJQxktuLUysX0maPb8DEPPGMK"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-RvCsNgCyHnVQnuXLTzXTTE9gpoWh2gv60aulBSQxuzmrnk3y"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-F9dguLROMp6jhhVUbkoy7EMzVlvz9hAcmnlziOR80ukmVqY2"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-ew7omBzu0lRy7Z5dAVSFVdQgEmxKOIvCkXPF0b7XgH2HcftD"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-bWUdpmLTRZCC4jf4rUxpKePLJ5sz2k08raSszC11o4jO9pbA"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-hfT9qn9hemhApwvpP5ySU8E3cfnP8LVL5X7cxGVmwmvyK1nG"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-odw7hZsQJt632TrHlTwny9HHz1atQhaMJZxbarPXbU1nQjy6"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-60czOfuYPbSc53KhfFhybWEhmeWdYheWRgWoogehGAqqae9b"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-ONKctd2yKI62Z23bSan1c2e3Bb706X0zodQcBT9htKhUz9cM"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-hB4MBU7ObePiMhJ7E5Gi9qv7hGgfsdt66p8XNfM2lbDXMaiJ"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-8dcdPCjJHgLmqxnd0XPSpoh6ClT50veXbbAPDxajWmEmg2a1"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-tYTnBjlwurNWSqyeS6MywvfdK1ANxgLMH2drCusMU0ks8Cxw"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-BTY75D8UtkxieROrEXOaXcScJQV4HG85W0dT2NMf38hUtM6q"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-7tv700xNlNGjKfXoomHkohyEt6i7XfPDmxsDQzou3vE3ykE8"
+  },
+  {
+    "provider": "openai",
+    "key": "sk-CA7nMnDziD1F3xmFwiKvekK0L6h758Wyv7YUWtpVaqmAxefC"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-jCyuz1nNVPMM1gmT9TUm05UubeliVtOnMDYPz7X9xYnv"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-tkDwL8FsqPDl8hcUitoOocAJfSCefr5TgC2QVSdFkW5u"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-UAu94dKFNE98LDhgOTYKaECrDW7oNoWuPf56qfHAQ0mW"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-z5ZwVQkOJFjrI3Go3zcpuYOzStohA73a4vRMRRWTsBlr"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-ZviPu12fEAaIccWwArhNxUxJmqr3o8hbwiEzG8BeGeuN"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-IyUnWy40gJ7jYa5nKmk50cJ6GMeDGcSfpGXYYpBrrNLS"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-ZHRpOmlvbL6x795tRcaPae7Hjwvb1pyMrs68MG4vTvdk"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-FIlXTHdScg2TbT496rwJHPNw9xdp177M2U8q9GgZgJ1a"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-TfTbeXdwpz4wMVRODQazx2tcclXZ00udQ12mnzXug1WB"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-5dCgdzcgYG61X9CmpFUeI3e7FC4yaRaIcXfGio6RyBGh"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-ePcqj0aqC3jOzC4W40eiKkfy72GTkKvX7uXxI3N0M8sG"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-eJkreEA0xcAgTudb28vYtS1vacZWgNjQPSz2jaIFGVhz"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-hfvRyLw8oWwco5fj5QNkhlQqprEVE12donTODPlaissp"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-YVkMfIWn2PT3fimFZd0XeJDfVhxqyG1gkNaMpg3V2fLn"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-PPehLXpWp35ZpTa3QKTMowuXkrCyKjTLXfWeCWxq0V5o"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-EaHKDzWtnnMswHb0Kn56VtrFrPIcMLphbbV0mOeynGyo"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-9AzjEY4aszCdJtDeZmNKjn5mKBLix4P2TSaaxZMnZdY4"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-OIHWfSu7vN4JenOcocr5YFm1LYtkNwUegt3TEj9qh5Pn"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-zoHEcjV9FdzYl2wKezKkJTTjxIu3ffyVNv3vpgHw2YAf"
+  },
+  {
+    "provider": "openai_project",
+    "key": "sk-proj-BvEf8o3YA30pwIECkVGwc9KWiqXcazyD3h5OllzJNwau"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-dkJ8wzRNEXdVCLbsndddk30WPGtOvBMEROo48Ax36Sic7YxGXc2/Kcvyf2rmh2qAERYGepoXN19+GQ5I"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-mlAWd4Inm/N4Kacl4McriB8ig8RvT8aToP3lgUB3EwGphl+Q1mUGy7UiQfcHC/ugDekx+XUKA3dExmzq"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-/gU7G3Ph7az8AtROpLR4vakjkDk91Mhp96SdIp725j1vcnnsYGEcdYJ8hyld7wKfG6SnHmM1hR4OZy0X"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-c/nCi7AZopM9tm9jwshZhy2vjKujj2J1iwT14V4AoP7YZaP8zZ6pgt5UuZwGoXB3lV7spVL5UuDXXBO0"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-M+kwNqRyQrk6mTEZGs0J0G5SdGaVREJVTRrZc1ON/vcPKbZ2zbwdLFwt/lnVnfuStDph5RYas5sEzGM1"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-bnYd8vjdePkKz1+rinS+Qp4xmaphmiN1Tx4uJHl4DGE31bITHyKvLfQLLRSrDYZSy/7B5vGbYTHypytl"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-7SARIFZk+suKMgIYc8LYyGF8PQadcnurMMSCcaCFTSP10Zsmv7lddvBXOzZqQXqKjfAaANluPMiRAaO4"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-HHQD51vIguP0VgiwqRmz2+1/Uvhpou5uBUAyYbaA+KyXizzSYRINj9N5fjgDqV+fQiGSy9+kujQPqvmw"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-nAxMs6Hm8B8HW2+S008hg5QHdfBbxrmD0VSBbvF0nPw4ZfSKJWnce7ZZOUEuBiTTnDgxqgULngMbS5vf"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-TsAk+6j5ySLRQOQidL8zsddVt6khOv0cI19UvqN/2+NohffYoTVjBOWjSQNqNWygf/BbLNKDlJ8HBuS9"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-9Xuma33N7wDK/+DE2ViB16FFMeP8e/EYvLpVcP9lTughgYO2h9Zz3jfzdX73YWU8oPiGVNwFdTXTunvJ"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-igBhT9UOOf6qlGe+7sUx3LCdMAuNvxbAK01scsIXSVZmsBA8S2IeC3VkLKQsVnKr5e1XsEpJ+B7r0JKA"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-W6fwaPoB6FcEQ5n8rzRf3ij3oSg+/pBadFrNg1G7LQCS8V8jJDQ5GAMkiYYz3v91Hj+/czFeHgs4YOT3"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-s/8o6QhwuL6TjrdYLzvnUWnHqW6IIatd0eCqA5SXR/Ji04PKDD1HjLwnPdNRqiHmzCAsWYum6UUA1+6w"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-uOsKpba1fGujzTWJ9khqscs8bhVjxclJ2A8FGE6BDJzBK/PG+gUYcHCTaM1t522Pt9XETYQvpGIdvZI1"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-GKB1wbrsHvnuDBvXw41NLigzRptRpOpXAxHX8rz8ypGhFDWk44xKClYkJ7o6B7U3S1AzI+8jsgRhAcl+"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-fMDXTQVGVOqiQNp4LIvz8/9H/SbFG7tSJRSR/t3uBqClsZK2DKSK8+WNIpRMUgZBptkDVlsMXuq+KEnE"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-On5Em2QZj8BOb+p8J/D71M/wPWVLwm+vQCBsHaz50+rv9zDJUVTrGfS5fRatH0KekvrB+xF4ACyl2Kb7"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-W1cQmr97CTALGX0BdTM7RZPfCA/DODSSj07KhdtMqEwEr7YkxlGIaSs7wciOMvjjeathkTCpRtXBGAQe"
+  },
+  {
+    "provider": "anthropic",
+    "key": "sk-ant-api03-9dWiIb1ugrz8oGqDF+WkgQ5Nt+4hR8bHKTSTE6E0s9OdcvFfTZr+0T4n/wVOsXV7K2C081Df5thafADJ"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "openrouter",
+    "key": "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"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIza92LHcIEZ9zrqvs6hPVspis0peUrWmZPzwGv"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzayLqM7Tsl65YcVMABdHZ2OBCbcbxZnwJVMLX"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzadxdd3PoqkkjO1JwbAD0fQaMOW1HwiOZ4XDh"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIza2lAzVPUUlzJRgdrJ69mYvyKqa4l9dZEagMx"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaisN455syxwZuS6rkeUru0Tje103146YX8Xw"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzabcunQ5EiQlyiNG0NFBFyCf4aCtFR68dPSlj"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIza0bwAmdBPMP4tDfHoEarHbCOhEqBuf06IVcm"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaegf7Ecd0WIy2Ffdn9HLBM87facuORZq71Tw"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzawermTfydWuarWKCYFlaEGvN9mi8HuYDf5Y5"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaTO9VY7c9gMgZlgaOZxbaxJMsoy5keYEGheG"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaTf5AgwTJhFee0Se1cJtNmDu2YSIup6osrKy"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaRKZaueQtGM5dEGkLeWad25jC0JYm2shF488"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaFOYghatctSewbV3xmryZqLXXV5KjysuX1Bj"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzazP8HwjQnOVq34r6Lp1o7sZ4UP6fADWIdllc"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIza1ahl6dWpjxLawET5PD56KvqmDGNauKxHh5h"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaqH2WH9N95AwVu5ezExujWFTBWDhb7gqoCmr"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaEFGzVeeOkC8iBThvxtrFtMAYaIMlVOQPLZH"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzaQG3uCqIBBgj6neNTAXsvxJubmSZs186sjgX"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIzack8wYUSoYWFN7IHSPvEXH7cNHqpZEFxJLMe"
+  },
+  {
+    "provider": "google_ai",
+    "key": "AIza1xgJa1j1wN7c9z6piYqGrFvEUKa2zHyJVWV"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAGYU5LWFINXEDEE0Y"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAIMKKFJVESTHV2KNO"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAJLE6KGCCXFSEYAAR"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAHYCLP7ZHIWJONKUF"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAEEUCYQR742HBXPZP"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAWGRZJGH59HXREOLM"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIABQIONVYH7RJKEXE0"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAWGJ8T0TEA167AJNZ"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAGXIUK7SFPLJACFSU"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIASIAOOFC44DKPWE7R"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAHQYAXHTPXJZPDJUW"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAXKQ7PSHFTUJDV4FB"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAU5MPJXWFDN2AQLNB"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAA9ZELU8YIG5ENFLV"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAO1RMKMA0LIMATQKL"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAG0A8UQL1PYJTOXXF"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAT8MTS4O8PGI0NKWD"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIA9TNIBDFM6QEDMTEU"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAYVZ4AIKDTMP5M0AP"
+  },
+  {
+    "provider": "aws_access_key",
+    "key": "AKIAFZROQE2VBYF8HMQB"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "sHXJnr3LxLE1QqtRy423JWUTsKiw40iY1GtfpoqO"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "wYfSOpmW5Xjy3EwBJS8ko+sSdEy4m0k3URcwYBTr"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "MWr5AnzNJjwjcy/Mk9BitVDpjZ+Iy6RmeWqKvZiB"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "yjAqu85Bg1TC1RThx+6+4HgBip0pdtA+UBdhArGU"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "Y92ZlqeumkK5xlTtU8+1RUtyPJrmn6AhvnSqDoFP"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "rgiS+8H7RsQBNA3a5F4yenn6PdeFowLzKWihdFwf"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "UL7S42Sw7zS9RlTSMS7POtjvQFLlArDuIDj1N/V7"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "gar15B9ISE7heQxMDmr2os6VP7sbnaRHuOyXne1n"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "o2RquQvdPvD3seIBdruWhfnIOURI5XjIBFkGxgMY"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "WEXwESIYy1OSwqbPoWPbJIAuTqBuqHG9qJeWi5ID"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "hFD12dvYdXxxi85sIvRK/ERt/h5CwSCDcTkYSoKT"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "ZKwKdNnDueGVHYJbCZNQN47jhZeDo5CPiEENeLfH"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "OyoUQWggiBcxZ1M1Qt8Aj9sFcUGQ5XWjz0aL0mow"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "jTlGF13wTFfA1VxXVA2FDo4w3ah0OlTdh3PI804s"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "+bE/iTa9Wx+rQc1ROcZU7gjLnGg9hpjMh+nlmp8G"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "E7fxVOyIBl9ubvOpGmh5aS0m4mXTfXlqCZC2sEYt"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "lbdx5+oDuLv8aLx0Qk+CNFGJwC8bQsfTI1OtZp6i"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "AR/c4RkYN0GfKM7hGrSfkQtG3pgnl/Tz3nGVNzAp"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "P0ZNU7jernHXIfaU5UhC2DDYOie6Q9E4ztQPmHlJ"
+  },
+  {
+    "provider": "aws_secret_key",
+    "key": "Hy1YtQLXESEWhwNKbFSQCsEkPgo0joeshp3vmwuW"
+  },
+  {
+    "provider": "cohere",
+    "key": "PEVszt5DlnP8Kc5JubGQg6sPaRMV29GPTB1oKRFb"
+  },
+  {
+    "provider": "cohere",
+    "key": "e8yijTK4O8vhL7CQHXivcCCCyERdv3TxrbOtwOce"
+  },
+  {
+    "provider": "cohere",
+    "key": "cWHKOpAjWmTFtbHscysgzkj02VBaeLobBzXB8cFL"
+  },
+  {
+    "provider": "cohere",
+    "key": "8Fpu2plANQm41koaPRqENgPl4MNf3DhuIHGHaMf3"
+  },
+  {
+    "provider": "cohere",
+    "key": "RR2KHCuuhw8wtiMRhXnhnAwu8tYr7hjYoHsNL3dh"
+  },
+  {
+    "provider": "cohere",
+    "key": "utTuQTB1VQQz80kN5gNZSui5QfJTcXJUL67s8nmR"
+  },
+  {
+    "provider": "cohere",
+    "key": "CLSThOhbDNEQocvu0itfykRlpDYof40f7o9pfKVL"
+  },
+  {
+    "provider": "cohere",
+    "key": "kOfKAXUtAVAfT1tu8Q2SvyYEZQjXN6NDKRTwrOmx"
+  },
+  {
+    "provider": "cohere",
+    "key": "D1mjPVWqR7GfcaDAuUz7Nds9iOBrNRgjH4Qx3msP"
+  },
+  {
+    "provider": "cohere",
+    "key": "WpMV1C71e3TbXkNdQg3jHPdidbDIQeYp0MldR25I"
+  },
+  {
+    "provider": "cohere",
+    "key": "p9vnfu9tHNrKEHTm4s3fwJnTMUSqnDNwMVb8kPuZ"
+  },
+  {
+    "provider": "cohere",
+    "key": "DGc57hCcozsNt678gSXO5bXlMOjnFcnhBKSTLKWH"
+  },
+  {
+    "provider": "cohere",
+    "key": "0GXXMcoLvet2I2ZLH1Jp3TmvAZoJpzrTNT623LHQ"
+  },
+  {
+    "provider": "cohere",
+    "key": "t8dCbzsbbw33qwshdF49oXkXAGGxbDfEfYa9EoRW"
+  },
+  {
+    "provider": "cohere",
+    "key": "8itUZYjBJmelbrc1upddsg0mhOTcuvhvOv9o6rHv"
+  },
+  {
+    "provider": "cohere",
+    "key": "pIGWHd2ujfHoNcxHpeHwKg18FKKsxZHWu6VBubi9"
+  },
+  {
+    "provider": "cohere",
+    "key": "vDfNBTvpONWlbWMq3nVNuznl2htG08OAkaRjmiBe"
+  },
+  {
+    "provider": "cohere",
+    "key": "wViY4RUhZelA7LB8qKrZP9ii8cwxesUcmvP3B7D8"
+  },
+  {
+    "provider": "cohere",
+    "key": "TAMAmcNmlrNXu6jWf8LHuPyDVbzJ4KGSJyNdlEoY"
+  },
+  {
+    "provider": "cohere",
+    "key": "JIqIAR3HKmX7uwfpblRmvfVrI5HTtgm0TQZwIMhL"
+  },
+  {
+    "provider": "mistral",
+    "key": "kJhWAXqZc7oShebVN5qi6e5wM6Rmbigd1lfE0ZX7W09OUZUK"
+  },
+  {
+    "provider": "mistral",
+    "key": "qNjQE7naIdQLWJfQcs1U3gGzDFzztolhPCcnyci4GrSkmg69"
+  },
+  {
+    "provider": "mistral",
+    "key": "iIVSP6YcCdJtQ9eAUcOMADj7TmkN7LXehrVvMlaZbAUl0Iyi"
+  },
+  {
+    "provider": "mistral",
+    "key": "mnhpCrW8KqrhWERcWMLqVwqtVr2VdhHc6fHZa60Su14Ozaav"
+  },
+  {
+    "provider": "mistral",
+    "key": "kcEXT1DH29SMXbRy84m5zw34tuna9sspY0Sh0GdgEgGL71Nf"
+  },
+  {
+    "provider": "mistral",
+    "key": "OSEoBLxUyHrkap7tyIIgDejgTa2je3oLyncnGOC4pHaIdLzS"
+  },
+  {
+    "provider": "mistral",
+    "key": "ZjUgK659XbhbbRzoQnNHgAwmg4TtNtJReBCOpH6lJzHXPUEu"
+  },
+  {
+    "provider": "mistral",
+    "key": "V0BgF2kYcd2k4skrVgwAoQZS1eaHl8NNqiro3Zyz7oAmbxvf"
+  },
+  {
+    "provider": "mistral",
+    "key": "UosC6KXlcwtL5ddf7ivYg3N2o8nAUcafYbfLwoVByCUXeAzv"
+  },
+  {
+    "provider": "mistral",
+    "key": "PK5aMXEZkGlShfOL5Ecmz0LwGk9qha5DbdQJ9KtHcALx4xB5"
+  },
+  {
+    "provider": "mistral",
+    "key": "7zwIzn3TtbGSZyPuRzcbjqqWRfhCzOitWkPfPvtUx0Iwq1A1"
+  },
+  {
+    "provider": "mistral",
+    "key": "G2tBDsNE6Z6w7DPKRtlO1AnvGV86Q3QpqXDd3wshpuQF7fuS"
+  },
+  {
+    "provider": "mistral",
+    "key": "2zFT8Rx1h26ViND9nNp3eu0oUOh5sJuMewCeGXDgDO8Wn9u7"
+  },
+  {
+    "provider": "mistral",
+    "key": "dnEulQGFHupOnYfu0GyXTblfWgYckMXUbPWX0N94TWAEJHXA"
+  },
+  {
+    "provider": "mistral",
+    "key": "E5IQYkIaQiQiwYofkgw4EaqmmxA1OISPMg3bjeCscmwrcfgp"
+  },
+  {
+    "provider": "mistral",
+    "key": "OcKgIrLQducrBY0a39xp0DBiN7izvqPCoQhtH053zTBYg8YM"
+  },
+  {
+    "provider": "mistral",
+    "key": "EMeSVVb57vokgpd523aWWCoGRjuiVQhwc2stdLD2SHg1ssTc"
+  },
+  {
+    "provider": "mistral",
+    "key": "Fua9og9Hdv5KbhdiAcmMCgHG1LGNnZVGHsPspTpeAbgnrHU5"
+  },
+  {
+    "provider": "mistral",
+    "key": "AT1Xj7ubObcP1vD9TH2ChkM6zMgQr6f3J5jlRrr9GKQ7Bndi"
+  },
+  {
+    "provider": "mistral",
+    "key": "dslz16MeNr3UzHBBtn8YszSRGyhc2cDNd7iDcXcHFwIN89pl"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_gfQ4dI5jvsJ62YezpOcUzU6ICQDDGO1Mio"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_EXWL6wsW7Hfx2tFLEwF3ToDDOiNgCcdiE2"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_8XcP2nyovVwLGQPMbO1Vcc1ovPRX05zpoe"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_ANc2aE6m97ebxtrJPdVhRqN9mXNgWhGFeG"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_3q6kscdqDC8QdqExw45caFg8Ha0jrj4Eg5"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_I5edqRoO7zEmwavaEi2DqE1sp9tA9s5F0a"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_mByhX2pF4rWcNHwHhsnr1og2hxMJK0bsoj"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_bQzfg5ZCyTsW1b89mSne5ABvXgyGGKp2LT"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_Bd8vLRpInxYcZPYVzDrh6qRoITg040eUVR"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_xhZmb67rhL02MnuNbU6SUZH0khjih2ZUva"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_ZZln0NTyRvGWiCDPwwtIOhY6BDqicP29lM"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_qHTjipugZyVcjW662pfkiJRtPZK3u7HnoS"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_APPOrrZBf7wAgnhw26VtYJXez9JweFgBj6"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_57ZFikhPSQY5q3J7dgsXZMgzw20wq4QHur"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_rmX9uLds00zGB43TWVrPolTqjiW1ZrBAqv"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_5brXDVHyXT4FNP1hi2MjdWQqDArful9VeM"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_7F0Iql15e9nPcGxnU5pte5bUgkpABInQYr"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_upzpOhOYUWpumdUuTbS48baDbXr9Yu3Kh7"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_SE2VaZdsa847UhR4HqZ3ok3AcubgTmsaaM"
+  },
+  {
+    "provider": "huggingface",
+    "key": "hf_dauAM0KgbVfd6r14iicrdAkufETGAiL1mb"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_5EqSMD7wcM1vcyuNqi1gVX9gAsFDdkg5cOhL5"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_0oUmnafvZfbKhgPGneSaqQkTUvveSgf9lQFCy"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_MWIW4NE7rGP9FFDc3sIvMheLj8jATPagQCfkf"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_RVtD76UhpC9Ez3Y0h5un1Ky6vGNZ8BqzK9hqH"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_70UuLP4QFV6CQLFYiX36gVAw54P4Rdxb9bPXV"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_mxT7kr8qRS70nFN8fqcxy7etDpApO1pCS1zkg"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_AdJBxlpfk62UvSFP0FwFjRIXcTA4vSYgO82Mz"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_j3NOezxtSYl0uSasVSa261yCG5bxfNeyKCIFS"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_DsKpRA9di4mpuP6k444DQwwEUfdeEa5ZBxW0O"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_n6oxiST7Usor39089hiesHN1vaq3Ptqfxay8l"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_jmgk0ePajbbfal7GvGBhVWYeNAd4JZ5bL5AW0"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_Q9b340NhTRoQoySbdxXRe76BmEH7tOuBeg9Zb"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_EUvgYQIL2HNL8btKbhd0wuBdpjSm4QpzunNVC"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_qGcRG1Uhp9HplNZvWOqTd2jUZzS5Ig1lvXhAg"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_vuzqOhXJNysKNnW6dvKru6hxvTGCYgYmsK7wt"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_NosuLl78oVAoh3kM4v0FxHqelDYunkSQJfiUc"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_TTTk3NyH4pKrqEaZUg0HaolQ6IudgofXiNQ5S"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_XapHDFhD0DLZAsPwQMbO4Po5FkYxyYeIXMyeZ"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_u8nh5qgTiyYmDuH0udJ0V1oYmHxWqQnTtbCck"
+  },
+  {
+    "provider": "replicate",
+    "key": "r8_LQbCKxbq60oyopcYdbYnbrkRdgxhY9HLV7da6"
+  },
+  {
+    "provider": "together",
+    "key": "90ae22fa5fb676fbc27568a98f624bb72ce9a3ab1fedf77a38054e4d02c98979"
+  },
+  {
+    "provider": "together",
+    "key": "aa4ec32d2eca63c905e5f54c280958f68854d4500c1306ca6db087c03a422e92"
+  },
+  {
+    "provider": "together",
+    "key": "6086f43df43d54f5efb65964e15a41cf0f24a11e4cdc783e8b2177e8cfada0ab"
+  },
+  {
+    "provider": "together",
+    "key": "51d74871db3a7c8c7ddba8d8724368d0881720a2bf975ffcc0bff5b1eadb4476"
+  },
+  {
+    "provider": "together",
+    "key": "1a05adf0eada312cb3b07ffc6a6d0e48de9d2b10caf5d45db0f15bd63045d946"
+  },
+  {
+    "provider": "together",
+    "key": "0502fa5231482a41755e025b793215569ae2051ce5c3cae291c423598c886c56"
+  },
+  {
+    "provider": "together",
+    "key": "e13f3d0aabbc2014a599eb637869808a16d336771e1dc28aad43ecbb1f9dca0c"
+  },
+  {
+    "provider": "together",
+    "key": "3b63e9563c991773e9c07d56f6f5bd238f49f75fd2eda700be5e063a124fee6c"
+  },
+  {
+    "provider": "together",
+    "key": "66a0c3adcea4561e601bfd3011befff2ab38737888f0722eb97bf39998b86255"
+  },
+  {
+    "provider": "together",
+    "key": "4d1bed9b7365489401e15964362d9ad23a77c4de67a89aca2d015b93af5bffc1"
+  },
+  {
+    "provider": "together",
+    "key": "9bdb5b613d4c87768db3e0cc91828c195a75a861b684c5a56e3e4671c478e685"
+  },
+  {
+    "provider": "together",
+    "key": "4e75c1561c28984d42fe4e9a616013c8fb9870dc08dc106b1d8415015eee87de"
+  },
+  {
+    "provider": "together",
+    "key": "ea770b0a970213e26570100e0c365195173903a089fdd483d85a71354fa30917"
+  },
+  {
+    "provider": "together",
+    "key": "dc8a385cf98ef3877d30c4c922d0ab799561089da3cb1e330f372c5cb7855937"
+  },
+  {
+    "provider": "together",
+    "key": "e41a41a618cfddc51e6e91d91376b2d8ba6e6eeac0ac887616ebe3afaf095cf0"
+  },
+  {
+    "provider": "together",
+    "key": "a75ab363404b2f899ecd9aa68022829e2dbfb2cfc412046530cb4976b49e540f"
+  },
+  {
+    "provider": "together",
+    "key": "abebfeb5cfdd74e93b7ea309911faf950afe86e8826821ad0985fc6786e0f084"
+  },
+  {
+    "provider": "together",
+    "key": "fae09253aefd6abe117379a83660457ba6ffbf8423812ef475b60f2600ce3153"
+  },
+  {
+    "provider": "together",
+    "key": "492d30ca4ed68dea02d00409fbfa59599c85fa4e7d13922e3056c12215200ecd"
+  },
+  {
+    "provider": "together",
+    "key": "c8cb97cecd0f976287d51cc7c6751038d3fa70e7a4c6c1a39ea14a9ed4760e70"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "groq",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_nh2wrdnezKTMNb8p59sZneORPbwQMDE13JYX"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_9u1iDNc5wffjEyA6ktuPQoRJvf87QZePU1Ue"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_R6Nh9w4SBPW3rWlzW5a9lEm0NHQcnCrlb1za"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_y7lJtlxo9kfl7jHEuQr8shRAVlnYFwOnVGtG"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_sV9EtpDghh7SKkvCd3WPz1Db0Obl9QbghHnY"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_pGiz0IlFvZvFKraL39wLWn2t9hOa26yQ6Um1"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_IspgQ1HuxiSTv0HknOLYGOzjzRe5HbuS5CQO"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_5kNQCCNiJ4okIsT3BXhyEfZidJ6M86N0p9jd"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_6d3j3KivCurkhNCtfpeOTEftnaCNbPvTPfrf"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_4t2AyRz5fBL3EKnFjAU2wtLf2XPkqfHbjejW"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_kLoa8fxuVPykxcfS57rFk7XDwT8TrlQgca0J"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_cma88ABWsgJtuQWPt1L5kR8rCFksclQpkRLR"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_u7VHBjokvMThheM1l072PAfbk0Q1MjfdTeeV"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_I0xljDakwd2zzkavUjsjvZc1BTgHR9xO6xbh"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_RJi2z79VGRI0yTsgPVeMYhM1jOiigAgh8Qb2"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_uy0mYjzey37hFYfcFjPowwRMh6p65AY8dNwb"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_aT7slXwcx7c2hxxXQBJsgqKHqPwXuGwFf2wd"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_Vg0vFwLR7eC5iRsjiSenV59KJkHNGrbkR8Xn"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_giLp7cPPk5OWzW6cCTlo1AIKqbVEjTghlFjv"
+  },
+  {
+    "provider": "github_pat_classic",
+    "key": "ghp_MeCotcDq6WeUcijCApUYrJPyp2XDHoopjaUd"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "github_pat_finegrained",
+    "key": "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"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-QJgShC9N58tYnqZq7bvv"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-10j1wJr8RB0LyoaSBuK4"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-G6yWC0RmdgxbsGM8byok"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-nkchlXfq4qSiwJIZS7J7"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-IEMErcHwZzeYlRhrwEzn"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-NsgZYaCrebpgyukqWJPJ"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-Yg6a9H1ZU1GTpgxgPAE4"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-vQSPpKaTEYhXYdU7bA2j"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-3OL8dwMM5dTTDq21XD4z"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-fuej2oiiwBbuR1bunEQ6"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-sxsvXW7c4An9g8E9Sl0t"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-NCaLkVWXXzNbmUfhnfkJ"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-VgBed2IiBk7WW6rX9Vgg"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-LbCbURBbmlAeahKZZP8p"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-ruEijKwFJnKNUWlNRu60"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-AVWr57GzgbNCtjeV2CcK"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-kM0LcrBkNLzJVHeKYasd"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-QtArzC2yNoaOMG4C0a28"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-Ys7SgVstcYHRZj6hn3JG"
+  },
+  {
+    "provider": "gitlab_pat",
+    "key": "glpat-jToeReTUdVHFYhK3uG7L"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-2HsLdEZtTgb-PrBcSUuXU8G-esWYXAYqSh2P5e9206lED1Io"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-j0DFVozBwTC-hphKQQuuKvz-PrauLB55MckISjubm22a1g49"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-UG4fqjqbfKG-1xSzzn7eGPd-t4APH657ABuHf4p3kjH8zv4P"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-TA98Xan1cr1-n8fiATnv0Zf-vaL4y9pNEFMy3JbYsAetmbNq"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-KZBW4I4V69L-43NhHAyRkrZ-KtcX9de53B5HglsSAuyi0ePe"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-fO2U4uJhbvC-59pSrh903KO-w27bR8TyCevojiOgc2TivTww"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-LC4f2qSN80p-tdWwdyqYyjJ-23wY4j5zPUIk3algvq7QIGS4"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-8K6aEMq9SM3-O2S840aXT0S-6B8EDJhKBDbgcvaiMdVPowOJ"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-eJEDChebOtu-dIcUQDtbhNL-w8iwBYMniThv87DsfSxYxc33"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-kveOfyUbqeV-LVuRx9X93V1-aZReyjbxb0hUidXrvv1dcENs"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-pBTi8ogt7Iw-tkncgTGczsa-H517JcEUcSWCLHqfJBxfhjHr"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-IJOU7dHGNBa-covkbrZo0go-O79ansvGpH2LYAbeA4TGZLEk"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-Qy5EFT119gU-m9ECPi2doqa-WOfiTE8N26ssBoVcKhG96Wu6"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-MPKKyvsGBJO-GxhAtBvZpUp-Ra7ocNWFxSfkjOQDTC16WhhT"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-legpZMhGYTD-B4RNXBce9qC-Uk6Dbt2iyFjMxQrlmx26C8pe"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-pYM0SIUNbMV-klQdpLHtUwz-kHbgLCDh8zA4Zr9UVcwczhlA"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-QehWNG4mcLH-VJN2V9XkHaw-hN3ds1zcd6JamhnU0QoIdNRs"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-R42taCAPzfv-lJAoMdhPafA-odIX7aiYbVhFqmanwtTRJW11"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-59ITg6NGcMj-zDkrvmb4kDD-5vPkRwTGiNKAhXY0Q4spHK3Z"
+  },
+  {
+    "provider": "slack_bot",
+    "key": "xoxb-YaYLNu8mcaj-vsXOWMf0M67-c725Bjj8hSdkCrkuwujyJ1ke"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_H517JcEUcSWCLHqfJBxfhjHriUae806XwYrkiDVsA8TZDQKU4O"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_O79ansvGpH2LYAbeA4TGZLEkOdcNITMBtsqEZQyjeeWPIUETUv"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_WOfiTE8N26ssBoVcKhG96Wu6q6oOK8YkZtqzGCxB0pHe71qsAe"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_Ra7ocNWFxSfkjOQDTC16WhhTOOs1K5F0IHo3ffEThT2ieXdHXL"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_Uk6Dbt2iyFjMxQrlmx26C8pe1NUimW9WIcSlfrsG23BfDtYdm5"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_kHbgLCDh8zA4Zr9UVcwczhlAcQG7WsSP9vKxhvYnWpPprOedUn"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_hN3ds1zcd6JamhnU0QoIdNRsiugYtyWN5NIYJs3u6Ioi9THa46"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_odIX7aiYbVhFqmanwtTRJW11U9OBoIzQmQwRE65EODEuRvmiSJ"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_5vPkRwTGiNKAhXY0Q4spHK3Zv6y4MCz9SqEhgZ2IqDXAakixMy"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_c725Bjj8hSdkCrkuwujyJ1keThf5CjXJevuSRkvTbnUVWwvh4t"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_dzkfy4p28dQOzXztgguJr1zcDh9BKCzRcJLkZu1Yhhlil4Ag87"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_stwNyxEX2VXSoBqMMZDpF58VMFz3pAZhehlFO8XQ45CTL0GiYX"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_BOpFRmIaPu8l14XgCkCxDGSQWLTa22eDje2ZZHXMObGaQAN3kM"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_5e3ZbHQhiEvs04iPo1cEPDqJxC9hfE1vC5N2HF5XRRjxOlOXIU"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_hXWk9uUEkUCoE0SNLtxGSEKb9XU6vNzBoLzU7lTow7iRWM5fgK"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_WMOKy0kSbmfGlq2eVOEWLrUfqfAWqdIXjWiUV7KZ8LBw4YKcci"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_7zdKXLJ4IsmjHgqrjmVn6p6QandUHaw2lFTgrrj34IH5aUsT9j"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_cQNPsWTgihWQ5b8On0wZFWbgrnu0glEALQp8OZQJAZcBINMzur"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_biBVrfZIbbR7nyuPWXyt0fTeTUBFiOYmrdAyMWUVRHhiKRJtCd"
+  },
+  {
+    "provider": "stripe_secret",
+    "key": "sk_live_U1RDHHBxDD2z3IDeAPAkqgDR5oIcgKgXaLtemKIhO6MoeeC1ZU"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "ACE2DC492B06F2F98B656333FFE09DBB54"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "ACBC5F6C8A53960EC6A3DE0D2FB36EA330"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC8BCCDFE905DE76EEBFAF698CEB004FBA"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC5B58444F82E07CB0968FB5BD3513281F"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC82F73623CC5F88941DE615CA482AFB7A"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "ACD80616C5A4BD1E3C2FCB4F2F197D84BF"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC145207973BEBC35A889AB9C3DEED681D"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "ACA7EA2D5F7AD8596BBA3D11494BA5B341"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "ACCA14937A6D221B7DB3F89606737FAE97"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC7056ACF75600059C78B7F450AC260B0D"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC1AD9BD9585D9C2FECB63771739158AD7"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC894536678F17FDD69210B8216A70BAE5"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC23D3AAB45CDA0071FE3C49D33A5F4EFF"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC3CD25CC9637906BDF58B047C47943E22"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC743A6E089E697ECB5F36F773F8351235"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC22D94E83F0C3578FD6CB1DAA4FF2389B"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC91CA840BBDA5A7892C7D58B2500173B6"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC7199D552C2552B0F732C4E142953E65C"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "ACFD81C9BFEA7E3287FC5E518B41C7C655"
+  },
+  {
+    "provider": "twilio_sid",
+    "key": "AC9FAF1A1F58C4DE9CC6D187E8D7FDBD51"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "SG.tTIpjypPxbgtSxpfLLL3HT.dk0rFM3SbQIVkbgTd2fL2dHUUSCSSWz9yhCYnepKJ0I"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "sendgrid",
+    "key": "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"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_GZcaOd1hdDghjOrgVgxw7qi1cS3jeHw9Igy65vdthbPo00LJof"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_jZa0Dt1KHxrdUyZIuVqD8UdrH8aPRxMc9WN3GG1YBNbgfMxge4"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_XNSw5Cf3db7w8ogBuh8E4cqj3ihKgzlploh92DwNIskb4U0woh"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_OUtuKo2wOsAWQMx5FCwQiaD5Lte6q9MXCzLtoAE3cMb8DhNqAB"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_ufnKjfrV7OdXLieXg2dGh0Kdm2wCYtbjq4qrob8O0PSkAomAZw"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_6f8i8uy1sh3pZeVWy1scjCfpTh22CV7XQVeJvHr5FUoR6z3DYT"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_7kNXMcyfBbn627VaCSN4gF0fFcouEe7U9zBHeouTIqMf3UT6ej"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_5cNXdRz9UBuStwn95unXnnvNhRK4Dk3s0j2JxJUEnCnZxxL0Ve"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_pofbInpTdw6ndRTL1eiJTq0QWLfRR84rIhuaWPFVYbddOT9St6"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_uOxi2cFn7zAhfdj2fLqN5ElqcVlfPgYbTh6ttT5RWwZuRZyC3S"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_P9zX9WTxYv5nlSMnqWBU9YMw0tzEvh8FeMGl29WBPS2r44YAzV"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_hhvrtkvvzIN8dPuMlKmtMg14kMF2jgIKZ0tr0d5kUEe2TfvgNx"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_9ASrD9uYcKubS4J2Uup2QNk980hQsFd6IP0zNvXrCMSdnU3RIF"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_Fhb8JQvCqBWiwQQquQ8Gf4xAINrLMtTWsjRkgY9s03Y0Te7SvO"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_9pquk4KmcikL56tFJsvznUybZLFBsaWPKB1afhcyP659TlZkJE"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_LTOhs3co9Yerri2c0GWEgwvcgy3O3Yxg6nsiY7ChiSP5Nnk0uQ"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_Jo4QzJOStNr7tXm5J2ACioFdLGHxJw4CVjFP5RaX7kRZScYf2C"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_ZgorRNhlVvweVAv60nINqgSYsu6CFG5310e4HEmO1iogvvrQSi"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_5J5HwjjX3FRKe1ElDzJZnm9CJKaXDm3dlIh1YmAPlS2oIhbMHe"
+  },
+  {
+    "provider": "notion",
+    "key": "ntn_XpLMMU3l2zTBsJyZ3GXxAV7Y3GJ0awMrAzIGT2q43h4L1YRBp6"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_WzhGm1Jme2pLMbhfnvdZQyJCok4s1XAbHC9KPLul"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_NmBFzlEasfADFuhlkewPMhusYP6R2GCDNi8tU0Lj"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_gxWPc8qQd0YqcEaPrp4Ja92MkHAEJ70xs39J3CDd"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_mUmAstmxghA4E8Q8S5ee7GnwtENzdjLDtdspk2Cj"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_eSiNDEFn54A0fY7slL4Gjr3ggeWtnL13WcFoSwds"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_i3JnC5J5hl0t05meuGGtxaEFNheadfYcqzpyOgjD"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_bGm8MhmIqMJPNEidPrT2f7YQ0hHbGQ5mxvwV1xQk"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_8epvdDn7FEBuzgkYySaecRYRXklyFa4evDqflih0"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_JeMzfRhmLA1XTCQunb0T0TPo1scZGlKSz8P4xeLe"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_df4BLVv1d0t5BWPQfDceNHvMVXYY8wzgVn1ieDgs"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_fesPdpxdgsnXxnxIPWtNu2NYnR0hmjP1KnI2wzSk"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_lZwApBgpPBqBWPWahbg01ZRjv77UP7LgbD2kXNhF"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_Bt3TGaJp6Kr2bpdtdhndIJp3UmT6GuAbrIRwxcwh"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_0afnSehW7xt3HzYIsRa1MbdlqfdRidtaOVkZefrP"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_skO8w5V7bBtHUYEIoj6SOxkuZgFyW4ie4xdcr0h7"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_hEOBnGKTu67jEPucvQYA8yavacSSA6oN0QEQeX1P"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_FmFYtrkfv38CSToLEfKR7IegHdktEXTUcPXe7i0m"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_GWawAGrLpcYcgMjevSVos0cQ51usEumPcO95cxSx"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_DbZtmA7Kf4i0rpn3j9PEmvUg17O85aSfBhkNToR7"
+  },
+  {
+    "provider": "linear",
+    "key": "lin_api_U9XfmmfzKdJA4v2IuGdZKRk8mjdVda1EYaxuAimX"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_yCjNjobkabGIQ0TXXyFYLoee"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_w5bIkqSzW54bGZq9hwRkfYwB"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_U7wyUJRJaK1F80GNBFvDyJPh"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_HslnWEvzRNFnSLYlLoorYAOn"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_9kIf9t4xajm3lZqSmwdONcAb"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_Tsz8EOXKkaMDeO80qTaJzUhc"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_ryt4Tex4CBNVONP1Q2vqEX7T"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_dSXtgBaGqKf9vtkDTjwdl9uc"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_5NqYyedGqYC2t0XlnEhWNRhU"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_MJNLexOmTMgL3YUm0OLgkWZ2"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_d1UbvatheE34sjBLQJ17gecV"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_KdRQuce4NsBtnhZBDjGs0xNs"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_aj7il9pINF1m2G7P4EQQJDce"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_C9qVPoawdCJrgQoIXsIkCZs0"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_LMK7HStdkBn49lhgd73McdZJ"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_1NzkasHMT994dHqzgabBqY6e"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_3wSHNqhMK7hdkcI7EheEcw41"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_fieRApHhN9FywzT9FrxOjSeK"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_w5V3IAahMny6xr6smiCFggNq"
+  },
+  {
+    "provider": "vercel",
+    "key": "vcp_h1KF3BpJaWgrBmmIwZMPwC4F"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_0898c4275ed63fd5e92e6431a9a2b6d00f440fbbf55694b6f9034788846806d4"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_e855f923864a7c850543ab870f4192600793c438dee351eeef1a5505bf5f2abf"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_63e5a725e0c3bd7e260f630793864d24b4ebfa56e2b7be9e9fda02a81114b8cb"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_90b2016021728b87b1947b0bb81bbb5396dec18d3e3a69621df28b8581602696"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_569f18e4db490735bc4b6dc9d68f3c06ee310e66ab759041d358e7dd78843c3c"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_0aea1fe35fd0152d8a39f4b69a7480487af74eeeeaa5f67b867ad7940b433ed5"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_145bbe894f9b644521b26858a2a9c1a927c27997f39226ed5f5151f42e234c83"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_0bdf6c0578a1af6cafb6bba4fa0f4ec9815cc8308ba7659caaf183452f820e65"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_35b79411a34f6bf04fae6767735b24bcb31740abe434223a60c3dc45481dc87a"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_3a2f8687f517b1d84f458a85d74cccabab3d5863a69f7f2a27593b4edccbd980"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_79fd99a8bb878352ddd8517f2cd1aa26884e4d8debcbb64ca9f0f700415cecac"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_0153e34e2c394aa2b30d88b53f3c7c5881b4be159f313cd942259b2631d9941c"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_7b7c67fe54417186a6bba9dec9d6b4306836407ec4dcaefcf7694813bbae63c1"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_88945be056b0e1545923074421362f9a4a2d3a54eb58516bdf449baf0fb58bda"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_ccabaa46855db41fa742069d8bca1a124b191ecd889c77552ed2b51efa9afaef"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_6da93d829c029e9f0e5c80c37a96d5e300ef1193ed5c2891d665e9529f897ac2"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_e9efe91971f8115eb8b2378f344968665d2813331bead1a873bd94e43c311e08"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_61ce1531d503f943a485d230a2c32e20e6cbe02dc801e5d09e63a409c7579b15"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_2003515ec3080d5d6d7a1cbc78dac663367e08a1c99da0c18e944c4a09613556"
+  },
+  {
+    "provider": "digitalocean",
+    "key": "dop_v1_6a8c1c4e935ed354c84f47ec21f080e305f4890bb033a7d2e19374f473cec5f7"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-d40b2868858264d8524868fa92e53dca"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-456f5e10fa81957cdda8651f01480b4c"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-58269294b8acf26e70d4b635541a5ed0"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-d2da997e9d8a61888ed0b2620b83944b"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-101b070c28d70d51ff1d325f725da40c"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-81b86ac103f1ba3c89479bb94d22d8de"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-98915ea0154181f9b5b5caa4c30f14c8"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-f768b0b9386b8240c11db82457f48d43"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-b7658ea184d39fa324c5eb220398e3ea"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-7c77e2e930d7ebf65fe4e81a6594d0fc"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-9301b75b6dd6d4f2d90feba51317c367"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-60036f08612f1bbb95bec02bdeaed067"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-ec6c24f4f5ac6bfa4d00c3e09632ffdd"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-8678cd6e18911d7003804f2802c9d99f"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-1fd55c3c477401b5c5d460826f248510"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-b7b3e8edae1703a8dacd64ab595e1db7"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-9c9694efa6bbefb3cf3db6050d6a1f8c"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-fad4db502fc5e04130761c527c89f51b"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-1bcb4a6fd714870ecc7aab1c381af334"
+  },
+  {
+    "provider": "mailgun",
+    "key": "key-268ac5229453db46939c52ece1909739"
+  }
+]

--- a/tests/fixtures/fake_api_keys.json.license
+++ b/tests/fixtures/fake_api_keys.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+SPDX-License-Identifier: Apache-2.0

--- a/tests/fixtures/generate_fake_keys.py
+++ b/tests/fixtures/generate_fake_keys.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regenerate tests/fixtures/fake_api_keys.json.
+
+Source of truth for the 500 deterministic fake API keys consumed by
+tests/test_encryption_fake_keys.py. All keys are FAKE, derived from a fixed
+seed via SHA-512; none are real credentials. The fixture filename and this
+script both contain 'fake' so the gitleaks allowlist skips them.
+
+Run from repo root:
+
+    python tests/fixtures/generate_fake_keys.py
+
+Writes tests/fixtures/fake_api_keys.json in place. Exits non-zero if the
+generated count is not exactly 500.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import string
+from pathlib import Path
+
+_RNG_SEED = "observal-test-fake-keys-seed-2026"
+_FIXTURE = Path(__file__).parent / "fake_api_keys.json"
+_EXPECTED_COUNT = 500
+
+
+def _deterministic_hex(index: int, length: int) -> str:
+    h = hashlib.sha512(f"{_RNG_SEED}:{index}".encode()).hexdigest()
+    return h[:length]
+
+
+def _deterministic_alnum(index: int, length: int) -> str:
+    h = ""
+    for block in range((length * 2 // 128) + 1):
+        h += hashlib.sha512(f"{_RNG_SEED}:alnum:{index}:{block}".encode()).hexdigest()
+    chars = string.ascii_letters + string.digits
+    return "".join(chars[int(h[i : i + 2], 16) % len(chars)] for i in range(0, length * 2, 2))
+
+
+def _deterministic_base64ish(index: int, length: int) -> str:
+    h = ""
+    for block in range((length * 2 // 128) + 1):
+        h += hashlib.sha512(f"{_RNG_SEED}:b64:{index}:{block}".encode()).hexdigest()
+    chars = string.ascii_letters + string.digits + "+/"
+    return "".join(chars[int(h[i : i + 2], 16) % len(chars)] for i in range(0, length * 2, 2))
+
+
+def build_keys() -> list[tuple[str, str]]:
+    """500 fake keys across 25 provider formats, 20 per provider."""
+    keys: list[tuple[str, str]] = []
+
+    # Round 1: 13 formats.
+    for i in range(20):
+        keys.append(("openai", f"sk-{_deterministic_alnum(i, 48)}"))
+    for i in range(20):
+        keys.append(("openai_project", f"sk-proj-{_deterministic_alnum(100 + i, 44)}"))
+    for i in range(20):
+        keys.append(("anthropic", f"sk-ant-api03-{_deterministic_base64ish(200 + i, 80)}"))
+    for i in range(20):
+        keys.append(("openrouter", f"sk-or-v1-{_deterministic_hex(300 + i, 64)}"))
+    for i in range(20):
+        keys.append(("google_ai", f"AIza{_deterministic_alnum(400 + i, 35)}"))
+    for i in range(20):
+        keys.append(("aws_access_key", f"AKIA{_deterministic_alnum(500 + i, 16).upper()}"))
+    for i in range(20):
+        keys.append(("aws_secret_key", _deterministic_base64ish(600 + i, 40)))
+    for i in range(20):
+        keys.append(("cohere", _deterministic_alnum(700 + i, 40)))
+    for i in range(20):
+        keys.append(("mistral", _deterministic_alnum(800 + i, 48)))
+    for i in range(20):
+        keys.append(("huggingface", f"hf_{_deterministic_alnum(900 + i, 34)}"))
+    for i in range(20):
+        keys.append(("replicate", f"r8_{_deterministic_alnum(1000 + i, 37)}"))
+    for i in range(20):
+        keys.append(("together", _deterministic_hex(1100 + i, 64)))
+    for i in range(20):
+        keys.append(("groq", f"gsk_{_deterministic_alnum(1200 + i, 52)}"))
+
+    # Round 2: 12 more formats, sourced from primary provider docs.
+    for i in range(20):
+        keys.append(("github_pat_classic", f"ghp_{_deterministic_alnum(1300 + i, 36)}"))
+    for i in range(20):
+        keys.append(("github_pat_finegrained", f"github_pat_{_deterministic_alnum(1400 + i, 82)}"))
+    for i in range(20):
+        keys.append(("gitlab_pat", f"glpat-{_deterministic_alnum(1500 + i, 20)}"))
+    for i in range(20):
+        keys.append(
+            (
+                "slack_bot",
+                f"xoxb-{_deterministic_alnum(1600 + i, 11)}-"
+                f"{_deterministic_alnum(1650 + i, 11)}-"
+                f"{_deterministic_alnum(1690 + i, 24)}",
+            )
+        )
+    for i in range(20):
+        keys.append(("stripe_secret", f"sk_live_{_deterministic_alnum(1700 + i, 50)}"))
+    for i in range(20):
+        keys.append(("twilio_sid", f"AC{_deterministic_hex(1800 + i, 32).upper()}"))
+    for i in range(20):
+        keys.append(
+            (
+                "sendgrid",
+                f"SG.{_deterministic_alnum(1900 + i, 22)}.{_deterministic_alnum(1950 + i, 43)}",
+            )
+        )
+    for i in range(20):
+        keys.append(("notion", f"ntn_{_deterministic_alnum(2100 + i, 50)}"))
+    for i in range(20):
+        keys.append(("linear", f"lin_api_{_deterministic_alnum(2200 + i, 40)}"))
+    for i in range(20):
+        keys.append(("vercel", f"vcp_{_deterministic_alnum(2300 + i, 24)}"))
+    for i in range(20):
+        keys.append(("digitalocean", f"dop_v1_{_deterministic_hex(2400 + i, 64)}"))
+    for i in range(20):
+        keys.append(("mailgun", f"key-{_deterministic_hex(2500 + i, 32)}"))
+
+    return keys
+
+
+def main() -> int:
+    keys = build_keys()
+    assert len(keys) == _EXPECTED_COUNT, f"Expected {_EXPECTED_COUNT} keys, got {len(keys)}"
+    payload = [{"provider": p, "key": k} for p, k in keys]
+    _FIXTURE.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"Wrote {len(keys)} fake keys to {_FIXTURE}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_encryption_fake_keys.py
+++ b/tests/test_encryption_fake_keys.py
@@ -4,20 +4,23 @@
 """Test encryption and key rotation with 500+ realistic fake API keys.
 
 This file is intentionally named with 'fake' so gitleaks allowlist skips it.
-All keys below are FAKE and generated deterministically; none are real credentials.
+All keys are FAKE and generated deterministically; none are real credentials.
+The 500 keys live in tests/fixtures/fake_api_keys.json (static, pre-generated).
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import string
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 # ---------------------------------------------------------------------------
-# Fake key generators (deterministic, format-realistic, never real)
+# Deterministic helpers (used for edge-case special values below)
 # ---------------------------------------------------------------------------
 
 _RNG_SEED = "observal-test-fake-keys-seed-2026"
@@ -45,244 +48,14 @@ def _deterministic_base64ish(index: int, length: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# 500 fake API keys across 25 provider formats (20 per provider)
+# 500 fake API keys across 25 provider formats (20 per provider), pre-generated
 # ---------------------------------------------------------------------------
 
-FAKE_KEYS: list[tuple[str, str]] = []
-
-# --- OpenAI (sk-..., 51 chars after prefix) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "openai",
-            f"sk-{_deterministic_alnum(i, 48)}",
-        )
-    )
-
-# --- OpenAI Project keys (sk-proj-..., 48 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "openai_project",
-            f"sk-proj-{_deterministic_alnum(100 + i, 44)}",
-        )
-    )
-
-# --- Anthropic (sk-ant-api03-..., 93 chars total) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "anthropic",
-            f"sk-ant-api03-{_deterministic_base64ish(200 + i, 80)}",
-        )
-    )
-
-# --- OpenRouter (sk-or-v1-..., 64 hex chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "openrouter",
-            f"sk-or-v1-{_deterministic_hex(300 + i, 64)}",
-        )
-    )
-
-# --- Google AI / Gemini (AIza..., 39 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "google_ai",
-            f"AIza{_deterministic_alnum(400 + i, 35)}",
-        )
-    )
-
-# --- AWS Access Key ID (AKIA..., 20 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "aws_access_key",
-            f"AKIA{_deterministic_alnum(500 + i, 16).upper()}",
-        )
-    )
-
-# --- AWS Secret Access Key (40 chars, mixed) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "aws_secret_key",
-            _deterministic_base64ish(600 + i, 40),
-        )
-    )
-
-# --- Cohere (bearer token style, 40 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "cohere",
-            _deterministic_alnum(700 + i, 40),
-        )
-    )
-
-# --- Mistral (48 char alnum) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "mistral",
-            _deterministic_alnum(800 + i, 48),
-        )
-    )
-
-# --- Hugging Face (hf_..., 37 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "huggingface",
-            f"hf_{_deterministic_alnum(900 + i, 34)}",
-        )
-    )
-
-# --- Replicate (r8_..., 40 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "replicate",
-            f"r8_{_deterministic_alnum(1000 + i, 37)}",
-        )
-    )
-
-# --- Together AI (64 hex chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "together",
-            _deterministic_hex(1100 + i, 64),
-        )
-    )
-
-# --- Groq (gsk_..., 56 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "groq",
-            f"gsk_{_deterministic_alnum(1200 + i, 52)}",
-        )
-    )
-
-# ===========================================================================
-# Round 2: 240 more fake keys across 12 additional provider formats (20 each)
-# Formats sourced from primary provider docs via the regextokens catalog.
-# ===========================================================================
-
-# --- GitHub classic PAT (ghp_..., 36 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "github_pat_classic",
-            f"ghp_{_deterministic_alnum(1300 + i, 36)}",
-        )
-    )
-
-# --- GitHub fine-grained PAT (github_pat_..., 82 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "github_pat_finegrained",
-            f"github_pat_{_deterministic_alnum(1400 + i, 82)}",
-        )
-    )
-
-# --- GitLab PAT (glpat-..., 20 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "gitlab_pat",
-            f"glpat-{_deterministic_alnum(1500 + i, 20)}",
-        )
-    )
-
-# --- Slack bot token (xoxb-<11>-<11>-<24>) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "slack_bot",
-            f"xoxb-{_deterministic_alnum(1600 + i, 11)}-"
-            f"{_deterministic_alnum(1650 + i, 11)}-"
-            f"{_deterministic_alnum(1690 + i, 24)}",
-        )
-    )
-
-# --- Stripe secret key (sk_live_..., 24+ chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "stripe_secret",
-            f"sk_live_{_deterministic_alnum(1700 + i, 50)}",
-        )
-    )
-
-# --- Twilio account SID (AC + 32 hex) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "twilio_sid",
-            f"AC{_deterministic_hex(1800 + i, 32).upper()}",
-        )
-    )
-
-# --- SendGrid API key (SG.<22>.<43>) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "sendgrid",
-            f"SG.{_deterministic_alnum(1900 + i, 22)}.{_deterministic_alnum(1950 + i, 43)}",
-        )
-    )
-
-# --- Notion integration token (ntn_..., 40-60 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "notion",
-            f"ntn_{_deterministic_alnum(2100 + i, 50)}",
-        )
-    )
-
-# --- Linear API key (lin_api_..., 40 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "linear",
-            f"lin_api_{_deterministic_alnum(2200 + i, 40)}",
-        )
-    )
-
-# --- Vercel access token (vcp_..., 24 chars) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "vercel",
-            f"vcp_{_deterministic_alnum(2300 + i, 24)}",
-        )
-    )
-
-# --- DigitalOcean PAT (dop_v1_ + 64 hex) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "digitalocean",
-            f"dop_v1_{_deterministic_hex(2400 + i, 64)}",
-        )
-    )
-
-# --- Mailgun private API key (key- + 32 hex) ---
-for i in range(20):
-    FAKE_KEYS.append(
-        (
-            "mailgun",
-            f"key-{_deterministic_hex(2500 + i, 32)}",
-        )
-    )
-
-assert len(FAKE_KEYS) == 500, f"Expected 500 keys, got {len(FAKE_KEYS)}"
+_FIXTURE = Path(__file__).parent / "fixtures" / "fake_api_keys.json"
+with _FIXTURE.open() as _f:
+    _RAW = json.load(_f)
+FAKE_KEYS: list[tuple[str, str]] = [(row["provider"], row["key"]) for row in _RAW]
+assert len(FAKE_KEYS) == 500, f"Expected 500 keys in {_FIXTURE}, got {len(FAKE_KEYS)}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Aryan Iyappan <aryaniyappan2006@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description
The encryption test suite (`tests/test_encryption_fake_keys.py`) generated 500 fake API keys inline at import time on every test collection. This made the keys non-inspectable and meant the test file carried ~150 lines of generation logic whose only job was to produce a static, deterministic dataset.

This PR extracts those 500 keys into a committed static JSON fixture and adds a source-of-truth regenerator script. All keys remain FAKE: derived deterministically via SHA-512 off a fixed seed, never real credentials.

## Fixes
* No issue. Follow-up to the `test/add-more-fake-api-keys` work that bumped the suite from 260 to 500 keys.

## Approach
- **`tests/fixtures/fake_api_keys.json`** (new): 500 pre-generated fake keys as `[{"provider", "key"}, ...]` across 25 provider formats (OpenAI, Anthropic, AWS, GitHub, Stripe, etc.), 20 per provider. Byte-identical to what the prior inline generators produced.
- **`tests/fixtures/generate_fake_keys.py`** (new): source-of-truth regenerator. Run `python tests/fixtures/generate_fake_keys.py` from repo root to rewrite the fixture in place. Verified idempotent (regenerating twice produces a byte-identical file).
- **`tests/test_encryption_fake_keys.py`**: replaced the in-file generation block with a fixture load at import. Kept the three `_deterministic_*` helpers only because `TestEdgeCases` parametrize uses them for a handful of special values (Bearer/Basic/slack-hook strings).
- **`.github/secret_scanning.yml`** (new): `paths-ignore` for the three fake-key paths so GitHub push protection does not block the fixture or regenerator. The existing gitleaks allowlist regex `tests?\/.*(fixture|mock|fake)` already covers these paths locally; this config extends the same exclusion to GitHub's server-side secret scanning.

## How Has This Been Tested?
- `python -m pytest tests/test_encryption_fake_keys.py -q` -> 1695 passed.
- `python tests/fixtures/generate_fake_keys.py` -> wrote 500 keys; second run produced a byte-identical file (idempotent).
- `ruff check` and `ruff format --check` clean on all three Python files.
- `pytest --collect-only` confirms 1695 parametrized test IDs, matching the prior inline-generation count.
- Fixture JSON byte count (51722) matches the original pre-generated output.

## Learning (optional, can help others)
- GitHub push protection is enforced server-side and rejects literal fake-secret strings even when they are clearly synthetic. The `.github/secret_scanning.yml` `paths-ignore` config excludes paths from both alerts and push protection: [docs](https://docs.github.com/en/code-security/how-tos/secure-your-secrets/customize-leak-detection/exclude-folders-and-files). The config must land on the default branch before the secret-bearing branch can be pushed.
- Deterministic key generation from a fixed SHA-512 seed keeps the fixture reproducible without storing any real credential material.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Pi coding agent
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refreshed encryption and key-rotation tests to use a deterministic, pre-generated set of 500 non-sensitive credential fixtures, improving consistency across runs.
  * Updated the test setup to load the shared fixture data instead of generating it in-code.

* **Chores**
  * Added a fixture generator script to deterministically produce and validate the fake credential set.
  * Updated secret scanning exclusions to prevent alerts on approved fake fixture data.
  * Bumped the `gitpython` dependency and added license metadata for the fixture file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->