### PR TITLE
Feat/registry recommendations

### DIFF
--- a/observal-server/alembic/versions/017_user_recommendations.py
+++ b/observal-server/alembic/versions/017_user_recommendations.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add per-user work profiles and recommendation feedback.
+
+Revision ID: 017_user_recommendations
+Revises: 016_registry_publish_loop
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "017_user_recommendations"
+down_revision = "016_registry_publish_loop"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    # Additive and idempotent: a partially applied migration must be safe to
+    # re-run, matching the convention used by earlier revisions here.
+    if not _has_table("user_work_profiles"):
+        op.create_table(
+            "user_work_profiles",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "user_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("computed_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("session_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("profile", postgresql.JSON(astext_type=sa.Text()), nullable=False),
+            sa.UniqueConstraint("user_id", name="uq_user_work_profiles_user"),
+        )
+
+    if not _has_table("recommendation_feedback"):
+        op.create_table(
+            "recommendation_feedback",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "user_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("component_type", sa.String(length=50), nullable=False),
+            sa.Column("component_id", postgresql.UUID(as_uuid=True), nullable=False),
+            sa.Column("action", sa.String(length=30), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.UniqueConstraint(
+                "user_id",
+                "component_type",
+                "component_id",
+                name="uq_recommendation_feedback_user_component",
+            ),
+        )
+        op.create_index("ix_recommendation_feedback_user", "recommendation_feedback", ["user_id"])
+
+
+def downgrade() -> None:
+    if _has_table("recommendation_feedback"):
+        op.drop_index("ix_recommendation_feedback_user", table_name="recommendation_feedback")
+        op.drop_table("recommendation_feedback")
+    if _has_table("user_work_profiles"):
+        op.drop_table("user_work_profiles")

--- a/observal-server/alembic/versions/022_user_recommendations.py
+++ b/observal-server/alembic/versions/022_user_recommendations.py
@@ -3,8 +3,8 @@
 
 """Add per-user work profiles and recommendation feedback.
 
-Revision ID: 017_user_recommendations
-Revises: 016_registry_publish_loop
+Revision ID: 022_user_recommendations
+Revises: 021_agent_success_criteria
 """
 
 import sqlalchemy as sa
@@ -12,8 +12,8 @@ from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
-revision = "017_user_recommendations"
-down_revision = "016_registry_publish_loop"
+revision = "022_user_recommendations"
+down_revision = "021_agent_success_criteria"
 branch_labels = None
 depends_on = None
 

--- a/observal-server/api/routes/admin/enterprise_settings.py
+++ b/observal-server/api/routes/admin/enterprise_settings.py
@@ -502,7 +502,11 @@ async def test_insights_connection(
     kwargs: dict = {
         "model": model,
         "messages": [{"role": "user", "content": "Say hello in exactly one word."}],
-        "max_tokens": 10,
+        # Reasoning models (Gemini 3, o-series, Claude thinking) spend their
+        # budget thinking before emitting text. A budget of 10 leaves nothing
+        # for the answer, so the call "succeeds" with zero choices and the
+        # test reports a bogus IndexError. Give it room to actually reply.
+        "max_tokens": 2048,
         "timeout": 15,
         "drop_params": True,
     }

--- a/observal-server/api/routes/recommendations.py
+++ b/observal-server/api/routes/recommendations.py
@@ -15,8 +15,9 @@ from loguru import logger as optic
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, get_project_id, require_role
+from api.deps import get_db, require_role
 from models.user import User, UserRole
+from observal_shared.migration.constants import DEFAULT_PROJECT_ID
 from services.registry_recommender import ALL_COMPONENT_TYPES
 from services.user_profile import WorkProfile, get_or_build_profile
 from services.user_recommendations import recommend_for_user, record_feedback
@@ -91,7 +92,7 @@ async def my_recommendations(
         profile = await get_or_build_profile(
             db,
             current_user.id,
-            get_project_id(current_user),
+            DEFAULT_PROJECT_ID,
             force=refresh,
         )
     except Exception as e:
@@ -102,7 +103,6 @@ async def my_recommendations(
     recommendations = await recommend_for_user(
         db,
         user_id=current_user.id,
-        org_id=current_user.org_id,
         profile=profile,
         component_types=component_types,
         limit=limit,

--- a/observal-server/api/routes/recommendations.py
+++ b/observal-server/api/routes/recommendations.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Personalised registry recommendations.
+
+A user's work profile is private to them: every endpoint here operates on
+``current_user`` only. There is deliberately no route to read someone else's
+profile or recommendations.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from loguru import logger as optic
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_db, get_project_id, require_role
+from models.user import User, UserRole
+from services.registry_recommender import ALL_COMPONENT_TYPES
+from services.user_profile import WorkProfile, get_or_build_profile
+from services.user_recommendations import recommend_for_user, record_feedback
+
+router = APIRouter(prefix="/api/v1/recommendations", tags=["recommendations"])
+
+_VALID_ACTIONS = {"dismissed", "not_relevant", "installed"}
+
+# The UI addresses component types in plural form ("mcps", "sandboxes").
+# `rstrip("s")` cannot be used here: it would turn "sandbox" into "sandbo".
+_TYPE_ALIASES: dict[str, str] = {
+    **{t: t for t in ALL_COMPONENT_TYPES},
+    "skills": "skill",
+    "hooks": "hook",
+    "prompts": "prompt",
+    "mcps": "mcp",
+    "sandboxes": "sandbox",
+}
+
+
+def _normalize_type(raw: str) -> str:
+    """Map a plural or singular type name onto its canonical singular form."""
+    normalized = _TYPE_ALIASES.get(raw.strip().lower())
+    if normalized is None:
+        raise HTTPException(status_code=400, detail=f"Unknown component type {raw!r}")
+    return normalized
+
+
+class RecommendationItem(BaseModel):
+    type: str
+    id: str
+    name: str
+    namespace: str
+    slug: str
+    qualified_name: str
+    description: str
+    category: str | None = None
+    latest_version: str
+    download_count: int
+    matched_on: list[str] = Field(default_factory=list)
+    score: float
+    reason: str
+
+
+class RecommendationsResponse(BaseModel):
+    items: list[RecommendationItem]
+    # False when the user has no session history yet, so the UI can label the
+    # rail honestly instead of implying personalisation that did not happen.
+    personalized: bool
+    profile_sessions: int
+    topics: list[str] = Field(default_factory=list)
+
+
+class FeedbackRequest(BaseModel):
+    component_type: str
+    component_id: uuid.UUID
+    action: str
+
+
+@router.get("/me", response_model=RecommendationsResponse)
+async def my_recommendations(
+    limit: int = Query(8, ge=1, le=24),
+    type_: str | None = Query(None, alias="type"),
+    refresh: bool = Query(False, description="Recompute the profile instead of using the cache"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Components recommended for the signed-in user."""
+    component_types = (_normalize_type(type_),) if type_ else ALL_COMPONENT_TYPES
+
+    try:
+        profile = await get_or_build_profile(
+            db,
+            current_user.id,
+            get_project_id(current_user),
+            force=refresh,
+        )
+    except Exception as e:
+        # Telemetry problems must not take down the registry home page.
+        optic.warning("recommendations: profile unavailable for {}: {}", current_user.id, e)
+        profile = WorkProfile()
+
+    recommendations = await recommend_for_user(
+        db,
+        user_id=current_user.id,
+        org_id=current_user.org_id,
+        profile=profile,
+        component_types=component_types,
+        limit=limit,
+    )
+
+    return RecommendationsResponse(
+        items=[RecommendationItem(**r.to_dict()) for r in recommendations],
+        personalized=not profile.is_empty(),
+        profile_sessions=profile.session_count,
+        topics=profile.topics,
+    )
+
+
+@router.post("/feedback", status_code=204)
+async def submit_feedback(
+    req: FeedbackRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    """Record a dismissal so the component stops being recommended."""
+    component_type = _normalize_type(req.component_type)
+    if req.action not in _VALID_ACTIONS:
+        raise HTTPException(status_code=400, detail=f"Unknown action {req.action!r}")
+
+    await record_feedback(db, current_user.id, component_type, req.component_id, req.action)

--- a/observal-server/jobs/catalog.py
+++ b/observal-server/jobs/catalog.py
@@ -48,9 +48,9 @@ async def refresh_user_profiles(ctx: dict):
     try:
         from sqlalchemy import select
 
-        from api.deps import get_project_id
         from database import async_session
         from models.user import User
+        from observal_shared.migration.constants import DEFAULT_PROJECT_ID
         from services.user_profile import get_or_build_profile, users_with_recent_activity
 
         active = await users_with_recent_activity()
@@ -62,11 +62,11 @@ async def refresh_user_profiles(ctx: dict):
         async with async_session() as db:
             users = (await db.execute(select(User).where(User.auth_provider != "deactivated"))).scalars().all()
             for user in users:
-                if active is not None and (get_project_id(user), str(user.id)) not in active:
+                if active is not None and (DEFAULT_PROJECT_ID, str(user.id)) not in active:
                     skipped += 1
                     continue
                 try:
-                    await get_or_build_profile(db, user.id, get_project_id(user), force=True)
+                    await get_or_build_profile(db, user.id, DEFAULT_PROJECT_ID, force=True)
                     refreshed += 1
                 except Exception as e:
                     # One bad user must not stop the sweep. The session is
@@ -75,6 +75,6 @@ async def refresh_user_profiles(ctx: dict):
                     # later user fails too, and one fault is misreported as N.
                     await db.rollback()
                     optic.warning("user_profile_refresh_failed", user_id=str(user.id), error=str(e))
-        optic.info("user_profiles_refreshed", count=refreshed, skipped_inactive=skipped)
+        optic.info("user_profiles_refreshed: count={}, skipped_inactive={}", refreshed, skipped)
     except Exception as e:
         optic.error("user_profile_batch_failed", error=str(e))

--- a/observal-server/jobs/catalog.py
+++ b/observal-server/jobs/catalog.py
@@ -28,3 +28,33 @@ async def batch_generate_insights(ctx: dict):
             optic.info("insight_batch_queued_reports", count=queued)
     except Exception as e:
         optic.error("insight_batch_failed", error=str(e))
+
+
+async def refresh_user_profiles(ctx: dict):
+    """Cron job: rebuild work profiles for users with recent activity.
+
+    Profiles are also built lazily on first request; this keeps the common
+    case warm so the registry home page never pays for a ClickHouse scan.
+    """
+    optic.debug("refresh_user_profiles")
+    try:
+        from sqlalchemy import select
+
+        from api.deps import get_project_id
+        from database import async_session
+        from models.user import User
+        from services.user_profile import get_or_build_profile
+
+        refreshed = 0
+        async with async_session() as db:
+            users = (await db.execute(select(User).where(User.auth_provider != "deactivated"))).scalars().all()
+            for user in users:
+                try:
+                    await get_or_build_profile(db, user.id, get_project_id(user), force=True)
+                    refreshed += 1
+                except Exception as e:
+                    # One bad user must not stop the sweep.
+                    optic.warning("user_profile_refresh_failed", user_id=str(user.id), error=str(e))
+        optic.info("user_profiles_refreshed", count=refreshed)
+    except Exception as e:
+        optic.error("user_profile_batch_failed", error=str(e))

--- a/observal-server/jobs/catalog.py
+++ b/observal-server/jobs/catalog.py
@@ -31,17 +31,18 @@ async def batch_generate_insights(ctx: dict):
 
 
 async def refresh_user_profiles(ctx: dict):
-    """Cron job: refresh every active user's work profile.
+    """Cron job: rebuild work profiles for users with recent session activity.
 
     Best-effort warm-up only. Correctness never depends on this job: a stale
-    or missing profile is rebuilt lazily on first request. It exists so the
-    registry home page rarely pays for a ClickHouse scan.
+    or missing profile is rebuilt lazily on first request, and a user skipped
+    here keeps an old ``computed_at`` so that lazy path still fires. It exists
+    so the registry home page rarely pays for a ClickHouse scan.
 
-    The sweep is sequential and unfiltered because there is no cheap
-    "recently active" signal in Postgres. A user with no sessions costs one
-    indexed ClickHouse lookup that returns nothing, so the floor is low; if
-    the job ever outgrows its timeout it is truncated harmlessly, and the
-    users it missed simply build on demand.
+    Cost scales with *active* users, not registered ones. One query collects
+    everyone with a session in the window, so an idle account costs nothing
+    instead of a round trip to discover it has no sessions. If that lookup
+    fails the sweep falls back to trying every user — degraded, not silently
+    disabled.
     """
     optic.debug("refresh_user_profiles")
     try:
@@ -50,12 +51,20 @@ async def refresh_user_profiles(ctx: dict):
         from api.deps import get_project_id
         from database import async_session
         from models.user import User
-        from services.user_profile import get_or_build_profile
+        from services.user_profile import get_or_build_profile, users_with_recent_activity
+
+        active = await users_with_recent_activity()
+        if active is None:
+            optic.warning("user_profile_activity_lookup_unavailable_sweeping_all")
 
         refreshed = 0
+        skipped = 0
         async with async_session() as db:
             users = (await db.execute(select(User).where(User.auth_provider != "deactivated"))).scalars().all()
             for user in users:
+                if active is not None and (get_project_id(user), str(user.id)) not in active:
+                    skipped += 1
+                    continue
                 try:
                     await get_or_build_profile(db, user.id, get_project_id(user), force=True)
                     refreshed += 1
@@ -66,6 +75,6 @@ async def refresh_user_profiles(ctx: dict):
                     # later user fails too, and one fault is misreported as N.
                     await db.rollback()
                     optic.warning("user_profile_refresh_failed", user_id=str(user.id), error=str(e))
-        optic.info("user_profiles_refreshed", count=refreshed)
+        optic.info("user_profiles_refreshed", count=refreshed, skipped_inactive=skipped)
     except Exception as e:
         optic.error("user_profile_batch_failed", error=str(e))

--- a/observal-server/jobs/catalog.py
+++ b/observal-server/jobs/catalog.py
@@ -31,10 +31,17 @@ async def batch_generate_insights(ctx: dict):
 
 
 async def refresh_user_profiles(ctx: dict):
-    """Cron job: rebuild work profiles for users with recent activity.
+    """Cron job: refresh every active user's work profile.
 
-    Profiles are also built lazily on first request; this keeps the common
-    case warm so the registry home page never pays for a ClickHouse scan.
+    Best-effort warm-up only. Correctness never depends on this job: a stale
+    or missing profile is rebuilt lazily on first request. It exists so the
+    registry home page rarely pays for a ClickHouse scan.
+
+    The sweep is sequential and unfiltered because there is no cheap
+    "recently active" signal in Postgres. A user with no sessions costs one
+    indexed ClickHouse lookup that returns nothing, so the floor is low; if
+    the job ever outgrows its timeout it is truncated harmlessly, and the
+    users it missed simply build on demand.
     """
     optic.debug("refresh_user_profiles")
     try:
@@ -53,7 +60,11 @@ async def refresh_user_profiles(ctx: dict):
                     await get_or_build_profile(db, user.id, get_project_id(user), force=True)
                     refreshed += 1
                 except Exception as e:
-                    # One bad user must not stop the sweep.
+                    # One bad user must not stop the sweep. The session is
+                    # shared across the loop, so a database error leaves it in
+                    # an aborted transaction: without this rollback every
+                    # later user fails too, and one fault is misreported as N.
+                    await db.rollback()
                     optic.warning("user_profile_refresh_failed", user_id=str(user.id), error=str(e))
         optic.info("user_profiles_refreshed", count=refreshed)
     except Exception as e:

--- a/observal-server/models/__init__.py
+++ b/observal-server/models/__init__.py
@@ -33,6 +33,7 @@ from models.submission import Submission
 from models.team import Team, TeamMembership, TeamRole
 from models.user import User, UserRole
 from models.user_group import UserGroup
+from models.user_profile import RecommendationFeedback, UserWorkProfile
 
 __all__ = [
     "Agent",
@@ -66,6 +67,7 @@ __all__ = [
     "MigrationStatus",
     "PromptDownload",
     "PromptListing",
+    "RecommendationFeedback",
     "SamlConfig",
     "SandboxDownload",
     "SandboxListing",
@@ -79,4 +81,5 @@ __all__ = [
     "User",
     "UserGroup",
     "UserRole",
+    "UserWorkProfile",
 ]

--- a/observal-server/models/user_profile.py
+++ b/observal-server/models/user_profile.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-user work profiles and recommendation feedback.
+
+A profile is a small, deterministic summary of what a user actually works on
+(languages, tools, MCP servers, topic buckets), derived from their own
+sessions. It exists so registry recommendations can be personal without
+re-scanning ClickHouse on every page load.
+
+Profiles are private to their owner. Nothing here stores prompt text or any
+other transcript content — only aggregate counts over metadata.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+
+
+class UserWorkProfile(Base):
+    """Cached summary of one user's recent work."""
+
+    __tablename__ = "user_work_profiles"
+    __table_args__ = (UniqueConstraint("user_id", name="uq_user_work_profiles_user"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    computed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    # Number of sessions the profile was derived from. Zero means the user has
+    # no usable history yet and callers should fall back to popularity.
+    session_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    # {"languages": [...], "tools": [...], "mcp_servers": [...],
+    #  "topics": [...], "harnesses": [...], "error_categories": [...]}
+    profile: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+
+
+class RecommendationFeedback(Base):
+    """A user's explicit response to a recommendation.
+
+    Dismissals are honoured on subsequent requests so a recommendation the
+    user rejected does not keep reappearing.
+    """
+
+    __tablename__ = "recommendation_feedback"
+    __table_args__ = (
+        UniqueConstraint("user_id", "component_type", "component_id", name="uq_recommendation_feedback_user_component"),
+        Index("ix_recommendation_feedback_user", "user_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    component_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    component_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    # "dismissed" | "not_relevant" | "installed"
+    action: Mapped[str] = mapped_column(String(30), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -26,6 +26,10 @@ dependencies = [
     "gitpython>=3.1.55",
     "boto3",
     "litellm>=1.80.0,<1.90.0",
+    # Required by LiteLLM for the `vertex_ai/*` models the insights settings
+    # page offers. Without it every Vertex call fails with "Google Cloud SDK
+    # not found", including Express Mode keys that need no GCP project.
+    "google-cloud-aiplatform>=1.60.0",
     "redis[hiredis]>=5.0",
     "arq",
     "strawberry-graphql[fastapi]>=0.315.4",

--- a/observal-server/routes.py
+++ b/observal-server/routes.py
@@ -29,6 +29,7 @@ from api.routes.logs_stream import router as logs_stream_router
 from api.routes.mcp import router as mcp_router
 from api.routes.preview import router as preview_router
 from api.routes.prompt import router as prompt_router
+from api.routes.recommendations import router as recommendations_router
 from api.routes.registry import router as registry_router
 from api.routes.review import router as review_router
 from api.routes.sandbox import router as sandbox_router
@@ -79,6 +80,7 @@ REST_ROUTERS = (
     sso_saml_router,
     scim_router,
     exec_dashboard_router,
+    recommendations_router,
 )
 
 

--- a/observal-server/services/dynamic_settings.py
+++ b/observal-server/services/dynamic_settings.py
@@ -234,6 +234,11 @@ DEFAULTS: dict[str, str] = {
     "insights.min_sessions": "5",
     "insights.facet_max_calls": "100",
     "insights.facet_concurrency": "25",
+    # Insights: reuse-existing-component suggestions. Disabling falls back to
+    # suggestions that only ever propose building something new.
+    "insights.registry_match_enabled": "true",
+    "insights.registry_match_per_type": "6",
+    "insights.registry_match_max_items": "24",
     # Auth
     "auth.self_registration_enabled": "false",
     # OIDC SSO. Changes require an API restart because the Authlib client is built at startup.

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -119,7 +119,7 @@ def _build_registry_scope(agent: Agent | None, agent_config: dict | None) -> Reg
     report's signals exist — see :mod:`services.insights.registry_match`.
     """
     if agent is None:
-        return RegistryScope(org_id=None, attached_ids=())
+        return RegistryScope(user_id=None, attached_ids=())
 
     attached: list = []
     for component in (agent_config or {}).get("current_components", []) or []:
@@ -131,7 +131,7 @@ def _build_registry_scope(agent: Agent | None, agent_config: dict | None) -> Reg
         except (ValueError, TypeError):
             continue
 
-    return RegistryScope(org_id=agent.owner_org_id, attached_ids=tuple(attached))
+    return RegistryScope(user_id=agent.created_by, attached_ids=tuple(attached))
 
 
 # Maximum time a report can stay in 'running' before being considered stale.

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -10,6 +10,7 @@ This module stays in the main repo because it directly interacts with
 PostgreSQL models (Agent, InsightReport) and Redis job queues.
 """
 
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -22,6 +23,8 @@ from services.clickhouse import _query
 from services.insight_version_filters import agent_version_filter
 from services.redis import _get_arq_pool
 from services.secrets_redactor import redact_secrets
+
+from .registry_match import RegistryScope
 
 logger = structlog.get_logger(__name__)
 
@@ -104,51 +107,31 @@ async def _load_agent_config(db, agent_id) -> dict | None:
     return config
 
 
-async def _load_registry_catalog(db) -> dict:
-    """Load a summary of available MCPs and skills from the registry.
+def _build_registry_scope(agent: Agent | None, agent_config: dict | None) -> RegistryScope:
+    """Describe which registry components this agent may be offered.
 
-    Returns a compact catalog for the LLM to reference when suggesting
-    new components the agent could benefit from.
+    Attached components come from ``agent_config``, which is built from the
+    latest *approved* version — the same one the report analyses. Reading
+    ``agent.latest_version`` instead could exclude the wrong set whenever a
+    newer version is still pending review.
+
+    The shortlist itself is built later, inside the pipeline, once the
+    report's signals exist — see :mod:`services.insights.registry_match`.
     """
-    from models.mcp import ListingStatus, McpListing, McpVersion
-    from models.skill import SkillListing, SkillVersion
+    if agent is None:
+        return RegistryScope(org_id=None, attached_ids=())
 
-    catalog: dict = {"mcps": [], "skills": []}
+    attached: list = []
+    for component in (agent_config or {}).get("current_components", []) or []:
+        component_id = component.get("id") if isinstance(component, dict) else None
+        if not component_id:
+            continue
+        try:
+            attached.append(uuid.UUID(str(component_id)))
+        except (ValueError, TypeError):
+            continue
 
-    # Public MCPs with their latest version description
-    mcp_stmt = (
-        select(McpListing.id, McpListing.name, McpListing.category, McpVersion.description)
-        .join(McpVersion, McpListing.latest_version_id == McpVersion.id, isouter=True)
-        .where(McpListing.is_private == False, McpVersion.status == ListingStatus.approved)  # noqa: E712
-    )
-    mcp_result = await db.execute(mcp_stmt)
-    for row in mcp_result.all():
-        catalog["mcps"].append(
-            {
-                "id": str(row[0]),
-                "name": row[1],
-                "category": row[2],
-                "description": (row[3] or "")[:120],
-            }
-        )
-
-    # Public skills with their latest version description
-    skill_stmt = (
-        select(SkillListing.id, SkillListing.name, SkillVersion.description)
-        .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id, isouter=True)
-        .where(SkillListing.is_private == False, SkillVersion.status == ListingStatus.approved)  # noqa: E712
-    )
-    skill_result = await db.execute(skill_stmt)
-    for row in skill_result.all():
-        catalog["skills"].append(
-            {
-                "id": str(row[0]),
-                "name": row[1],
-                "description": (row[2] or "")[:120],
-            }
-        )
-
-    return catalog
+    return RegistryScope(org_id=agent.owner_org_id, attached_ids=tuple(attached))
 
 
 # Maximum time a report can stay in 'running' before being considered stale.
@@ -238,8 +221,9 @@ async def run_single_report(report_id: str) -> None:
                 if prev_report and prev_report.aggregated_data:
                     previous_metrics = prev_report.aggregated_data
 
-            # Load registry catalog for component-aware suggestions
-            registry_catalog = await _load_registry_catalog(db)
+            # Scope for registry reuse suggestions. The shortlist itself is
+            # built inside the pipeline once the report's signals exist.
+            registry_scope = _build_registry_scope(agent, agent_config)
 
             async def progress_callback(phase: str, current: int, total: int, message: str) -> None:
                 await _update_report_progress(db, report, phase, current, total, message)
@@ -254,7 +238,7 @@ async def run_single_report(report_id: str) -> None:
                 period_end=end_str,
                 previous_metrics=previous_metrics,
                 agent_config=agent_config,
-                registry_catalog=registry_catalog,
+                registry_scope=registry_scope,
                 db=db,
                 progress_callback=progress_callback,
             )

--- a/observal-server/services/insights/generator.py
+++ b/observal-server/services/insights/generator.py
@@ -25,6 +25,13 @@ from observal_shared.migration.constants import DEFAULT_PROJECT_ID
 
 from ._deps import get_db_session
 from .facets import aggregate_facets, extract_and_cache_facets, load_cached_facets_batch
+from .registry_match import (
+    RegistryScope,
+    build_catalog,
+    build_signals,
+    count_reused,
+    validate_reuse_suggestions,
+)
 from .sections import generate_sections
 from .session_meta_extractor import aggregate_metas, extract_all_session_metas
 from .transcript import build_session_transcript
@@ -46,7 +53,7 @@ async def generate_report_content(
     period_end: str = "",
     previous_metrics: dict | None = None,
     agent_config: dict | None = None,
-    registry_catalog: dict | None = None,
+    registry_scope: RegistryScope | None = None,
     db=None,
     progress_callback=None,
 ) -> dict:
@@ -71,7 +78,7 @@ async def generate_report_content(
             period_end=period_end,
             previous_metrics=previous_metrics,
             agent_config=agent_config,
-            registry_catalog=registry_catalog,
+            registry_scope=registry_scope,
             db=db,
             progress_callback=progress_callback,
         )
@@ -89,11 +96,12 @@ async def _run_pipeline(
     period_end: str,
     previous_metrics: dict | None,
     agent_config: dict | None,
-    registry_catalog: dict | None,
+    registry_scope: RegistryScope | None,
     db=None,
     progress_callback=None,
 ) -> dict:
     """Core pipeline execution."""
+    registry_scope = registry_scope or RegistryScope()
 
     logger.info(
         "insight_pipeline_started",
@@ -369,13 +377,39 @@ async def _run_pipeline(
     except Exception as e:
         logger.warning("version_impact_analysis_failed", error=str(e))
 
+    # ── Step 4c: Shortlist reusable registry components ───────────────────
+    # Driven by this report's own signals, so the model is offered things
+    # that actually relate to the observed work rather than the whole
+    # registry. Never fatal: an empty offer just omits the catalog block.
+    # build_signals runs before build_catalog's own guard, so it needs its
+    # own: a malformed facet shape must not take down the whole report.
+    try:
+        registry_signals = build_signals(agg=agg, facets_summary=facets_summary, agent_config=agent_config)
+    except Exception as e:
+        logger.warning("insight_signal_build_failed", error=str(e))
+        registry_signals = ""
+    registry_offer = await build_catalog(db, registry_scope, registry_signals)
+
     # ── Step 5: Generate narrative sections (7 parallel + 1 synthesis) ────
     await _emit_progress(progress_callback, "generating_sections", 7, 9, "Generating report sections")
     narrative = await generate_sections(
         data_block=data_block,
         previous_report=previous_metrics,
-        registry_catalog=registry_catalog,
+        registry_offer=registry_offer,
     )
+
+    # Ground every reuse suggestion before anything renders it. An id the
+    # model invented must never reach the UI as a real component link.
+    try:
+        narrative = await validate_reuse_suggestions(narrative, registry_offer, db, registry_scope)
+    except Exception as e:
+        logger.warning("insight_reuse_validation_failed", error=str(e))
+
+    # Record what the reuse search actually did, so the report can say
+    # "nothing matched" rather than leaving the reader to guess whether it
+    # even ran.
+    if isinstance(narrative, dict):
+        narrative["registry_match"] = registry_offer.to_summary(reused=count_reused(narrative))
 
     await _emit_progress(progress_callback, "synthesizing", 8, 9, "Synthesizing report")
 

--- a/observal-server/services/insights/html_export.py
+++ b/observal-server/services/insights/html_export.py
@@ -642,12 +642,41 @@ def render_report_html(report: dict) -> str:
                 if isinstance(f, dict):
                     example = f.get("example", "")
                     example_attr = html.escape(example, quote=True) if example else ""
+                    ref = f.get("component_ref") if isinstance(f.get("component_ref"), dict) else None
+                    # A validated reuse suggestion shows the real component
+                    # instead of generated content there is nothing to copy from.
+                    reuse_html = ""
+                    if ref:
+                        reuse_html = (
+                            '<div style="margin-top:10px;padding:10px 12px;border:1px solid var(--border);'
+                            'border-radius:var(--radius-xs);background:var(--bg-alt)">'
+                            '<div style="font-size:11px;text-transform:uppercase;letter-spacing:.04em;'
+                            'color:var(--text-muted);margin-bottom:4px">Already in your registry</div>'
+                            f'<div style="font-size:13px;font-weight:600">{_esc(ref.get("qualified_name") or ref.get("name", ""))}'
+                            f'<span style="font-family:monospace;font-weight:400;color:var(--text-muted);margin-left:8px">'
+                            f"v{_esc(ref.get('latest_version', ''))}</span></div></div>"
+                        )
+                    match_reason = f.get("match_reason") or ""
+                    match_html = (
+                        f'<p style="font-size:12px;color:var(--text-muted);margin-top:8px;font-style:italic">'
+                        f"Why this fits: {_esc(match_reason)}</p>"
+                        if match_reason
+                        else ""
+                    )
+                    badge = "Reuse existing" if ref else f.get("feature", "")
+                    example_html = (
+                        f'<pre style="background:var(--bg-alt);border:1px solid var(--border);border-radius:var(--radius-xs);padding:12px 14px;font-family:monospace;font-size:12px;color:var(--text-secondary);white-space:pre-wrap;word-break:break-all;margin-top:10px">{_esc(example)}</pre><button class="copy-btn" style="margin-top:6px" onclick="navigator.clipboard.writeText(this.getAttribute(&quot;data-text&quot;)).then(()=>{{this.textContent=&quot;Copied!&quot;;setTimeout(()=>this.textContent=&quot;Copy&quot;,1500)}})" data-text="{example_attr}">Copy</button>'
+                        if example and not ref
+                        else ""
+                    )
                     feat_cards += f"""
         <div class="suggestion-card">
-          <span class="meta-badge" style="margin-bottom:8px;display:inline-block">{_esc(f.get("feature", ""))}</span>
+          <span class="meta-badge" style="margin-bottom:8px;display:inline-block">{_esc(badge)}</span>
           <h4 style="font-size:14px;margin-bottom:4px">{_esc(f.get("one_liner", ""))}</h4>
           <p style="font-size:13px;color:var(--text-secondary);margin-top:6px">{_esc(f.get("why_for_you", ""))}</p>
-          {f'<pre style="background:var(--bg-alt);border:1px solid var(--border);border-radius:var(--radius-xs);padding:12px 14px;font-family:monospace;font-size:12px;color:var(--text-secondary);white-space:pre-wrap;word-break:break-all;margin-top:10px">{_esc(example)}</pre><button class="copy-btn" style="margin-top:6px" onclick="navigator.clipboard.writeText(this.getAttribute(&quot;data-text&quot;)).then(()=>{{this.textContent=&quot;Copied!&quot;;setTimeout(()=>this.textContent=&quot;Copy&quot;,1500)}})" data-text="{example_attr}">Copy</button>' if example else ""}
+          {reuse_html}
+          {match_html}
+          {example_html}
         </div>"""
             sugg_parts.append(f"""
       <h3 style="font-size:15px;font-weight:600;margin:24px 0 12px">Features to Try</h3>

--- a/observal-server/services/insights/registry_match.py
+++ b/observal-server/services/insights/registry_match.py
@@ -199,10 +199,13 @@ async def build_catalog(
     if not ds.get_sync_bool("insights.registry_match_enabled", True):
         return CatalogOffer(enabled=False)
 
-    per_type = ds.get_sync_int("insights.registry_match_per_type", 6)
-    total = ds.get_sync_int("insights.registry_match_max_items", 24)
-
     try:
+        # Operator-supplied caps. A zero or negative value would become
+        # LIMIT 0 and make the feature look broken rather than disabled —
+        # `registry_match_enabled` is the switch for turning it off.
+        per_type = max(1, ds.get_sync_int("insights.registry_match_per_type", 6))
+        total = max(1, ds.get_sync_int("insights.registry_match_max_items", 24))
+
         candidates = await shortlist(
             db,
             signals=signals,

--- a/observal-server/services/insights/registry_match.py
+++ b/observal-server/services/insights/registry_match.py
@@ -8,7 +8,7 @@ Three stages, in order:
 1. :func:`build_signals` — distil a report's aggregates and facets into a
    search string describing what this agent actually does.
 2. :func:`build_catalog` — ask the shared recommender for a small, ranked,
-   org-visible shortlist of components the agent is *not* already using.
+   user-visible shortlist of components the agent is *not* already using.
 3. :func:`validate_reuse_suggestions` — after the LLM has written its
    suggestions, drop any reuse that names a component we did not offer or
    that no longer resolves. The model's output is never trusted as a
@@ -49,7 +49,7 @@ REUSE_ACTIONS = frozenset({"reuse_existing_component", "attach_registry_componen
 class RegistryScope:
     """Which components an agent may be offered, and which it already has."""
 
-    org_id: uuid.UUID | None = None
+    user_id: uuid.UUID | None = None
     attached_ids: tuple[uuid.UUID, ...] = ()
 
 
@@ -209,7 +209,7 @@ async def build_catalog(
         candidates = await shortlist(
             db,
             signals=signals,
-            org_id=scope.org_id,
+            user_id=scope.user_id,
             exclude_ids=scope.attached_ids,
             per_type_limit=per_type,
             total_limit=total,
@@ -246,7 +246,7 @@ async def _registry_has_any(db: AsyncSession, scope: RegistryScope) -> bool:
         probe = await shortlist(
             db,
             signals="",
-            org_id=scope.org_id,
+            user_id=scope.user_id,
             exclude_ids=scope.attached_ids,
             per_type_limit=1,
             total_limit=1,
@@ -303,7 +303,7 @@ async def validate_reuse_suggestions(
     resolved = {}
     if eligible:
         refs = [(t, cid) for _, cid in eligible for t in ALL_COMPONENT_TYPES]
-        resolved = await resolve_components(db, refs, org_id=scope.org_id)
+        resolved = await resolve_components(db, refs, user_id=scope.user_id)
 
     resolved_by_id: dict[uuid.UUID, object] = {}
     for (_component_type, component_id), component in resolved.items():

--- a/observal-server/services/insights/registry_match.py
+++ b/observal-server/services/insights/registry_match.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Point insight suggestions at components the registry already has.
+
+Three stages, in order:
+
+1. :func:`build_signals` — distil a report's aggregates and facets into a
+   search string describing what this agent actually does.
+2. :func:`build_catalog` — ask the shared recommender for a small, ranked,
+   org-visible shortlist of components the agent is *not* already using.
+3. :func:`validate_reuse_suggestions` — after the LLM has written its
+   suggestions, drop any reuse that names a component we did not offer or
+   that no longer resolves. The model's output is never trusted as a
+   registry reference.
+
+Stage 3 is the part that makes this safe to ship: without it a hallucinated
+UUID would be rendered to users as a real component.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import structlog
+
+from services.registry_recommender import (
+    ALL_COMPONENT_TYPES,
+    build_signal_query,
+    coerce_uuid,
+    resolve_components,
+    shortlist,
+)
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger(__name__)
+
+# Action types the LLM may use to mean "attach something that already exists".
+REUSE_ACTIONS = frozenset({"reuse_existing_component", "attach_registry_component"})
+
+
+@dataclass(frozen=True)
+class RegistryScope:
+    """Which components an agent may be offered, and which it already has."""
+
+    org_id: uuid.UUID | None = None
+    attached_ids: tuple[uuid.UUID, ...] = ()
+
+
+@dataclass
+class CatalogOffer:
+    """The shortlist that was actually shown to the model.
+
+    Kept so validation can check the model only referenced what it was given,
+    and so the report can tell the reader *why* there were no reuse
+    suggestions. "We searched and nothing fit" and "there was nothing to
+    search" look identical from an empty list, but mean opposite things to
+    someone deciding whether the feature works.
+    """
+
+    entries_by_type: dict[str, list[dict]] = field(default_factory=dict)
+    offered_ids: set[uuid.UUID] = field(default_factory=set)
+    # False when the agent can see no approved components at all. None when
+    # we did not need to check (because the shortlist found something).
+    registry_has_components: bool | None = None
+    # False when an operator turned reuse suggestions off.
+    enabled: bool = True
+
+    def __bool__(self) -> bool:
+        return bool(self.entries_by_type)
+
+    @property
+    def item_count(self) -> int:
+        return sum(len(v) for v in self.entries_by_type.values())
+
+    def to_summary(self, reused: int = 0) -> dict:
+        """Persisted alongside the narrative so the UI can explain itself."""
+        return {
+            "enabled": self.enabled,
+            "offered": self.item_count,
+            "reused": reused,
+            "registry_has_components": self.registry_has_components,
+        }
+
+
+def build_signals(
+    agg: dict | None = None,
+    facets_summary: dict | None = None,
+    agent_config: dict | None = None,
+) -> str:
+    """Build the search string that drives the shortlist.
+
+    Draws on what the agent *does* (goals, languages, tools) and where it
+    *struggles* (friction types, tool error categories), because both are
+    reasons to reach for an existing component.
+    """
+    agg = agg or {}
+    facets_summary = facets_summary or {}
+
+    def _labels(items, key: str) -> list[str]:
+        """Pull labels out of the assorted shapes aggregates use.
+
+        Facets come back from an LLM, so a field can arrive as the wrong
+        shape entirely. Anything unexpected yields no labels rather than
+        raising — a bad signal is recoverable, a failed report is not.
+        """
+        out: list[str] = []
+        if isinstance(items, str):
+            # Iterating a string would emit one token per character.
+            return []
+        if isinstance(items, dict):
+            items = list(items.items())
+        if not isinstance(items, list | tuple):
+            return []
+        for item in items or []:
+            if isinstance(item, dict):
+                value = item.get(key) or item.get("name") or item.get("category")
+            elif isinstance(item, list | tuple) and item:
+                value = item[0]
+            else:
+                value = item
+            if value:
+                out.append(str(value))
+        return out
+
+    tools = _labels(agg.get("top_tools"), "tool")[:12]
+    config = agent_config or {}
+
+    return build_signal_query(
+        # What the agent is *for*. Tool names and languages describe mechanics
+        # ("Edit", "TypeScript") but carry no domain vocabulary, so an agent
+        # doing React work looks identical to one doing terraform work. The
+        # agent's own prompt is where words like "React" or "terraform" live,
+        # and without it the shortlist starves on anything but tool-name matches.
+        _domain_words(config),
+        _labels(facets_summary.get("goal_categories"), "category")[:10],
+        _labels(facets_summary.get("friction_types"), "type")[:8],
+        _labels(agg.get("top_languages"), "language")[:6],
+        tools,
+        # An MCP tool reads as one opaque token ("mcp__postgres__query"), which
+        # matches nothing. The server name inside it is the useful signal — it
+        # names the domain the user actually works in.
+        _mcp_server_names(tools),
+        _labels(agg.get("tool_error_categories"), "category")[:5],
+        _labels(facets_summary.get("repeated_instructions"), "instruction")[:5],
+        (agent_config or {}).get("category") or "",
+        (agent_config or {}).get("configured_mcps") or [],
+    )
+
+
+# Enough of the prompt to carry the domain, not so much that boilerplate
+# ("you are a helpful assistant...") drowns out the specific words.
+_PROMPT_SIGNAL_CHARS = 400
+
+
+def _domain_words(agent_config: dict) -> list[str]:
+    """Domain vocabulary describing what this agent is for."""
+    parts: list[str] = []
+    excerpt = agent_config.get("system_prompt_excerpt")
+    if isinstance(excerpt, str) and excerpt.strip():
+        parts.append(excerpt[:_PROMPT_SIGNAL_CHARS])
+    for key in ("name", "description", "category"):
+        value = agent_config.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(value)
+    return parts
+
+
+def _mcp_server_names(tool_names: list[str]) -> list[str]:
+    """Pull server names out of ``mcp__<server>__<tool>`` tool identifiers."""
+    servers: list[str] = []
+    for name in tool_names:
+        if not name.startswith("mcp__"):
+            continue
+        parts = name.split("__")
+        if len(parts) >= 2 and parts[1]:
+            servers.append(parts[1])
+    return servers
+
+
+async def build_catalog(
+    db: AsyncSession,
+    scope: RegistryScope,
+    signals: str,
+) -> CatalogOffer:
+    """Shortlist components for the suggestions prompt.
+
+    Returns an empty offer when the feature is disabled or nothing matches;
+    callers then simply omit the catalog block from the prompt.
+    """
+    import services.dynamic_settings as ds
+
+    if not ds.get_sync_bool("insights.registry_match_enabled", True):
+        return CatalogOffer(enabled=False)
+
+    per_type = ds.get_sync_int("insights.registry_match_per_type", 6)
+    total = ds.get_sync_int("insights.registry_match_max_items", 24)
+
+    try:
+        candidates = await shortlist(
+            db,
+            signals=signals,
+            org_id=scope.org_id,
+            exclude_ids=scope.attached_ids,
+            per_type_limit=per_type,
+            total_limit=total,
+        )
+    except Exception as e:
+        # A recommendation failure must never fail the whole report.
+        logger.warning("insight_registry_shortlist_failed", error=str(e))
+        return CatalogOffer()
+
+    offer = CatalogOffer()
+    for candidate in candidates:
+        offer.entries_by_type.setdefault(f"{candidate.component_type}s", []).append(candidate.to_catalog_entry())
+        offer.offered_ids.add(candidate.id)
+
+    if not offer:
+        # Nothing matched. Find out whether that is because the registry is
+        # empty or because nothing was relevant — the report says different
+        # things in each case. One cheap unfiltered lookup answers it.
+        offer.registry_has_components = await _registry_has_any(db, scope)
+
+    logger.info(
+        "insight_registry_shortlist",
+        items=offer.item_count,
+        types=sorted(offer.entries_by_type),
+        signal_chars=len(signals),
+        registry_has_components=offer.registry_has_components,
+    )
+    return offer
+
+
+async def _registry_has_any(db: AsyncSession, scope: RegistryScope) -> bool:
+    """Whether this agent can see any approved component at all."""
+    try:
+        probe = await shortlist(
+            db,
+            signals="",
+            org_id=scope.org_id,
+            exclude_ids=scope.attached_ids,
+            per_type_limit=1,
+            total_limit=1,
+        )
+        return bool(probe)
+    except Exception as e:
+        logger.warning("insight_registry_probe_failed", error=str(e))
+        return False
+
+
+async def validate_reuse_suggestions(
+    narrative: dict,
+    offer: CatalogOffer,
+    db: AsyncSession,
+    scope: RegistryScope,
+) -> dict:
+    """Ground every reuse suggestion against the registry.
+
+    A ``features_to_try`` entry claiming to reuse an existing component is
+    kept only when its id was in the shortlist we offered *and* still
+    resolves to an approved, visible listing. Anything else is rewritten
+    into a plain suggestion with the bogus reference stripped, so the user
+    still sees the idea but never a fake component link.
+
+    Returns the narrative (mutated in place) for convenience.
+    """
+    suggestions = narrative.get("suggestions")
+    if not isinstance(suggestions, dict):
+        return narrative
+
+    features = suggestions.get("features_to_try")
+    if not isinstance(features, list):
+        return narrative
+
+    # Collect the ids the model claims to reuse.
+    wanted: list[tuple[int, uuid.UUID]] = []
+    for idx, feature in enumerate(features):
+        if not isinstance(feature, dict):
+            continue
+        action = str(feature.get("action_type") or "").lower()
+        if action not in REUSE_ACTIONS:
+            continue
+        component_id = coerce_uuid(feature.get("existing_component_id"))
+        if component_id is not None:
+            wanted.append((idx, component_id))
+
+    if not wanted:
+        return narrative
+
+    # Only ids we actually offered are eligible. This is what stops a
+    # plausible-looking but invented UUID from reaching the UI.
+    eligible = [(idx, cid) for idx, cid in wanted if cid in offer.offered_ids]
+
+    resolved = {}
+    if eligible:
+        refs = [(t, cid) for _, cid in eligible for t in ALL_COMPONENT_TYPES]
+        resolved = await resolve_components(db, refs, org_id=scope.org_id)
+
+    resolved_by_id: dict[uuid.UUID, object] = {}
+    for (_component_type, component_id), component in resolved.items():
+        resolved_by_id.setdefault(component_id, component)
+
+    dropped = 0
+    for idx, component_id in wanted:
+        feature = features[idx]
+        component = resolved_by_id.get(component_id)
+        if component is None:
+            dropped += 1
+            feature["action_type"] = "create_new_skill" if _looks_like_skill(feature) else "no_action"
+            feature["existing_component_id"] = None
+            feature["component_ref"] = None
+            continue
+        # Attach the resolved reference so UI/HTML/CLI can render a real
+        # link and the correct version without re-querying.
+        feature["existing_component_id"] = str(component.id)
+        feature["component_ref"] = component.to_ref()
+
+    if dropped:
+        logger.warning(
+            "insight_reuse_suggestions_rejected",
+            dropped=dropped,
+            offered=len(offer.offered_ids),
+            claimed=len(wanted),
+        )
+
+    return narrative
+
+
+def _looks_like_skill(feature: dict) -> bool:
+    label = f"{feature.get('feature') or ''}".lower()
+    return "skill" in label
+
+
+def count_reused(narrative: dict) -> int:
+    """How many suggestions survived validation with a real component."""
+    suggestions = narrative.get("suggestions")
+    if not isinstance(suggestions, dict):
+        return 0
+    features = suggestions.get("features_to_try")
+    if not isinstance(features, list):
+        return 0
+    return sum(1 for f in features if isinstance(f, dict) and f.get("component_ref"))
+
+
+def catalog_block(offer: CatalogOffer) -> str:
+    """Render the shortlist for inclusion in the suggestions prompt."""
+    if not offer:
+        return ""
+    return (
+        "\n\n## Reusable Components Already In This Registry\n"
+        "These are approved components this agent is NOT currently using. "
+        "When one of them solves an observed problem, prefer reusing it over "
+        "inventing something new. Copy `id` verbatim into "
+        "`existing_component_id` — never invent an id.\n" + json.dumps(offer.entries_by_type, indent=2)
+    )
+
+
+def offered_summary(offer: CatalogOffer) -> list[str]:
+    """Short human-readable list of what was offered (for logs/debugging)."""
+    names: list[str] = []
+    for entries in offer.entries_by_type.values():
+        names.extend(str(e.get("qualified_name") or e.get("name") or "") for e in entries)
+    return [n for n in names if n]
+
+
+__all__ = [
+    "CatalogOffer",
+    "RegistryScope",
+    "build_catalog",
+    "build_signals",
+    "catalog_block",
+    "count_reused",
+    "offered_summary",
+    "validate_reuse_suggestions",
+]

--- a/observal-server/services/insights/sections.py
+++ b/observal-server/services/insights/sections.py
@@ -21,10 +21,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import TYPE_CHECKING
 
 import structlog
 
 from ._deps import get_call_model
+from .registry_match import catalog_block
+
+if TYPE_CHECKING:
+    from .registry_match import CatalogOffer
 
 logger = structlog.get_logger(__name__)
 
@@ -205,9 +210,10 @@ RESPOND WITH ONLY A VALID JSON OBJECT:
     "features_to_try": [
       {{
         "action_type": "reuse_existing_component | attach_registry_component | remove_component | create_new_skill | create_new_hook | no_action",
-        "feature": "Skill | Hook | Prompt | Component",
+        "feature": "Skill | Hook | Prompt | MCP | Sandbox | Component",
         "name": "short-kebab-name (max 30 chars, e.g. 'scope-guard', 'pr-review', 'test-runner')",
-        "existing_component_id": "registry/current component id when action_type is reuse/attach/remove, else null",
+        "existing_component_id": "the exact `id` copied from the reusable-components list when action_type is reuse/attach/remove, else null",
+        "match_reason": "for reuse only: which observed problem this existing component solves, citing the data",
         "one_liner": "what it does in one sentence",
         "why_for_you": "why this would help YOU based on your sessions",
         "confidence": "high | medium | low | insufficient_data",
@@ -228,11 +234,27 @@ RESPOND WITH ONLY A VALID JSON OBJECT:
 
 Rules:
 - config_additions: PRIORITIZE instructions from USER INSTRUCTIONS and REPEATED INSTRUCTIONS sections. These are things the user has ALREADY told the agent but it keeps forgetting. Maximum 7.
-- features_to_try: 2-3 concrete suggestions. Prefer reuse_existing_component or attach_registry_component when the registry/current agent already has a matching component. ONLY create new Skills or Hooks when no existing component fits. NEVER suggest MCP servers.
+- features_to_try: 2-3 concrete suggestions.
 - usage_patterns: 2-4 suggestions for how to prompt differently. Each must include a copyable prompt the user can try immediately.
 - NEVER suggest vague improvements. Be specific: include the exact text, command, or config.
 - If COMPONENT UTILIZATION marks a component unused/harmful, you may suggest action_type=remove_component with the existing component id/name and risk.
 - Every suggested action must include confidence and risk.
+
+REUSING WHAT ALREADY EXISTS (most important rule):
+If a "Reusable Components Already In This Registry" section is present, it lists approved
+components this agent is NOT yet using. Building something the user already owns wastes
+their time, so:
+- FIRST check whether a listed component genuinely solves an observed problem.
+- If one does, use action_type=reuse_existing_component, set "existing_component_id" to that
+  entry's `id` copied EXACTLY, set "feature" to its type, and explain the fit in "match_reason".
+- Only suggest create_new_skill / create_new_hook when NOTHING listed fits. When you create
+  something new despite the list being non-empty, say why in "why_for_you".
+- ONLY suggest a match when it genuinely fits. A forced or approximate match is worse than
+  no suggestion: it sends the user to install something that will not help. If nothing fits,
+  do not reuse anything.
+- NEVER invent an id. Any id not copied from the list is discarded, and the suggestion with it.
+- MCP servers may be RECOMMENDED FOR REUSE from the list, but never invented: do not propose
+  creating a new MCP server.
 
 FEATURE FORMAT REQUIREMENTS:
 
@@ -277,9 +299,10 @@ If "Agent Configuration" is present:
 - If tool_errors are high, suggest a validation hook
 - For registry components, include: `observal agent add skill <id>`
 
-SKILLS TO ADD (always include at least 1 skill suggestion):
+SKILLS (include at least 1 skill suggestion, reused or new):
 - Identify the user's most repetitive workflows from goal_categories and session summaries
-- Suggest a specific skill with name, description, and the full SKILL.md content
+- If a listed reusable component already covers that workflow, reuse it instead of writing a new one
+- Otherwise suggest a specific skill with name, description, and the full SKILL.md content
 - The skill content must be actionable steps using real tools, not pseudocode
 
 HOOKS TO ADD (include if friction warrants it):
@@ -537,14 +560,14 @@ async def _call_section(section_name: str, prompt: str, model: str | None = None
 async def generate_sections(
     data_block: str,
     previous_report: dict | None = None,
-    registry_catalog: dict | None = None,
+    registry_offer: CatalogOffer | None = None,
 ) -> dict:
     """Run parallel section prompts + 1 synthesis, return combined narrative.
 
     Args:
         data_block: Formatted string with all metrics, facets, and session data.
         previous_report: Previous report's aggregated_data for regression comparison.
-        registry_catalog: Filtered catalog of available components (only for suggestions).
+        registry_offer: Shortlist of reusable components (only for suggestions).
 
     Returns:
         Dict with structured section outputs for each narrative section.
@@ -558,13 +581,7 @@ async def generate_sections(
     else:
         previous_data_block = "## Previous Period Metrics\nNo previous period data available."
 
-    # Build catalog block for suggestions
-    catalog_block = ""
-    if registry_catalog:
-        catalog_block = (
-            "\n\n## Available Components (registry catalog, NOT yet configured on this agent)\n"
-            + json.dumps(registry_catalog, indent=2)
-        )
+    offer_block = catalog_block(registry_offer) if registry_offer else ""
 
     # Resolve models
     deep_model = await _get_section_model()
@@ -574,9 +591,7 @@ async def generate_sections(
         "insight_sections_starting",
         deep_model=deep_model or "default",
         fast_model=fast_model or "default",
-        catalog_items=(len(registry_catalog.get("mcps", [])) + len(registry_catalog.get("skills", [])))
-        if registry_catalog
-        else 0,
+        catalog_items=registry_offer.item_count if registry_offer else 0,
     )
 
     # Build prompts for all sections
@@ -588,7 +603,7 @@ async def generate_sections(
                 previous_data_block=previous_data_block,
             )
         elif name == "suggestions":
-            built = template.format(data_block=data_block + catalog_block)
+            built = template.format(data_block=data_block + offer_block)
         else:
             built = template.format(data_block=data_block)
         section_prompts[name] = SECTION_PREAMBLE + built

--- a/observal-server/services/insights/self_learn.py
+++ b/observal-server/services/insights/self_learn.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.agent import Agent, AgentStatus, AgentVersion
+from models.agent_component import AgentComponent
 from models.hook import HookListing, HookVersion
 from models.insight_report import InsightReport, InsightReportStatus
 from models.mcp import ListingStatus
@@ -39,7 +40,36 @@ from models.prompt import PromptListing, PromptVersion
 from models.skill import SkillListing, SkillVersion
 from models.user import User
 from services.registry_namespace import slugify
+from services.registry_recommender import (
+    ALL_COMPONENT_TYPES,
+    COMPONENT_MODELS,
+    ResolvedComponent,
+    coerce_uuid,
+    resolve_component_any_type,
+    visibility_clause,
+)
 from services.versioning import bump_version
+
+
+class _NewComponent:
+    """A listing created during this apply run (always version 1.0.0).
+
+    Deliberately a plain class rather than a dataclass: this module combines
+    ``from __future__ import annotations`` with being loaded standalone by
+    tests via ``importlib`` under a synthetic module name. Dataclass field
+    resolution looks that name up in ``sys.modules`` and crashes when it is
+    absent, so the decorator would make the module unloadable in that test.
+    """
+
+    __slots__ = ("component_id", "component_type")
+
+    def __init__(self, component_type: str, component_id: uuid.UUID) -> None:
+        self.component_type = component_type
+        self.component_id = component_id
+
+
+# Action types that mean "attach something the registry already has".
+_REUSE_ACTIONS = frozenset({"reuse_existing_component", "attach_registry_component"})
 
 # Separator appended before auto-generated additions to the system prompt
 _SELF_LEARN_SEPARATOR = "\n\n# ── Auto-learned from Insights ──\n"
@@ -49,7 +79,7 @@ _MAX_NAME_LEN = 48
 
 
 async def apply_insight_suggestions(
-    report_id: str,
+    report_id: str | uuid.UUID,
     db: AsyncSession,
     triggered_by: uuid.UUID,
     selection: dict | None = None,
@@ -66,8 +96,13 @@ async def apply_insight_suggestions(
 
     Returns a summary dict of what was created.
     """
-    # Load report
-    stmt = select(InsightReport).where(InsightReport.id == report_id)
+    # Load report. Accept either a UUID or its string form — callers come
+    # from both HTTP paths (string) and internal code (UUID).
+    report_uuid = coerce_uuid(report_id)
+    if report_uuid is None:
+        raise ValueError("Report not found")
+
+    stmt = select(InsightReport).where(InsightReport.id == report_uuid)
     result = await db.execute(stmt)
     report = result.scalar_one_or_none()
 
@@ -128,8 +163,9 @@ async def apply_insight_suggestions(
     features_to_try = suggestions.get("features_to_try", [])
     created_skill_ids: list[uuid.UUID] = []
     created_hook_ids: list[uuid.UUID] = []
-    existing_skill_ids: list[uuid.UUID] = []
-    existing_hook_ids: list[uuid.UUID] = []
+    # Reused registry components, keyed by type. Values carry the resolved
+    # name and version so the AgentComponent row is written accurately.
+    linked_existing: list[ResolvedComponent] = []
     removed_component_ids: list[uuid.UUID] = []
 
     for idx in feature_indices:
@@ -138,40 +174,33 @@ async def apply_insight_suggestions(
         feature = features_to_try[idx]
         action_type = str(feature.get("action_type") or "").lower()
         existing_id = feature.get("existing_component_id")
-        # Never create MCPs from insights
-        if _is_mcp_suggestion(feature):
+        if action_type in _REUSE_ACTIONS and existing_id:
+            resolved = await _resolve_reusable_component(feature, agent, db)
+            if not resolved:
+                optic.info(
+                    "self_learn_reuse_rejected",
+                    agent=agent.name,
+                    component_id=str(existing_id),
+                    declared_type=feature.get("feature"),
+                )
+                continue
+            linked_existing.append(resolved)
+            applied["linked_existing"].append(
+                {
+                    "type": resolved.component_type,
+                    "id": str(resolved.id),
+                    "name": resolved.name,
+                    "qualified_name": resolved.qualified_name,
+                    "version": resolved.latest_version,
+                    "reason": feature.get("why_for_you"),
+                    "confidence": feature.get("confidence"),
+                    "risk": feature.get("risk"),
+                }
+            )
             continue
-        if action_type in {"reuse_existing_component", "attach_registry_component"} and existing_id:
-            try:
-                cid = uuid.UUID(str(existing_id))
-            except ValueError:
-                cid = None
-            if cid and _is_skill_suggestion(feature):
-                if not await _is_active_skill(cid, db):
-                    continue
-                existing_skill_ids.append(cid)
-                applied["linked_existing"].append(
-                    {
-                        "type": "skill",
-                        "id": str(cid),
-                        "reason": feature.get("why_for_you"),
-                        "confidence": feature.get("confidence"),
-                        "risk": feature.get("risk"),
-                    }
-                )
-            elif cid and _is_hook_suggestion(feature):
-                if not await _is_active_hook(cid, db):
-                    continue
-                existing_hook_ids.append(cid)
-                applied["linked_existing"].append(
-                    {
-                        "type": "hook",
-                        "id": str(cid),
-                        "reason": feature.get("why_for_you"),
-                        "confidence": feature.get("confidence"),
-                        "risk": feature.get("risk"),
-                    }
-                )
+        # Creating brand-new MCPs from an LLM suggestion is never safe: they
+        # carry commands, images and credentials. Reuse above is allowed.
+        if _is_mcp_suggestion(feature):
             continue
         if action_type == "remove_component" and existing_id:
             try:
@@ -191,14 +220,16 @@ async def apply_insight_suggestions(
                 )
             continue
         if _is_skill_suggestion(feature):
-            existing_match = await _find_existing_skill_match(feature, db)
+            existing_match = await _find_existing_skill_match(feature, agent, db)
             if existing_match:
-                existing_skill_ids.append(existing_match.id)
+                linked_existing.append(existing_match)
                 applied["linked_existing"].append(
                     {
                         "type": "skill",
                         "id": str(existing_match.id),
                         "name": existing_match.name,
+                        "qualified_name": existing_match.qualified_name,
+                        "version": existing_match.latest_version,
                         "reason": "matched existing registry skill",
                         "confidence": feature.get("confidence"),
                         "risk": feature.get("risk") or "low",
@@ -265,18 +296,22 @@ async def apply_insight_suggestions(
             for item in selected_additions
         ]
 
-    linked_skill_ids = created_skill_ids + existing_skill_ids
-    linked_hook_ids = created_hook_ids + existing_hook_ids
+    # Components created in this run are always at 1.0.0 by construction;
+    # reused ones carry whatever version the registry resolved.
+    new_components = (
+        [_NewComponent("skill", cid) for cid in created_skill_ids]
+        + [_NewComponent("hook", cid) for cid in created_hook_ids]
+        + [_NewComponent("prompt", cid) for cid in created_prompt_ids]
+    )
 
-    if selected_additions or linked_skill_ids or linked_hook_ids or created_prompt_ids or removed_component_ids:
+    if selected_additions or new_components or linked_existing or removed_component_ids:
         version_info = await _create_agent_version_with_additions(
             agent=agent,
             config_additions=selected_additions,
             submitter_id=submitter_id,
             db=db,
-            linked_skill_ids=linked_skill_ids,
-            linked_hook_ids=linked_hook_ids,
-            linked_prompt_ids=created_prompt_ids,
+            new_components=new_components,
+            linked_existing=linked_existing,
             removed_component_ids=removed_component_ids,
         )
         if version_info:
@@ -402,14 +437,13 @@ async def _create_agent_version_with_additions(
     config_additions: list[dict],
     submitter_id: uuid.UUID,
     db: AsyncSession,
-    linked_skill_ids: list[uuid.UUID] | None = None,
-    linked_hook_ids: list[uuid.UUID] | None = None,
-    linked_prompt_ids: list[uuid.UUID] | None = None,
+    new_components: list[_NewComponent] | None = None,
+    linked_existing: list[ResolvedComponent] | None = None,
     removed_component_ids: list[uuid.UUID] | None = None,
 ) -> dict | None:
     """Create a new pending AgentVersion with config_additions appended to the prompt.
 
-    Links any created skills/hooks/prompts as AgentComponents so the review
+    Links created and reused components as AgentComponents so the review
     queue enforces approval dependency.
     """
     # Get the latest approved version
@@ -439,14 +473,11 @@ async def _create_agent_version_with_additions(
     ]
     additions_text = _build_additions_text(config_additions)
 
-    # Even without text additions, we might be linking new components
-    if (
-        not additions_text.strip()
-        and not linked_skill_ids
-        and not linked_hook_ids
-        and not linked_prompt_ids
-        and not removed_component_ids
-    ):
+    new_components = new_components or []
+    linked_existing = linked_existing or []
+
+    # Even without text additions, we might be linking components
+    if not additions_text.strip() and not new_components and not linked_existing and not removed_component_ids:
         return None
 
     new_prompt = current_prompt
@@ -475,7 +506,7 @@ async def _create_agent_version_with_additions(
             optic.error("self_learn_version_exhaustion", agent=agent.name)
             return None
 
-    total_linked = len(linked_skill_ids or []) + len(linked_hook_ids or []) + len(linked_prompt_ids or [])
+    total_linked = len(new_components) + len(linked_existing)
     desc_parts = []
     if config_additions:
         desc_parts.append(f"{len(config_additions)} prompt additions")
@@ -505,8 +536,6 @@ async def _create_agent_version_with_additions(
     await db.flush()
 
     # Copy components from the latest version
-    from models.agent_component import AgentComponent
-
     order_idx = 0
     removed_set = set(removed_component_ids or [])
     for comp in latest_version.components or []:
@@ -525,47 +554,39 @@ async def _create_agent_version_with_additions(
         )
         order_idx = max(order_idx, (comp.order_index or 0) + 1)
 
-    # Link newly created skills
-    for skill_id in linked_skill_ids or []:
+    # Link components created in this run. These are always born at 1.0.0,
+    # but resolve the name so later reports don't fall back to a UUID stub.
+    created_names = await _component_names(new_components, db)
+    for component in new_components:
         db.add(
             AgentComponent(
                 agent_version_id=new_version.id,
-                component_type="skill",
-                component_id=skill_id,
-                component_name="",
+                component_type=component.component_type,
+                component_id=component.component_id,
+                component_name=created_names.get(component.component_id, ""),
                 resolved_version="1.0.0",
                 order_index=order_idx,
             )
         )
         order_idx += 1
 
-    # Link newly created hooks
-    for hook_id in linked_hook_ids or []:
+    # Link reused registry components at the version the registry actually
+    # has. Pinning a version that does not exist breaks agent pulls.
+    for resolved in linked_existing:
         db.add(
             AgentComponent(
                 agent_version_id=new_version.id,
-                component_type="hook",
-                component_id=hook_id,
-                component_name="",
-                resolved_version="1.0.0",
+                component_type=resolved.component_type,
+                component_id=resolved.id,
+                component_name=resolved.name,
+                resolved_version=resolved.latest_version,
                 order_index=order_idx,
             )
         )
         order_idx += 1
 
-    # Link newly created prompts
-    for prompt_id in linked_prompt_ids or []:
-        db.add(
-            AgentComponent(
-                agent_version_id=new_version.id,
-                component_type="prompt",
-                component_id=prompt_id,
-                component_name="",
-                resolved_version="1.0.0",
-                order_index=order_idx,
-            )
-        )
-        order_idx += 1
+    await db.flush()
+    await _refresh_capability_inference(new_version, db)
 
     return {
         "id": str(new_version.id),
@@ -574,6 +595,57 @@ async def _create_agent_version_with_additions(
         "linked_components": total_linked,
         "removed_components": len(removed_component_ids or []),
     }
+
+
+async def _component_names(components: list[_NewComponent], db: AsyncSession) -> dict[uuid.UUID, str]:
+    """Look up display names for freshly created listings."""
+    names: dict[uuid.UUID, str] = {}
+    by_type: dict[str, list[uuid.UUID]] = {}
+    for component in components:
+        by_type.setdefault(component.component_type, []).append(component.component_id)
+
+    for component_type, ids in by_type.items():
+        models = COMPONENT_MODELS.get(component_type)
+        if not models:
+            continue
+        listing_model = models[0]
+        rows = (await db.execute(select(listing_model.id, listing_model.name).where(listing_model.id.in_(ids)))).all()
+        for row in rows:
+            names[row[0]] = row[1]
+    return names
+
+
+async def _refresh_capability_inference(version: AgentVersion, db: AsyncSession) -> None:
+    """Recompute required capabilities for a version we just built.
+
+    The HTTP publish paths do this after every component change; self-learn
+    previously did not, so insight-generated versions silently lost the
+    harness-compatibility warnings shown at pull time.
+    """
+    from services.harness_capability_inference import compute_supported_harnesses, infer_required_features
+
+    components = (
+        (await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version.id))).scalars().all()
+    )
+
+    skill_ids = [c.component_id for c in components if c.component_type == "skill"]
+    skill_listings: dict[uuid.UUID, SkillListing] = {}
+    if skill_ids:
+        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_ids)))).scalars().all()
+        skill_listings = {listing.id: listing for listing in rows}
+
+    class _VersionProxy:
+        """Shape `infer_required_features` expects: components + external_mcps."""
+
+        def __init__(self) -> None:
+            self.components = components
+            self.external_mcps = version.external_mcps
+
+    try:
+        version.required_capabilities = infer_required_features(_VersionProxy(), skill_listings=skill_listings)
+        version.inferred_supported_harnesses = compute_supported_harnesses(version.required_capabilities)
+    except Exception as e:  # pragma: no cover - inference must never block the apply
+        optic.warning("self_learn_capability_inference_failed", version=version.version, error=str(e))
 
 
 def _build_additions_text(config_additions: list[dict]) -> str:
@@ -711,50 +783,88 @@ def _slugify(text: str) -> str:
     return slug.strip("-")
 
 
-async def _is_active_skill(component_id: uuid.UUID, db: AsyncSession) -> bool:
-    result = await db.execute(
-        select(SkillListing.id)
-        .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id, isouter=True)
-        .where(SkillListing.id == component_id, SkillVersion.status == ListingStatus.approved)
+def _declared_component_type(feature: dict) -> str | None:
+    """Best guess at the component type an LLM suggestion refers to.
+
+    Returns None when the wording is ambiguous; the caller then falls back to
+    resolving by id across every type, which is authoritative anyway.
+    """
+    if _is_skill_suggestion(feature):
+        return "skill"
+    if _is_hook_suggestion(feature):
+        return "hook"
+    if _is_mcp_suggestion(feature):
+        return "mcp"
+    label = f"{feature.get('feature') or ''} {feature.get('name') or ''}".lower()
+    if "prompt" in label:
+        return "prompt"
+    if "sandbox" in label:
+        return "sandbox"
+    return None
+
+
+async def _resolve_reusable_component(feature: dict, agent: Agent, db: AsyncSession) -> ResolvedComponent | None:
+    """Validate a reuse suggestion against the registry.
+
+    The declared type is a hint only. The id is resolved across every
+    component type and the *actual* type wins, so a mislabelled suggestion
+    still attaches correctly instead of being silently dropped.
+
+    Scoped to the agent's org so a suggestion can never attach another
+    tenant's private component.
+    """
+    component_id = coerce_uuid(feature.get("existing_component_id"))
+    if component_id is None:
+        return None
+
+    declared = _declared_component_type(feature)
+    ordered_types = (
+        [declared, *[t for t in ALL_COMPONENT_TYPES if t != declared]] if declared else list(ALL_COMPONENT_TYPES)
     )
-    return result.scalar_one_or_none() is not None
-
-
-async def _is_active_hook(component_id: uuid.UUID, db: AsyncSession) -> bool:
-    result = await db.execute(
-        select(HookListing.id)
-        .join(HookVersion, HookListing.latest_version_id == HookVersion.id, isouter=True)
-        .where(HookListing.id == component_id, HookVersion.status == ListingStatus.approved)
+    return await resolve_component_any_type(
+        db,
+        component_id,
+        org_id=agent.owner_org_id,
+        component_types=ordered_types,
     )
-    return result.scalar_one_or_none() is not None
 
 
-async def _find_existing_skill_match(feature: dict, db: AsyncSession) -> SkillListing | None:
-    """Deterministically find an existing approved skill before creating a duplicate."""
+async def _find_existing_skill_match(feature: dict, agent: Agent, db: AsyncSession) -> ResolvedComponent | None:
+    """Deterministically find an existing approved skill before creating a duplicate.
+
+    Scoped to the agent's org: matching must never reach into another
+    tenant's private skills.
+    """
     raw_name = _slugify(str(feature.get("name") or ""))
     one_liner = str(feature.get("one_liner") or feature.get("why_for_you") or "")
-    keywords = set(_extract_keywords(f"{raw_name} {one_liner}", max_words=6).split("-"))
+    keywords = [kw for kw in _extract_keywords(f"{raw_name} {one_liner}", max_words=6).split("-") if kw]
     if not raw_name and not keywords:
         return None
 
-    rows = (
-        (
-            await db.execute(
-                select(SkillListing)
-                .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id, isouter=True)
-                .where(SkillVersion.status == ListingStatus.approved)
-            )
-        )
-        .scalars()
-        .all()
+    stmt = (
+        select(SkillListing, SkillVersion)
+        .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id)
+        .where(SkillVersion.status == ListingStatus.approved)
     )
-    for listing in rows:
+    visibility = visibility_clause(SkillListing, agent.owner_org_id)
+    if visibility is not None:
+        stmt = stmt.where(visibility)
+
+    for listing, version in (await db.execute(stmt)).all():
         listing_slug = _slugify(listing.name or "")
-        if raw_name and (listing_slug == raw_name or raw_name in listing_slug or listing_slug in raw_name):
-            return listing
-        haystack = f"{listing.name} {getattr(listing.latest_version, 'description', '')}".lower()
-        if keywords and sum(1 for kw in keywords if kw and kw in haystack) >= min(3, len(keywords)):
-            return listing
+        haystack = f"{listing.name} {version.description or ''}".lower()
+        hit = raw_name and (listing_slug == raw_name or raw_name in listing_slug or listing_slug in raw_name)
+        if not hit and keywords:
+            hit = sum(1 for kw in keywords if kw in haystack) >= min(3, len(keywords))
+        if hit:
+            return ResolvedComponent(
+                component_type="skill",
+                id=listing.id,
+                name=listing.name,
+                namespace=listing.namespace,
+                slug=listing.slug,
+                latest_version=version.version,
+            )
     return None
 
 
@@ -922,7 +1032,11 @@ async def _create_hook_listing(
             event=event,
             execution_mode=execution_mode,
             priority=100,
-            handler_type="script",
+            # "script" is not a valid handler_type — only "command" and
+            # "http" are (schemas/constants.VALID_HOOK_HANDLER_TYPES). Using
+            # it meant every generated hook silently failed validation and
+            # was dropped. Inline scripts are delivered as "command".
+            handler_type="command",
             handler_config={"inline": True},
             scope="agent",
             script_content=script_content,

--- a/observal-server/services/insights/self_learn.py
+++ b/observal-server/services/insights/self_learn.py
@@ -538,9 +538,11 @@ async def _create_agent_version_with_additions(
     # Copy components from the latest version
     order_idx = 0
     removed_set = set(removed_component_ids or [])
+    carried_ids: set[uuid.UUID] = set()
     for comp in latest_version.components or []:
         if comp.component_id in removed_set:
             continue
+        carried_ids.add(comp.component_id)
         db.add(
             AgentComponent(
                 agent_version_id=new_version.id,
@@ -572,7 +574,21 @@ async def _create_agent_version_with_additions(
 
     # Link reused registry components at the version the registry actually
     # has. Pinning a version that does not exist breaks agent pulls.
+    #
+    # Skip anything the agent already carries. The insights shortlist excludes
+    # attached components, but `_find_existing_skill_match` does not, and an
+    # agent can gain a component between report generation and apply. Adding it
+    # twice would write two AgentComponent rows for one component, at differing
+    # resolved_versions.
     for resolved in linked_existing:
+        if resolved.id in carried_ids:
+            optic.info(
+                "self_learn_reuse_already_attached",
+                agent=agent.name,
+                component=resolved.qualified_name,
+            )
+            continue
+        carried_ids.add(resolved.id)
         db.add(
             AgentComponent(
                 agent_version_id=new_version.id,

--- a/observal-server/services/insights/self_learn.py
+++ b/observal-server/services/insights/self_learn.py
@@ -28,6 +28,8 @@ import yaml
 from loguru import logger as optic
 from sqlalchemy import select
 
+from api.search import keyword_search
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -826,8 +828,8 @@ async def _resolve_reusable_component(feature: dict, agent: Agent, db: AsyncSess
     component type and the *actual* type wins, so a mislabelled suggestion
     still attaches correctly instead of being silently dropped.
 
-    Scoped to the agent's org so a suggestion can never attach another
-    tenant's private component.
+    Scoped to the agent's visibility so a suggestion can never attach another
+    user's private component.
     """
     component_id = coerce_uuid(feature.get("existing_component_id"))
     if component_id is None:
@@ -840,7 +842,7 @@ async def _resolve_reusable_component(feature: dict, agent: Agent, db: AsyncSess
     return await resolve_component_any_type(
         db,
         component_id,
-        org_id=agent.owner_org_id,
+        user_id=agent.created_by,
         component_types=ordered_types,
     )
 
@@ -848,8 +850,8 @@ async def _resolve_reusable_component(feature: dict, agent: Agent, db: AsyncSess
 async def _find_existing_skill_match(feature: dict, agent: Agent, db: AsyncSession) -> ResolvedComponent | None:
     """Deterministically find an existing approved skill before creating a duplicate.
 
-    Scoped to the agent's org: matching must never reach into another
-    tenant's private skills.
+    Scoped to the agent's visibility: matching must never reach into another
+    user's private or team-private skills.
     """
     raw_name = _slugify(str(feature.get("name") or ""))
     one_liner = str(feature.get("one_liner") or feature.get("why_for_you") or "")
@@ -862,9 +864,17 @@ async def _find_existing_skill_match(feature: dict, agent: Agent, db: AsyncSessi
         .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id)
         .where(SkillVersion.status == ListingStatus.approved)
     )
-    visibility = visibility_clause(SkillListing, agent.owner_org_id)
+    search_filter, search_rank = keyword_search(
+        f"{raw_name} {one_liner}",
+        [SkillListing.name, SkillVersion.description],
+        name_field=SkillListing.name,
+    )
+    visibility = visibility_clause(SkillListing, agent.created_by)
     if visibility is not None:
         stmt = stmt.where(visibility)
+    if search_filter is not None:
+        stmt = stmt.where(search_filter).order_by(search_rank.desc())
+    stmt = stmt.limit(100)
 
     for listing, version in (await db.execute(stmt)).all():
         listing_slug = _slugify(listing.name or "")

--- a/observal-server/services/registry_recommender.py
+++ b/observal-server/services/registry_recommender.py
@@ -15,9 +15,9 @@ Everything here is deterministic (lexical match + popularity prior). No LLM
 call happens in this module; callers may re-rank with one afterwards.
 
 Visibility is enforced at the query level via :func:`visibility_clause`,
-which is the worker-safe sibling of ``api.deps.apply_visibility_filter``:
-it takes an ``org_id``/``user_id`` pair instead of a request-scoped ``User``
-so background jobs (which have no authenticated user) can use it too.
+which is the worker-safe sibling of ``api.deps.apply_visibility_filter``.
+It takes a user id instead of a request-scoped ``User`` so background jobs can
+apply the same public, personal, and team-private rules.
 """
 
 from __future__ import annotations
@@ -36,6 +36,7 @@ from models.mcp import ListingStatus, McpListing, McpVersion
 from models.prompt import PromptListing, PromptVersion
 from models.sandbox import SandboxListing, SandboxVersion
 from models.skill import SkillListing, SkillVersion
+from models.team import TeamMembership
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -118,39 +119,35 @@ class ComponentCandidate:
         }
 
 
-def visibility_clause(listing_model, org_id: uuid.UUID | None, user_id: uuid.UUID | None = None):
-    """Return a WHERE clause restricting *listing_model* to visible rows.
+def visibility_clause(listing_model, user_id: uuid.UUID | None = None):
+    """Return a worker-safe visibility predicate for a registry listing.
 
-    Mirrors ``api.deps.apply_visibility_filter`` but takes plain ids so it
-    works inside background jobs that have no request user.
-
-    Rules (identical to the request-scoped filter, minus the admin bypass —
-    recommendations must never surface something the *agent owner* could not
-    see, even when an admin triggered the run):
-
-    * public listings are always visible
-    * private listings are visible to the owning org
-    * private listings are visible to their submitter
-
-    ``org_id=None`` means "no org" — such a caller sees public listings plus
-    their own private ones. It must never be allowed to match rows whose
-    ``owner_org_id`` is also NULL, which is why the org branch is skipped
-    entirely rather than compared (``NULL = NULL`` is never true in SQL, but
-    being explicit keeps the intent obvious).
+    This mirrors ``api.deps.apply_visibility_filter`` without requiring a
+    request-scoped ``User``. Public listings are always visible. Personal
+    private listings are visible to their submitter, and team-private listings
+    are visible to team members. ``None`` means public listings only.
     """
     if not hasattr(listing_model, "is_private"):
-        # Agents have no privacy flag; everything in the instance is visible.
         return None
 
     public = listing_model.is_private == False  # noqa: E712
-    clauses = [public]
+    if user_id is None:
+        return public
 
-    if org_id is not None:
-        clauses.append(and_(listing_model.is_private == True, listing_model.owner_org_id == org_id))  # noqa: E712
-    if user_id is not None:
-        clauses.append(and_(listing_model.is_private == True, listing_model.submitted_by == user_id))  # noqa: E712
+    creator = getattr(listing_model, "submitted_by", None) or getattr(listing_model, "created_by", None)
+    private = listing_model.is_private == True  # noqa: E712
+    if not hasattr(listing_model, "team_id"):
+        return or_(public, and_(private, creator == user_id)) if creator is not None else public
 
-    return clauses[0] if len(clauses) == 1 else or_(*clauses)
+    personal = and_(private, listing_model.team_id.is_(None), creator == user_id) if creator is not None else False
+    member = (
+        select(TeamMembership.id)
+        .where(TeamMembership.team_id == listing_model.team_id, TeamMembership.user_id == user_id)
+        .correlate(listing_model)
+        .exists()
+    )
+    team_private = and_(private, listing_model.team_id.is_not(None), member)
+    return or_(public, personal, team_private)
 
 
 def _search_fields(component_type: str, listing_model, version_model) -> list:
@@ -231,7 +228,6 @@ async def shortlist(
     *,
     signals: str,
     component_types: Sequence[str] = ALL_COMPONENT_TYPES,
-    org_id: uuid.UUID | None = None,
     user_id: uuid.UUID | None = None,
     exclude_ids: Iterable[uuid.UUID] = (),
     per_type_limit: int = 6,
@@ -260,7 +256,7 @@ async def shortlist(
         )
         stmt = stmt.where(version_model.status == ListingStatus.approved)
 
-        visibility = visibility_clause(listing_model, org_id, user_id)
+        visibility = visibility_clause(listing_model, user_id)
         if visibility is not None:
             stmt = stmt.where(visibility)
         if excluded:
@@ -364,13 +360,12 @@ async def resolve_components(
     db: AsyncSession,
     refs: Iterable[tuple[str, uuid.UUID]],
     *,
-    org_id: uuid.UUID | None = None,
     user_id: uuid.UUID | None = None,
 ) -> dict[tuple[str, uuid.UUID], ResolvedComponent]:
     """Validate ``(type, id)`` references against the registry.
 
     A reference resolves only when the listing exists, its latest version is
-    approved, and it is visible to the given org/user. Anything else is
+    approved, and it is visible to the given user. Anything else is
     simply absent from the result — callers treat a miss as "drop it".
     """
     by_type: dict[str, list[uuid.UUID]] = {}
@@ -395,7 +390,7 @@ async def resolve_components(
                 version_model.status == ListingStatus.approved,
             )
         )
-        visibility = visibility_clause(listing_model, org_id, user_id)
+        visibility = visibility_clause(listing_model, user_id)
         if visibility is not None:
             stmt = stmt.where(visibility)
 
@@ -422,7 +417,6 @@ async def resolve_component_any_type(
     db: AsyncSession,
     component_id: uuid.UUID,
     *,
-    org_id: uuid.UUID | None = None,
     user_id: uuid.UUID | None = None,
     component_types: Sequence[str] = ALL_COMPONENT_TYPES,
 ) -> ResolvedComponent | None:
@@ -431,7 +425,7 @@ async def resolve_component_any_type(
     Used for LLM output, where the declared type may not match the id.
     """
     refs = [(t, component_id) for t in component_types]
-    resolved = await resolve_components(db, refs, org_id=org_id, user_id=user_id)
+    resolved = await resolve_components(db, refs, user_id=user_id)
     for component_type in component_types:
         hit = resolved.get((component_type, component_id))
         if hit:

--- a/observal-server/services/registry_recommender.py
+++ b/observal-server/services/registry_recommender.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared registry component matching.
+
+One ranking implementation serves both consumers:
+
+* **Agent insights** (:mod:`services.insights`) — given the signals of an
+  insight report, shortlist components the agent could reuse instead of
+  building something new.
+* **Per-user recommendations** (:mod:`services.user_profile`) — given a
+  user's work profile, shortlist components they are likely to want.
+
+Everything here is deterministic (lexical match + popularity prior). No LLM
+call happens in this module; callers may re-rank with one afterwards.
+
+Visibility is enforced at the query level via :func:`visibility_clause`,
+which is the worker-safe sibling of ``api.deps.apply_visibility_filter``:
+it takes an ``org_id``/``user_id`` pair instead of a request-scoped ``User``
+so background jobs (which have no authenticated user) can use it too.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger as optic
+from sqlalchemy import and_, or_, select
+
+from api.search import keyword_search, keyword_tokens
+from models.hook import HookListing, HookVersion
+from models.mcp import ListingStatus, McpListing, McpVersion
+from models.prompt import PromptListing, PromptVersion
+from models.sandbox import SandboxListing, SandboxVersion
+from models.skill import SkillListing, SkillVersion
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+# Component type -> (listing model, version model). Order is the tie-break
+# order used when trimming a blended shortlist down to ``total_limit``.
+COMPONENT_MODELS: dict[str, tuple[Any, Any]] = {
+    "skill": (SkillListing, SkillVersion),
+    "hook": (HookListing, HookVersion),
+    "prompt": (PromptListing, PromptVersion),
+    "mcp": (McpListing, McpVersion),
+    "sandbox": (SandboxListing, SandboxVersion),
+}
+
+ALL_COMPONENT_TYPES: tuple[str, ...] = tuple(COMPONENT_MODELS)
+
+# Popularity is a tie-breaker, not a driver: a wildly popular component must
+# not outrank a genuinely relevant one. Capped so a single runaway listing
+# cannot dominate the ordering.
+_POPULARITY_WEIGHT = 0.4
+_POPULARITY_CAP = 50
+
+# Fetch a wider slice than we return so the Python-side blend has room to
+# reorder before trimming.
+_OVERFETCH = 3
+
+
+@dataclass
+class ComponentCandidate:
+    """A registry component that plausibly matches the caller's signals."""
+
+    component_type: str
+    id: uuid.UUID
+    name: str
+    namespace: str
+    slug: str
+    description: str
+    latest_version: str
+    download_count: int
+    score: float
+    category: str | None = None
+    matched_terms: list[str] = field(default_factory=list)
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{self.namespace}/{self.slug}"
+
+    def to_catalog_entry(self) -> dict:
+        """Compact dict for embedding in an LLM prompt. Keep this small."""
+        entry = {
+            "type": self.component_type,
+            "id": str(self.id),
+            "qualified_name": self.qualified_name,
+            "name": self.name,
+            "description": self.description[:160],
+        }
+        if self.category:
+            entry["category"] = self.category
+        if self.matched_terms:
+            entry["matched_on"] = self.matched_terms
+        return entry
+
+    def to_api_dict(self) -> dict:
+        """Full dict for API responses and UI rendering."""
+        return {
+            "type": self.component_type,
+            "id": str(self.id),
+            "name": self.name,
+            "namespace": self.namespace,
+            "slug": self.slug,
+            "qualified_name": self.qualified_name,
+            "description": self.description,
+            "category": self.category,
+            "latest_version": self.latest_version,
+            "download_count": self.download_count,
+            "matched_on": self.matched_terms,
+            "score": round(self.score, 3),
+        }
+
+
+def visibility_clause(listing_model, org_id: uuid.UUID | None, user_id: uuid.UUID | None = None):
+    """Return a WHERE clause restricting *listing_model* to visible rows.
+
+    Mirrors ``api.deps.apply_visibility_filter`` but takes plain ids so it
+    works inside background jobs that have no request user.
+
+    Rules (identical to the request-scoped filter, minus the admin bypass —
+    recommendations must never surface something the *agent owner* could not
+    see, even when an admin triggered the run):
+
+    * public listings are always visible
+    * private listings are visible to the owning org
+    * private listings are visible to their submitter
+
+    ``org_id=None`` means "no org" — such a caller sees public listings plus
+    their own private ones. It must never be allowed to match rows whose
+    ``owner_org_id`` is also NULL, which is why the org branch is skipped
+    entirely rather than compared (``NULL = NULL`` is never true in SQL, but
+    being explicit keeps the intent obvious).
+    """
+    if not hasattr(listing_model, "is_private"):
+        # Agents have no privacy flag; everything in the instance is visible.
+        return None
+
+    public = listing_model.is_private == False  # noqa: E712
+    clauses = [public]
+
+    if org_id is not None:
+        clauses.append(and_(listing_model.is_private == True, listing_model.owner_org_id == org_id))  # noqa: E712
+    if user_id is not None:
+        clauses.append(and_(listing_model.is_private == True, listing_model.submitted_by == user_id))  # noqa: E712
+
+    return clauses[0] if len(clauses) == 1 else or_(*clauses)
+
+
+def _search_fields(component_type: str, listing_model, version_model) -> list:
+    """Text columns worth matching for a component type."""
+    fields = [listing_model.name, version_model.description]
+    if component_type == "mcp":
+        fields.append(listing_model.category)
+    elif component_type == "skill":
+        fields.append(version_model.task_type)
+    elif component_type == "hook":
+        fields.append(version_model.event)
+    elif component_type == "prompt":
+        fields.append(version_model.category)
+    return fields
+
+
+def _row_category(component_type: str, listing, version) -> str | None:
+    if component_type == "mcp":
+        return listing.category
+    if component_type == "skill":
+        return getattr(version, "task_type", None)
+    if component_type == "hook":
+        return getattr(version, "event", None)
+    if component_type == "prompt":
+        return getattr(version, "category", None)
+    return None
+
+
+def _token_display_map(signals: str) -> dict[str, str]:
+    """Map each stemmed search token back to the word the caller actually wrote.
+
+    ``keyword_tokens`` stems trailing plurals ("postgres" -> "postgre"), which
+    is fine for matching but reads as a typo when shown to a user. Matching
+    still happens on the stem; only the label is restored.
+    """
+    mapping: dict[str, str] = {}
+    for word in re.findall(r"[A-Za-z0-9][A-Za-z0-9_-]*", signals or ""):
+        for token in keyword_tokens(word):
+            mapping.setdefault(token, word.lower())
+    return mapping
+
+
+def _matched_terms(tokens: Sequence[str], haystack: str, display: dict[str, str]) -> list[str]:
+    lowered = haystack.lower()
+    return [display.get(t, t) for t in tokens if t in lowered]
+
+
+def build_signal_query(*parts: Iterable[str] | str | None) -> str:
+    """Flatten assorted signal collections into one search string.
+
+    Accepts strings and iterables of strings, skipping empties. Order is
+    preserved and duplicates are dropped so the token ranking stays stable.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for part in parts:
+        if part is None:
+            continue
+        items = [part] if isinstance(part, str) else list(part)
+        for item in items:
+            # A None *inside* a collection would stringify to the literal
+            # "None" and pollute the search with a meaningless token.
+            if item is None:
+                continue
+            text = str(item).strip()
+            if not text:
+                continue
+            key = text.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(text)
+    return " ".join(out)
+
+
+async def shortlist(
+    db: AsyncSession,
+    *,
+    signals: str,
+    component_types: Sequence[str] = ALL_COMPONENT_TYPES,
+    org_id: uuid.UUID | None = None,
+    user_id: uuid.UUID | None = None,
+    exclude_ids: Iterable[uuid.UUID] = (),
+    per_type_limit: int = 6,
+    total_limit: int = 24,
+) -> list[ComponentCandidate]:
+    """Return the most relevant visible components for *signals*.
+
+    Only approved latest versions are considered. When *signals* yields no
+    usable tokens the result falls back to a popularity ordering, which is
+    what cold-start callers want.
+    """
+    tokens = keyword_tokens(signals)
+    display = _token_display_map(signals)
+    excluded = {cid for cid in exclude_ids if cid is not None}
+    candidates: list[ComponentCandidate] = []
+
+    for component_type in component_types:
+        models = COMPONENT_MODELS.get(component_type)
+        if not models:
+            optic.warning("registry_recommender: unknown component type {}", component_type)
+            continue
+        listing_model, version_model = models
+
+        stmt = select(listing_model, version_model).join(
+            version_model, listing_model.latest_version_id == version_model.id
+        )
+        stmt = stmt.where(version_model.status == ListingStatus.approved)
+
+        visibility = visibility_clause(listing_model, org_id, user_id)
+        if visibility is not None:
+            stmt = stmt.where(visibility)
+        if excluded:
+            stmt = stmt.where(listing_model.id.notin_(excluded))
+
+        search_filter, search_rank = keyword_search(
+            signals,
+            _search_fields(component_type, listing_model, version_model),
+            name_field=listing_model.name,
+        )
+        if search_filter is not None:
+            stmt = stmt.where(search_filter)
+            stmt = stmt.order_by(search_rank.desc(), version_model.download_count.desc())
+        else:
+            stmt = stmt.order_by(version_model.download_count.desc(), listing_model.created_at.desc())
+
+        stmt = stmt.limit(max(per_type_limit * _OVERFETCH, per_type_limit))
+
+        try:
+            rows = (await db.execute(stmt)).all()
+        except Exception as e:  # pragma: no cover - defensive, keeps callers alive
+            optic.warning("registry_recommender: {} query failed: {}", component_type, e)
+            continue
+
+        typed: list[ComponentCandidate] = []
+        for listing, version in rows:
+            haystack = " ".join(
+                str(x)
+                for x in (
+                    listing.name,
+                    version.description,
+                    _row_category(component_type, listing, version),
+                )
+                if x
+            )
+            matched = _matched_terms(tokens, haystack, display)
+            # Relevance dominates; popularity only separates near-ties.
+            relevance = float(len(matched))
+            popularity = min(version.download_count or 0, _POPULARITY_CAP) / _POPULARITY_CAP
+            typed.append(
+                ComponentCandidate(
+                    component_type=component_type,
+                    id=listing.id,
+                    name=listing.name,
+                    namespace=listing.namespace,
+                    slug=listing.slug,
+                    description=version.description or "",
+                    latest_version=version.version,
+                    download_count=version.download_count or 0,
+                    score=relevance + popularity * _POPULARITY_WEIGHT,
+                    category=_row_category(component_type, listing, version),
+                    matched_terms=matched,
+                )
+            )
+
+        typed.sort(key=lambda c: (-c.score, -c.download_count, c.name.lower()))
+        candidates.extend(typed[:per_type_limit])
+
+    candidates.sort(key=lambda c: (-c.score, -c.download_count, c.component_type, c.name.lower()))
+    return candidates[:total_limit]
+
+
+@dataclass
+class ResolvedComponent:
+    """A registry reference that survived validation."""
+
+    component_type: str
+    id: uuid.UUID
+    name: str
+    namespace: str
+    slug: str
+    latest_version: str
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{self.namespace}/{self.slug}"
+
+    def to_ref(self) -> dict:
+        return {
+            "type": self.component_type,
+            "id": str(self.id),
+            "name": self.name,
+            "qualified_name": self.qualified_name,
+            "latest_version": self.latest_version,
+        }
+
+
+def coerce_uuid(value: object) -> uuid.UUID | None:
+    """Parse a UUID from arbitrary (often LLM-produced) input."""
+    if isinstance(value, uuid.UUID):
+        return value
+    if not value:
+        return None
+    try:
+        return uuid.UUID(str(value).strip())
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+async def resolve_components(
+    db: AsyncSession,
+    refs: Iterable[tuple[str, uuid.UUID]],
+    *,
+    org_id: uuid.UUID | None = None,
+    user_id: uuid.UUID | None = None,
+) -> dict[tuple[str, uuid.UUID], ResolvedComponent]:
+    """Validate ``(type, id)`` references against the registry.
+
+    A reference resolves only when the listing exists, its latest version is
+    approved, and it is visible to the given org/user. Anything else is
+    simply absent from the result — callers treat a miss as "drop it".
+    """
+    by_type: dict[str, list[uuid.UUID]] = {}
+    for component_type, component_id in refs:
+        if component_type in COMPONENT_MODELS and component_id is not None:
+            by_type.setdefault(component_type, []).append(component_id)
+
+    resolved: dict[tuple[str, uuid.UUID], ResolvedComponent] = {}
+    for component_type, ids in by_type.items():
+        listing_model, version_model = COMPONENT_MODELS[component_type]
+        stmt = (
+            select(listing_model, version_model)
+            .join(version_model, listing_model.latest_version_id == version_model.id)
+            .where(
+                listing_model.id.in_(ids),
+                version_model.status == ListingStatus.approved,
+            )
+        )
+        visibility = visibility_clause(listing_model, org_id, user_id)
+        if visibility is not None:
+            stmt = stmt.where(visibility)
+
+        try:
+            rows = (await db.execute(stmt)).all()
+        except Exception as e:  # pragma: no cover - defensive
+            optic.warning("registry_recommender: resolve {} failed: {}", component_type, e)
+            continue
+
+        for listing, version in rows:
+            resolved[(component_type, listing.id)] = ResolvedComponent(
+                component_type=component_type,
+                id=listing.id,
+                name=listing.name,
+                namespace=listing.namespace,
+                slug=listing.slug,
+                latest_version=version.version,
+            )
+
+    return resolved
+
+
+async def resolve_component_any_type(
+    db: AsyncSession,
+    component_id: uuid.UUID,
+    *,
+    org_id: uuid.UUID | None = None,
+    user_id: uuid.UUID | None = None,
+    component_types: Sequence[str] = ALL_COMPONENT_TYPES,
+) -> ResolvedComponent | None:
+    """Resolve a component id when its type is unknown or untrusted.
+
+    Used for LLM output, where the declared type may not match the id.
+    """
+    refs = [(t, component_id) for t in component_types]
+    resolved = await resolve_components(db, refs, org_id=org_id, user_id=user_id)
+    for component_type in component_types:
+        hit = resolved.get((component_type, component_id))
+        if hit:
+            return hit
+    return None

--- a/observal-server/services/registry_recommender.py
+++ b/observal-server/services/registry_recommender.py
@@ -375,8 +375,14 @@ async def resolve_components(
     """
     by_type: dict[str, list[uuid.UUID]] = {}
     for component_type, component_id in refs:
-        if component_type in COMPONENT_MODELS and component_id is not None:
-            by_type.setdefault(component_type, []).append(component_id)
+        if component_type not in COMPONENT_MODELS:
+            continue
+        # Callers include paths that hand us LLM-derived ids. A non-UUID
+        # reaching `id.in_(...)` makes the driver raise, and the broad
+        # handler below would then drop every valid id in the same batch.
+        parsed = coerce_uuid(component_id)
+        if parsed is not None:
+            by_type.setdefault(component_type, []).append(parsed)
 
     resolved: dict[tuple[str, uuid.UUID], ResolvedComponent] = {}
     for component_type, ids in by_type.items():

--- a/observal-server/services/user_profile.py
+++ b/observal-server/services/user_profile.py
@@ -160,6 +160,39 @@ def _id_array(session_ids: list[str]) -> str:
     return "[" + ",".join(f"'{sid}'" for sid in safe[:MAX_ID_ARRAY]) + "]"
 
 
+async def users_with_recent_activity(days: int = DEFAULT_PROFILE_DAYS) -> set[tuple[str, str]] | None:
+    """``(project_id, user_id)`` pairs that have a session in the window.
+
+    One query for the whole instance, so a caller sweeping every user can
+    skip the inactive ones instead of paying a ClickHouse round trip each to
+    discover they have nothing. ``session_stats_agg`` is the aggregate table,
+    so this reads far less than the per-user profile queries it saves.
+
+    Returns ``None`` — distinct from an empty set — when the lookup fails, so
+    callers can fall back to sweeping everyone rather than silently deciding
+    that nobody is active.
+    """
+    since = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        response = await _query(
+            """
+            SELECT DISTINCT project_id, user_id
+            FROM session_stats_agg FINAL
+            WHERE last_event_time >= {since:String}
+              AND user_id != ''
+            FORMAT JSON
+            """,
+            {"param_since": since},
+        )
+        response.raise_for_status()
+        rows = response.json().get("data", [])
+    except Exception as e:
+        optic.warning("user_profile: active-user lookup failed: {}", e)
+        return None
+
+    return {(str(r.get("project_id") or ""), str(r.get("user_id") or "")) for r in rows}
+
+
 async def build_profile(
     user_id: uuid.UUID,
     project_id: str,

--- a/observal-server/services/user_profile.py
+++ b/observal-server/services/user_profile.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build per-user work profiles from session telemetry.
+
+A profile answers "what does this person actually work on?" using only
+metadata — file extensions, tool names, MCP server names, harnesses, error
+categories. Prompt and transcript text is never read, so the profile is safe
+to compute for every user regardless of the org's ``trace_privacy`` setting.
+
+ClickHouse access pattern matters here. ``session_stats_agg`` has a bloom
+filter on ``user_id``; ``session_events`` does **not** (only session_id,
+project_id, event_type, line_hash). So we resolve user -> session ids from the
+aggregate table first, then fetch events by session id. Filtering
+``session_events`` on ``user_id`` directly would scan whole partitions.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from loguru import logger as optic
+from sqlalchemy import select
+
+from models.user_profile import UserWorkProfile
+from services.clickhouse import _query
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+# How far back a profile looks, and how many sessions it will consider.
+DEFAULT_PROFILE_DAYS = 60
+MAX_PROFILE_SESSIONS = 300
+# Session ids travel to ClickHouse in the HTTP query string, so the id-array
+# queries use a tighter cap than the session listing to keep the URI sane.
+MAX_ID_ARRAY = 150
+
+# Tool/server name fragments mapped to a coarse work topic. Deliberately a
+# small, readable heuristic rather than a classifier: it feeds a lexical
+# search, so precision matters more than coverage. Tune here, nowhere else.
+TOPIC_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "databases": ("postgres", "mysql", "sqlite", "mongo", "redis", "sql", "prisma", "database", "db"),
+    "frontend": ("react", "vue", "svelte", "css", "tailwind", "browser", "figma", "ui"),
+    "infrastructure": ("docker", "kubernetes", "k8s", "terraform", "aws", "gcp", "azure", "helm", "deploy"),
+    "version-control": ("git", "github", "gitlab", "pr", "commit", "branch"),
+    "testing": ("pytest", "jest", "vitest", "playwright", "test", "coverage"),
+    "observability": ("grafana", "prometheus", "sentry", "datadog", "log", "trace", "metric"),
+    "security": ("auth", "oauth", "saml", "secret", "vault", "crypto", "vulnerab"),
+    "data-analytics": ("pandas", "spark", "airflow", "dbt", "warehouse", "analytic"),
+    "productivity": ("slack", "notion", "jira", "linear", "calendar", "email"),
+}
+
+
+@dataclass
+class WorkProfile:
+    """A user's derived interests. All fields are ordered most-used first."""
+
+    languages: list[str] = field(default_factory=list)
+    tools: list[str] = field(default_factory=list)
+    mcp_servers: list[str] = field(default_factory=list)
+    topics: list[str] = field(default_factory=list)
+    harnesses: list[str] = field(default_factory=list)
+    error_categories: list[str] = field(default_factory=list)
+    session_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "languages": self.languages,
+            "tools": self.tools,
+            "mcp_servers": self.mcp_servers,
+            "topics": self.topics,
+            "harnesses": self.harnesses,
+            "error_categories": self.error_categories,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict, session_count: int = 0) -> WorkProfile:
+        data = data or {}
+        return cls(
+            languages=list(data.get("languages") or []),
+            tools=list(data.get("tools") or []),
+            mcp_servers=list(data.get("mcp_servers") or []),
+            topics=list(data.get("topics") or []),
+            harnesses=list(data.get("harnesses") or []),
+            error_categories=list(data.get("error_categories") or []),
+            session_count=session_count,
+        )
+
+    def is_empty(self) -> bool:
+        return not (self.languages or self.tools or self.mcp_servers or self.topics)
+
+    def search_signals(self) -> str:
+        """Flatten the profile into a search string for the recommender."""
+        from services.registry_recommender import build_signal_query
+
+        return build_signal_query(
+            self.topics,
+            self.mcp_servers,
+            self.languages,
+            self.tools[:10],
+            self.error_categories,
+        )
+
+
+def _mcp_server_name(tool_name: str) -> str | None:
+    """Extract the server from an ``mcp__<server>__<tool>`` tool name."""
+    if not tool_name.startswith("mcp__"):
+        return None
+    parts = tool_name.split("__")
+    return parts[1] if len(parts) >= 2 and parts[1] else None
+
+
+def _topics_for(terms: list[str]) -> Counter:
+    """Bucket assorted terms into coarse topics."""
+    found: Counter = Counter()
+    for term in terms:
+        lowered = term.lower()
+        for topic, keywords in TOPIC_KEYWORDS.items():
+            if any(keyword in lowered for keyword in keywords):
+                found[topic] += 1
+    return found
+
+
+async def _ch_rows(sql: str, params: dict) -> list[dict]:
+    try:
+        response = await _query(sql, params)
+        response.raise_for_status()
+        return response.json().get("data", [])
+    except Exception as e:
+        optic.warning("user_profile: clickhouse query failed: {}", e)
+        return []
+
+
+# Session ids originate from client-supplied ingest payloads, so they are
+# untrusted. Everything a real harness emits is a uuid or a slug-ish id, and
+# this is deliberately narrower than that.
+_SAFE_SESSION_ID = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+
+def _id_array(session_ids: list[str]) -> str:
+    """Render session ids as a ClickHouse array literal.
+
+    Parameters travel as HTTP query values, so the array has to arrive
+    pre-formatted rather than bound. Ids are therefore *rejected* unless they
+    match a strict allowlist — not escaped, and not merely quote-stripped.
+    Stripping only quotes would still admit a trailing backslash, which
+    ClickHouse treats as an escape and which could swallow the closing quote
+    of the literal.
+    """
+    safe = [sid for sid in session_ids if _SAFE_SESSION_ID.match(sid or "")]
+    dropped = len(session_ids) - len(safe)
+    if dropped:
+        optic.warning("user_profile: dropped {} session id(s) with unexpected characters", dropped)
+    return "[" + ",".join(f"'{sid}'" for sid in safe[:MAX_ID_ARRAY]) + "]"
+
+
+async def build_profile(
+    user_id: uuid.UUID,
+    project_id: str,
+    days: int = DEFAULT_PROFILE_DAYS,
+) -> WorkProfile:
+    """Compute a fresh profile for one user from their own sessions."""
+    since = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+
+    # Step 1: user -> sessions, via the table that indexes user_id.
+    session_rows = await _ch_rows(
+        """
+        SELECT session_id, anyLast(harness) AS harness
+        FROM session_stats_agg FINAL
+        WHERE user_id = {uid:String}
+          AND project_id = {pid:String}
+          AND last_event_time >= {since:String}
+        GROUP BY session_id
+        ORDER BY max(last_event_time) DESC
+        LIMIT {limit:UInt32}
+        FORMAT JSON
+        """,
+        {
+            "param_uid": str(user_id),
+            "param_pid": project_id,
+            "param_since": since,
+            "param_limit": MAX_PROFILE_SESSIONS,
+        },
+    )
+    if not session_rows:
+        return WorkProfile()
+
+    session_ids = [row["session_id"] for row in session_rows if row.get("session_id")]
+    harnesses = Counter(row["harness"] for row in session_rows if row.get("harness"))
+    if not session_ids:
+        return WorkProfile()
+
+    # Step 2: sessions -> tool usage, keyed on the indexed session_id column.
+    tool_rows = await _ch_rows(
+        """
+        SELECT tool_name, count() AS uses
+        FROM session_events
+        WHERE session_id IN ({ids:Array(String)})
+          AND tool_name IS NOT NULL
+          AND tool_name != ''
+        GROUP BY tool_name
+        ORDER BY uses DESC
+        LIMIT 200
+        FORMAT JSON
+        """,
+        {"param_ids": _id_array(session_ids)},
+    )
+
+    tools: Counter = Counter()
+    mcp_servers: Counter = Counter()
+    for row in tool_rows:
+        name = str(row.get("tool_name") or "")
+        uses = int(row.get("uses") or 0)
+        if not name:
+            continue
+        server = _mcp_server_name(name)
+        if server:
+            mcp_servers[server] += uses
+        else:
+            tools[name] += uses
+
+    # Step 3: file extensions -> languages, from tool-call previews.
+    languages = await _languages_for_sessions(session_ids)
+
+    topic_terms = list(mcp_servers) + list(tools) + list(languages)
+    topics = _topics_for(topic_terms)
+
+    return WorkProfile(
+        languages=[name for name, _ in languages.most_common(8)],
+        tools=[name for name, _ in tools.most_common(15)],
+        mcp_servers=[name for name, _ in mcp_servers.most_common(10)],
+        topics=[name for name, _ in topics.most_common(6)],
+        harnesses=[name for name, _ in harnesses.most_common(5)],
+        error_categories=[],
+        session_count=len(session_ids),
+    )
+
+
+async def _languages_for_sessions(session_ids: list[str]) -> Counter:
+    """Infer languages from file paths mentioned in tool-call previews.
+
+    ``content_preview`` is a short, already-truncated summary written at
+    ingest — this does not read full transcripts.
+    """
+    rows = await _ch_rows(
+        """
+        SELECT content_preview
+        FROM session_events
+        WHERE session_id IN ({ids:Array(String)})
+          AND event_type = 'tool_call'
+          AND content_preview != ''
+        LIMIT 5000
+        FORMAT JSON
+        """,
+        {"param_ids": _id_array(session_ids)},
+    )
+
+    # Imported lazily: `services.insights` pulls in LiteLLM at package import
+    # time, and a profile rebuild should not pay for that.
+    from services.insights.session_meta_extractor import EXTENSION_TO_LANGUAGE
+
+    languages: Counter = Counter()
+    for row in rows:
+        preview = str(row.get("content_preview") or "")
+        for extension, language in EXTENSION_TO_LANGUAGE.items():
+            if extension in preview:
+                languages[language] += 1
+    return languages
+
+
+async def get_or_build_profile(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    project_id: str,
+    max_age_hours: int = 24,
+    force: bool = False,
+) -> WorkProfile:
+    """Return a cached profile, recomputing it when stale.
+
+    Recomputation touches ClickHouse, so the cache is what keeps the
+    recommendations endpoint cheap enough to call on page load.
+    """
+    existing = (
+        await db.execute(select(UserWorkProfile).where(UserWorkProfile.user_id == user_id))
+    ).scalar_one_or_none()
+
+    if existing and not force:
+        computed_at = existing.computed_at
+        if computed_at is not None:
+            if computed_at.tzinfo is None:
+                computed_at = computed_at.replace(tzinfo=UTC)
+            if datetime.now(UTC) - computed_at < timedelta(hours=max_age_hours):
+                return WorkProfile.from_dict(existing.profile, existing.session_count)
+
+    profile = await build_profile(user_id, project_id)
+    await _persist(db, user_id, profile, existing)
+    return profile
+
+
+async def _persist(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    profile: WorkProfile,
+    existing: UserWorkProfile | None,
+) -> None:
+    try:
+        if existing:
+            existing.profile = profile.to_dict()
+            existing.session_count = profile.session_count
+            existing.computed_at = datetime.now(UTC)
+        else:
+            db.add(
+                UserWorkProfile(
+                    user_id=user_id,
+                    profile=profile.to_dict(),
+                    session_count=profile.session_count,
+                    computed_at=datetime.now(UTC),
+                )
+            )
+        await db.commit()
+    except Exception as e:
+        # A cache write failure must not break the caller's request.
+        await db.rollback()
+        optic.warning("user_profile: persist failed for {}: {}", user_id, e)

--- a/observal-server/services/user_profile.py
+++ b/observal-server/services/user_profile.py
@@ -186,8 +186,8 @@ async def users_with_recent_activity(days: int = DEFAULT_PROFILE_DAYS) -> set[tu
         )
         response.raise_for_status()
         rows = response.json().get("data", [])
-    except Exception as e:
-        optic.warning("user_profile: active-user lookup failed: {}", e)
+    except Exception:
+        optic.warning("user_profile: active-user lookup failed")
         return None
 
     return {(str(r.get("project_id") or ""), str(r.get("user_id") or "")) for r in rows}

--- a/observal-server/services/user_recommendations.py
+++ b/observal-server/services/user_recommendations.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Personalised registry recommendations.
+
+Two stages:
+
+1. **Candidates** — deterministic. The user's work profile becomes a search
+   string; the shared recommender ranks visible components against it, with
+   popularity as a tie-break. Components the user already installed (via an
+   agent) or explicitly dismissed are removed.
+2. **Explanations** — the "why you" line. Derived from which profile terms
+   matched, so it stays truthful and costs nothing.
+
+Cold start (no sessions yet) falls back to popular components rather than
+showing an empty rail or inventing relevance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from loguru import logger as optic
+from sqlalchemy import select
+
+from models.agent import Agent, AgentVersion
+from models.agent_component import AgentComponent
+from models.download import AgentDownloadRecord
+from models.user_profile import RecommendationFeedback
+from services.registry_recommender import (
+    ALL_COMPONENT_TYPES,
+    ComponentCandidate,
+    shortlist,
+)
+
+if TYPE_CHECKING:
+    import uuid
+    from collections.abc import Sequence
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from services.user_profile import WorkProfile
+
+DEFAULT_LIMIT = 8
+CANDIDATE_POOL = 40
+
+
+@dataclass
+class Recommendation:
+    """A component suggested to a user, with the reason it was chosen."""
+
+    candidate: ComponentCandidate
+    reason: str
+
+    def to_dict(self) -> dict:
+        data = self.candidate.to_api_dict()
+        data["reason"] = self.reason
+        return data
+
+
+async def _installed_component_ids(db: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+    """Components the user already has, via agents they installed.
+
+    ``component_download_records`` is never written by the application, so
+    adoption is derived from agent installs instead — which is also the
+    signal the component leaderboard uses.
+    """
+    stmt = (
+        select(AgentComponent.component_id)
+        .join(AgentVersion, AgentComponent.agent_version_id == AgentVersion.id)
+        .join(Agent, Agent.latest_version_id == AgentVersion.id)
+        .join(AgentDownloadRecord, AgentDownloadRecord.agent_id == Agent.id)
+        .where(AgentDownloadRecord.user_id == user_id)
+    )
+    try:
+        return {row[0] for row in (await db.execute(stmt)).all()}
+    except Exception as e:
+        optic.warning("recommendations: installed lookup failed: {}", e)
+        return set()
+
+
+async def _dismissed_component_ids(db: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+    stmt = select(RecommendationFeedback.component_id).where(
+        RecommendationFeedback.user_id == user_id,
+        RecommendationFeedback.action.in_(["dismissed", "not_relevant"]),
+    )
+    try:
+        return {row[0] for row in (await db.execute(stmt)).all()}
+    except Exception as e:
+        optic.warning("recommendations: dismissal lookup failed: {}", e)
+        return set()
+
+
+def _explain(candidate: ComponentCandidate, profile: WorkProfile) -> str:
+    """Say why this was recommended, using only what actually matched."""
+    if candidate.matched_terms:
+        shown = candidate.matched_terms[:3]
+        joined = ", ".join(shown)
+        return f"Matches your work on {joined}"
+    if profile.is_empty():
+        return "Popular in your registry"
+    return "Popular among components like the ones you use"
+
+
+async def recommend_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID | None,
+    profile: WorkProfile,
+    component_types: Sequence[str] = ALL_COMPONENT_TYPES,
+    limit: int = DEFAULT_LIMIT,
+) -> list[Recommendation]:
+    """Rank components for one user. Never raises; returns [] on failure."""
+    exclude = await _installed_component_ids(db, user_id)
+    exclude |= await _dismissed_component_ids(db, user_id)
+
+    signals = profile.search_signals()
+
+    try:
+        candidates = await shortlist(
+            db,
+            signals=signals,
+            component_types=component_types,
+            org_id=org_id,
+            user_id=user_id,
+            exclude_ids=exclude,
+            per_type_limit=max(limit, 4),
+            total_limit=CANDIDATE_POOL,
+        )
+    except Exception as e:
+        optic.warning("recommendations: shortlist failed for {}: {}", user_id, e)
+        return []
+
+    recommendations = [Recommendation(candidate=c, reason=_explain(c, profile)) for c in candidates[:limit]]
+
+    # A thin profile can match almost nothing, leaving a near-empty rail even
+    # though the registry is full. Top up with popular components so the page
+    # still helps — labelled as popularity, not as a personal match.
+    if len(recommendations) < limit:
+        already = exclude | {r.candidate.id for r in recommendations}
+        try:
+            filler = await shortlist(
+                db,
+                signals="",
+                component_types=component_types,
+                org_id=org_id,
+                user_id=user_id,
+                exclude_ids=already,
+                per_type_limit=limit,
+                total_limit=limit - len(recommendations),
+            )
+        except Exception as e:
+            optic.warning("recommendations: popularity top-up failed for {}: {}", user_id, e)
+            filler = []
+        recommendations.extend(Recommendation(candidate=c, reason="Popular in your registry") for c in filler)
+
+    optic.debug(
+        "recommendations: user={} profile_sessions={} returned={}",
+        user_id,
+        profile.session_count,
+        len(recommendations),
+    )
+    return recommendations
+
+
+async def record_feedback(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    component_type: str,
+    component_id: uuid.UUID,
+    action: str,
+) -> None:
+    """Persist a dismissal (or install) so it is honoured next time."""
+    existing = (
+        await db.execute(
+            select(RecommendationFeedback).where(
+                RecommendationFeedback.user_id == user_id,
+                RecommendationFeedback.component_type == component_type,
+                RecommendationFeedback.component_id == component_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if existing:
+        existing.action = action
+    else:
+        db.add(
+            RecommendationFeedback(
+                user_id=user_id,
+                component_type=component_type,
+                component_id=component_id,
+                action=action,
+            )
+        )
+    await db.commit()

--- a/observal-server/services/user_recommendations.py
+++ b/observal-server/services/user_recommendations.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger as optic
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from models.agent import Agent, AgentVersion
 from models.agent_component import AgentComponent
@@ -44,6 +45,10 @@ if TYPE_CHECKING:
 
 DEFAULT_LIMIT = 8
 CANDIDATE_POOL = 40
+
+# Feedback actions that stop a component being recommended again. Every action
+# the API accepts is terminal: the user has either rejected it or taken it.
+SUPPRESSING_ACTIONS: frozenset[str] = frozenset({"dismissed", "not_relevant", "installed"})
 
 
 @dataclass
@@ -80,15 +85,22 @@ async def _installed_component_ids(db: AsyncSession, user_id: uuid.UUID) -> set[
         return set()
 
 
-async def _dismissed_component_ids(db: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+async def _suppressed_component_ids(db: AsyncSession, user_id: uuid.UUID) -> set[uuid.UUID]:
+    """Components the user has told us to stop recommending.
+
+    "installed" belongs here alongside the rejections: adoption is normally
+    inferred from agent installs, but a user who reports installing something
+    directly has answered the question just as definitively as one who
+    dismissed it. Leaving it out made the action accepted and then ignored.
+    """
     stmt = select(RecommendationFeedback.component_id).where(
         RecommendationFeedback.user_id == user_id,
-        RecommendationFeedback.action.in_(["dismissed", "not_relevant"]),
+        RecommendationFeedback.action.in_(list(SUPPRESSING_ACTIONS)),
     )
     try:
         return {row[0] for row in (await db.execute(stmt)).all()}
     except Exception as e:
-        optic.warning("recommendations: dismissal lookup failed: {}", e)
+        optic.warning("recommendations: feedback lookup failed: {}", e)
         return set()
 
 
@@ -113,7 +125,7 @@ async def recommend_for_user(
 ) -> list[Recommendation]:
     """Rank components for one user. Never raises; returns [] on failure."""
     exclude = await _installed_component_ids(db, user_id)
-    exclude |= await _dismissed_component_ids(db, user_id)
+    exclude |= await _suppressed_component_ids(db, user_id)
 
     signals = profile.search_signals()
 
@@ -171,20 +183,21 @@ async def record_feedback(
     component_id: uuid.UUID,
     action: str,
 ) -> None:
-    """Persist a dismissal (or install) so it is honoured next time."""
-    existing = (
-        await db.execute(
-            select(RecommendationFeedback).where(
-                RecommendationFeedback.user_id == user_id,
-                RecommendationFeedback.component_type == component_type,
-                RecommendationFeedback.component_id == component_id,
-            )
-        )
-    ).scalar_one_or_none()
+    """Persist a dismissal (or install) so it is honoured next time.
 
-    if existing:
-        existing.action = action
-    else:
+    Insert-then-recover rather than a native upsert: the unique key makes the
+    race safe, and this stays portable across the Postgres deployment and the
+    SQLite the tests run on. Two clicks racing would otherwise both see no row
+    and the loser would surface a unique violation as a 500.
+    """
+    lookup = select(RecommendationFeedback).where(
+        RecommendationFeedback.user_id == user_id,
+        RecommendationFeedback.component_type == component_type,
+        RecommendationFeedback.component_id == component_id,
+    )
+    existing = (await db.execute(lookup)).scalar_one_or_none()
+
+    if existing is None:
         db.add(
             RecommendationFeedback(
                 user_id=user_id,
@@ -193,4 +206,16 @@ async def record_feedback(
                 action=action,
             )
         )
+        try:
+            await db.commit()
+            return
+        except IntegrityError:
+            # Someone inserted the same row between our SELECT and INSERT.
+            # Fall through and update whatever is there now.
+            await db.rollback()
+            existing = (await db.execute(lookup)).scalar_one_or_none()
+            if existing is None:
+                raise
+
+    existing.action = action
     await db.commit()

--- a/observal-server/services/user_recommendations.py
+++ b/observal-server/services/user_recommendations.py
@@ -118,7 +118,6 @@ def _explain(candidate: ComponentCandidate, profile: WorkProfile) -> str:
 async def recommend_for_user(
     db: AsyncSession,
     user_id: uuid.UUID,
-    org_id: uuid.UUID | None,
     profile: WorkProfile,
     component_types: Sequence[str] = ALL_COMPONENT_TYPES,
     limit: int = DEFAULT_LIMIT,
@@ -134,7 +133,6 @@ async def recommend_for_user(
             db,
             signals=signals,
             component_types=component_types,
-            org_id=org_id,
             user_id=user_id,
             exclude_ids=exclude,
             per_type_limit=max(limit, 4),
@@ -156,7 +154,6 @@ async def recommend_for_user(
                 db,
                 signals="",
                 component_types=component_types,
-                org_id=org_id,
                 user_id=user_id,
                 exclude_ids=already,
                 per_type_limit=limit,

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [manifest]
 overrides = [{ name = "starlette", specifier = ">=1.3.1" }]
@@ -607,6 +612,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -850,6 +864,218 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/62/8fb1fb647d2788c950d69d6a769cd9d55c918ac1fc57be2f90b7e4029787/google_api_core-2.33.0.tar.gz", hash = "sha256:3a36bcc3e319783f4c97da41f6f45ea6ffcaa55848e341de16e09cb70243c2bb", size = 181607, upload-time = "2026-07-22T16:28:28.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/31/5056a347bb934ea04583c8b27916ef1501729c72638629545bce26ff4223/google_api_core-2.33.0-py3-none-any.whl", hash = "sha256:a2e22a0c1d0f03eafff1858b38cf46f832d5902b0c052235bf0ab8402929fbdc", size = 176462, upload-time = "2026-07-22T16:28:22.447Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/dbc946a407401b975f0719658f18e664ece2109f79ffd1ff3bf226c205f4/google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051", size = 365820, upload-time = "2026-07-21T21:53:28.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/63/50636aae68c9bf17c891c7eb18b49baa9bd6b31d2a97b8de4813a9fc8d1c/google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6", size = 258588, upload-time = "2026-07-21T21:53:26.399Z" },
+]
+
+[package.optional-dependencies]
+pyopenssl = [
+    { name = "cryptography" },
+]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-cloud-aiplatform"
+version = "1.163.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "docstring-parser" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-bigquery" },
+    { name = "google-cloud-resource-manager" },
+    { name = "google-cloud-storage" },
+    { name = "google-genai" },
+    { name = "packaging" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/ea/257c5fc5d04bff5b237a10761c89564828e98c2c80aedb1531465c80bedb/google_cloud_aiplatform-1.163.0.tar.gz", hash = "sha256:b570d22b145504e66f3f50f4bdeeae3c818ba46f330276566e80a42937ff53ef", size = 11235221, upload-time = "2026-07-28T17:34:06.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/4b/8e45c1b9e404d42c66bf231d62eae5236855fa428a0d5c6d02ac72dc4514/google_cloud_aiplatform-1.163.0-py2.py3-none-any.whl", hash = "sha256:23855d261aadcf949fa6102f94d0d0dbd9af879dc4e3f651e7f4e27296af8cca", size = 9401645, upload-time = "2026-07-28T17:34:02.71Z" },
+]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "3.42.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth", extra = ["pyopenssl"] },
+    { name = "google-cloud-core" },
+    { name = "google-resumable-media" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/7a/6109aa1803b0c8c93c7064e0e555cff1b12e1692b7b7bc63cdc1619e3722/google_cloud_bigquery-3.42.2.tar.gz", hash = "sha256:08d4b264e5ee4790f719724c76b538f204b7190999328a2f1a6a95eaab74ca39", size = 517250, upload-time = "2026-07-08T17:03:40.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/ee/3f3ff62d4ce39e6868ef9b98bea0af46f0c9c270092ef64d2bb5897c6e11/google_cloud_bigquery-3.42.2-py3-none-any.whl", hash = "sha256:41658c19e8ed5b83307011b4e55aca3b1f72052545a22788f1d637984615173f", size = 264272, upload-time = "2026-07-08T17:03:09.511Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-resource-manager"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/70/d467d93528905700826d26a48ad16ac39d4b36dd6efb5a86fb338efa81aa/google_cloud_resource_manager-1.18.0.tar.gz", hash = "sha256:db689f800a14c66d041196a7fbb8bb8aae8dc87f28c2929e101a5ec766b15512", size = 463674, upload-time = "2026-06-22T23:22:27.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/62/2dbecda08a32aa9d4e6909eba3e31731c2d4452687bb6364a8d7950aed74/google_cloud_resource_manager-1.18.0-py3-none-any.whl", hash = "sha256:69bab144acd75878ebe44b720903dc3d140cb7d3be3261eaa8bc81e48afaff33", size = 404211, upload-time = "2026-06-22T23:20:25.88Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/25/355ed97c1723c787dfaa888808d55db18371f82c38ff862357b1e902cd19/google_cloud_storage-3.13.0.tar.gz", hash = "sha256:d11d8706ea1520fba0f21043bcb7897caf7015d76ce1ad9a4f60237e4d7a9f6c", size = 17340960, upload-time = "2026-07-13T19:10:07.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e8/b3678a0931ee7d4b3fdaf0813e6206d66e0922b2c26d912f308728b5b95a/google_cloud_storage-3.13.0-py3-none-any.whl", hash = "sha256:648af3ef8a6acc674e1359d3c920c67eb89a7a5ab66b336bd3ac43fed6b5ab84", size = 341428, upload-time = "2026-07-13T19:09:52.39Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/df/4f820054c99f29f2fe3de4a8a7c9534dd795302e4a07483a0cb07c3a29b6/google_genai-2.14.0.tar.gz", hash = "sha256:a9d1f4f362d76280f1be1340fcb3c86e63dbca128f6a4ae09d86ab47ff7148e8", size = 641055, upload-time = "2026-07-22T21:35:44.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/86/5ac5fb53e44cca4a6607fb917eb331fa237c65a103b9ec2e8e8acc8a42db/google_genai-2.14.0-py3-none-any.whl", hash = "sha256:ae7172cdd35695189b516b33a878e4132e5daa2dbc03a5b44cddfa8a82fad664", size = 1030738, upload-time = "2026-07-22T21:35:42.785Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+]
+
+[[package]]
 name = "graphql-core"
 version = "3.2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -908,6 +1134,85 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos", extra = ["grpc"] },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/4f/d098419ad0bfc06c9ce440575f05aa22d8973b6c276e86ac7890093d3c37/grpc_google_iam_v1-0.14.4.tar.gz", hash = "sha256:392b3796947ed6334e61171d9ab06bf7eb357f554e5fc7556ad7aab6d0e17038", size = 23706, upload-time = "2026-04-01T01:57:49.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/c2dd50c09bf679bd38173656cd4402d2511e563b33bc88f90009cf50613c/grpc_google_iam_v1-0.14.4-py3-none-any.whl", hash = "sha256:412facc320fcbd94034b4df3d557662051d4d8adfa86e0ddb4dca70a3f739964", size = 32675, upload-time = "2026-04-01T01:57:47.69Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/f6/3b781cd07a715ea5f5125ae264226e7fc4d87603d6d3955022cabfdc5da2/grpcio-1.83.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:8ff0b8767ddd62704e0d9571c1890af08d84a3a689ebba1807e62519d0b3277f", size = 6338720, upload-time = "2026-07-23T15:19:13.177Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/d14833d15d5984e366f1b027fa78bd038c9b028c66880bffb0f5a4d25ee2/grpcio-1.83.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4772402f43517b4824980be4b3b2274a81eec0004a70009473c31b340d43e223", size = 12178773, upload-time = "2026-07-23T15:19:15.401Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/98/8acbb416544e7871132d8e42a07ed70c802d70e6a16c6009e505a34d32a4/grpcio-1.83.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f4cee5fc86e84a0cf7ad1574b454c3320e087c07f55b7df5dc0ac6a873fb90c0", size = 6921203, upload-time = "2026-07-23T15:19:17.824Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/0fdbfaf4fc54e5c88f6bce4008a065092fe7fbc4460eb5617ae8b20fd505/grpcio-1.83.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f5e822a7e7d03282f6ad225e710493c48b9057a353358344a5f7c42b2b37618d", size = 7648508, upload-time = "2026-07-23T15:19:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ea/107b9dbb2ed3ad14dd774fd3dde7d29ff9938a6c198654becb2c3a0e9a6a/grpcio-1.83.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5f410d7c2903eabb34789dfd6342eef04af1ad459943936b7e09a9f5bd417b9", size = 7079466, upload-time = "2026-07-23T15:19:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/06/9fa9941089e6fae83b060b6ce61c1e81053e52decae43197245f45e07d36/grpcio-1.83.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee94a4016fdf8699fb1fd8a38652475ff677f1c72074cee44deeeb9a7e95e745", size = 7605583, upload-time = "2026-07-23T15:19:23.74Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/f10fb56062dc2771c630827a82d9ad0ecd05cad572ea3b08d49f6631680a/grpcio-1.83.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c6444666317338e903093c7c756e6cc88eee59f798cb8dd41e87725bf54e1617", size = 8637810, upload-time = "2026-07-23T15:19:25.536Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/f84927258f6a1b6ea6dea661fdc6de859b35e560c96f3012d15ccd39f85e/grpcio-1.83.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aa074041231f03959cb097dd5517b0677b8ea49215bae01d5710a7b69dd59969", size = 8008021, upload-time = "2026-07-23T15:19:27.863Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/cdf72161397ccd29d4ca2192f641524536c9cf54ad948c9dd0e0e01138fa/grpcio-1.83.0-cp311-cp311-win32.whl", hash = "sha256:cb056f6e171c42639a50460b2929c82241fda51f71cf3dcdd68090fe45095a45", size = 4404376, upload-time = "2026-07-23T15:19:30.137Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ed/e0ffeb4c848699c194dc9fb6a29ab29bcb2b6aac8c416bf18c51bfe8242c/grpcio-1.83.0-cp311-cp311-win_amd64.whl", hash = "sha256:7416952ca770477990257206276999056f8316d79196f2f25942393e58a20b49", size = 5164469, upload-time = "2026-07-23T15:19:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2b/51e32514a4e9b715375c99721aadff0f24164cc2049b8269eda4de82a814/grpcio-1.83.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:28f6c35ac8fcf10e4594f138e468f194360089dde40d126a7033e863fc479930", size = 6303167, upload-time = "2026-07-23T15:19:33.78Z" },
+    { url = "https://files.pythonhosted.org/packages/39/33/b5b50fc2c6fbe350e04814047bb2d409feec7b36ef8b170254c050e06bc0/grpcio-1.83.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:33898e6a28e4ae598f1577cb1c4fec2a15c033d0ec52b9b45a09610dd045b9da", size = 12160538, upload-time = "2026-07-23T15:19:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5f/734e72e7b9f79bcf0b2c270b8d3bca0e4ebb97a27a50d06240b145f6d41e/grpcio-1.83.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fb8a1dd0c6f0f931e69e9d0dc6d1c406ed2a44fa963414eafba07b7fb685d16", size = 6869310, upload-time = "2026-07-23T15:19:38.607Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/a1735f215b2a5cd43c38b79eac072ad197e61be9829905b6b29550abd0db/grpcio-1.83.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2b5e75c34842cd9c1b95285ca395c6a569664b81e3ffa6b714125922942abaaf", size = 7613472, upload-time = "2026-07-23T15:19:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeb339838db07600481ef869507279b75326c75eac6d10f7afa62a0da1d2bcdd", size = 7040616, upload-time = "2026-07-23T15:19:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ba/94cd5af859876049d340480acbb61a959096c84b567f215534faa78d0424/grpcio-1.83.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f47d62808b4c0a97b78bff88a6d4ca283a2a492b9a04a87d814af95ca3b9c19c", size = 7570491, upload-time = "2026-07-23T15:19:44.357Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/15/108d30d5a5c964312ae8b9cb0e8cc5b3c1cc68d8f757cca52b3565534d26/grpcio-1.83.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62003babc444a606dcd1f009cd16391ce23669ae4ad6ec267a873da7937a69f5", size = 8605036, upload-time = "2026-07-23T15:19:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/23/3828ae13c3db8233d123ad612747665817b952d8a954f32390230b582336/grpcio-1.83.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1aa567f8c3f19850ffd5d2858c9a8ea7c80f0db6c01186b71eb31e923ec984f5", size = 7981587, upload-time = "2026-07-23T15:19:48.913Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/77af31228f55f55a2a5112bb0077ad0a1c4d23dbb0c2853a62475bbdcc14/grpcio-1.83.0-cp312-cp312-win32.whl", hash = "sha256:cb2906c61db4f9c64cc360054b5df70eeb81846228e9e56a4944bd415a63dadc", size = 4394004, upload-time = "2026-07-23T15:19:50.618Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/f706e39550e7a3732ce2b9c5926107a93d74a802775b19b642a6df27dc96/grpcio-1.83.0-cp312-cp312-win_amd64.whl", hash = "sha256:1c699bbb20f143c8f2bff219de578aa2dc1f919399d67dc702b038b986ee62df", size = 5158525, upload-time = "2026-07-23T15:19:52.246Z" },
+    { url = "https://files.pythonhosted.org/packages/56/eb/135daaa713f32d33b8f99b4153b3f8dc3b2a124996ac15581bf9ebdad3c3/grpcio-1.83.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:6662f3b1e07cc7493d437351860dc867bddc6a93c83ecf33bbfdaf0c217ab2d0", size = 6304480, upload-time = "2026-07-23T15:19:53.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a1/121806ce69f23138dabe06aa595b0e5f1ae051a37e4c1954eed7d692c800/grpcio-1.83.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:74fe6f9e8a35c7dbf32255ee154d15e3e5338a81ed39173d079d594d2e544cd1", size = 12154419, upload-time = "2026-07-23T15:19:56.3Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e8/d0389e09cd6b4c4d3089b92967ae4e3ffd64795bd349bf2f85cd6656d3da/grpcio-1.83.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10b3fa0475eb572c9a81a6fe37fa16a9c500c0c91cfc148cac15692b7e3c2867", size = 6873200, upload-time = "2026-07-23T15:19:58.701Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/51/f464c1d211fa50d5adbabe1b2e519948d99c13757052bfc9ea7afa28e284/grpcio-1.83.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5f20a988480b0f28207f057f7f7ae1313393c3cef0adcfeae8248f9947eaf881", size = 7618811, upload-time = "2026-07-23T15:20:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c0/539fe0832f2dd6500a28f5263071623fb34e8d4867aec632ccf81bd21156/grpcio-1.83.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bd82671b39065ba18cd536e9cd45b27ff649053f81ddd2c6a966d595067080f", size = 7042310, upload-time = "2026-07-23T15:20:02.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ca/ccf617d37ffa72567fa8e005ec7090c99da922799be2fb9847c8b21ca18c/grpcio-1.83.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc60215b5cb9fc8ca72942c498b551ac2305bd08f6ef8d4e3f0d21b64fbecd61", size = 7575412, upload-time = "2026-07-23T15:20:04.712Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b9/fd8d5245f823a8e0fd35d90e20ea3aa4acd47f8d5318fa8df307df52dec6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f1c3e5689d4b90987b1d72022bcfe866a9a3dc66197484cf856d96b6150e7f45", size = 8604248, upload-time = "2026-07-23T15:20:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/f37632fc11db72dfa4bba86c3a43e54358e53030df111ecae5e91a733ad6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a21cb4eeeba124443f399be2e8b624943cde864dcbe588cb42e5c483a52a906c", size = 7977458, upload-time = "2026-07-23T15:20:09.109Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b6/d70b69ae5c0cfc341b9ba474980e4ed99cbf05c0e4a14e9eee8cb73db0a5/grpcio-1.83.0-cp313-cp313-win32.whl", hash = "sha256:8fe04f1050a59f875601eb55d42b4f66946fe89817f967e34db1462ccd07dadf", size = 4393993, upload-time = "2026-07-23T15:20:11.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/13/45d4cccb555cf4c476226979bf3d2fd0b0254216f7564c3a053e35117efc/grpcio-1.83.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e01ecd9d8ef280abe1365138a4dc318f9a5287f4cb1b41d07816f796653f735", size = 5159650, upload-time = "2026-07-23T15:20:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/60/f2cca8147ea213d3e43ae9158d03ad04e020fdf32ff027253e1fe93f921d/grpcio-1.83.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3f351629f6ae16ecc0ec3553e586a6763ffd9f6114044286d0cbec3e09241bfa", size = 6305607, upload-time = "2026-07-23T15:20:15.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ab/d3874931d123a95e83a3ebf8aa04537988fb62425cedb8bf3cefc5ad41b2/grpcio-1.83.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d05ff664100d429335b93c91b8b34ddf9e94a112205e7fa06dede309e44a4e4c", size = 12166617, upload-time = "2026-07-23T15:20:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ff/6f18f9426b69306f4e00a9add3b0ee2748da8aad53836ef80cab0d62d04f/grpcio-1.83.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7936f2a56cf04f6514705c0fedf400971de01b6aa1719327e4718f410a765e2b", size = 6880213, upload-time = "2026-07-23T15:20:19.98Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/706d1147c6b93b98f179240c13991fbcc56880eba0c868abb1ad40d8a0a6/grpcio-1.83.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b0a0be840e51b6b7ee9df9269770faf77bdf4b771053c257c21d12bad607714c", size = 7618335, upload-time = "2026-07-23T15:20:22.161Z" },
+    { url = "https://files.pythonhosted.org/packages/74/04/1a8443c889115ec9e213a213e86bc93a71ee9088027e5befa09aaa0edd9d/grpcio-1.83.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:009667eaf3dcd5224c713589cdc98e7ca4ed0ff0b61132c6b276e930eb83a2df", size = 7043416, upload-time = "2026-07-23T15:20:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c6/94e0fee5b12bc1da1370185b680988db6f739d19b42d9959db01a7ea50bf/grpcio-1.83.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb669918fd88936b15599caff4160a77ab74bdeb25f2231f6e45b61282d6107b", size = 7583253, upload-time = "2026-07-23T15:20:26.313Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/97/de1ccb671fb85575bc5192faedf9ecdbdf5b390d2e6584dcf552bcbd370e/grpcio-1.83.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c19b454d3d3f28db81f2c7c4dbaee96e7f6fd149721733ffe79d6bc530f17404", size = 8605102, upload-time = "2026-07-23T15:20:28.437Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0f/0e0ec749a7034ffcbaa050e39779872950ead90c22e7e0116be3f28b2b46/grpcio-1.83.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:61007cd08640abc5c54547ee32505474c482cd733a53cb87551ea81faa6350af", size = 7979826, upload-time = "2026-07-23T15:20:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/c3fda157287f64bc65acee6c5aa90c41acf9e0d3a8e69a265eecff6d00a1/grpcio-1.83.0-cp314-cp314-win32.whl", hash = "sha256:32e11c37f5285b0c6fa3042c05fe06903696689749833fc64e67dec71b9bbe33", size = 4471765, upload-time = "2026-07-23T15:20:33.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/00/b1b26431c9d54eee11724fd6e5585473a2ed47fbc1fb95e5204906a642ce/grpcio-1.83.0-cp314-cp314-win_amd64.whl", hash = "sha256:2bb48cb5e6dd005ca12b89ce4b6ac0b48ff3112c747542ee7986ef611a8ca6d9", size = 5298932, upload-time = "2026-07-23T15:20:35.48Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/fd/848dd7e009de85f8ca59999d1cc618ff8ebf7ea5636d083a47455d212d24/grpcio_status-1.83.0.tar.gz", hash = "sha256:837219c6de9afdccb6f6f72b34bc71e151a2011ef04040e3faaca746a57e54ae", size = 13965, upload-time = "2026-07-23T15:24:26.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/00/73204406228cf989bea6b0fd9fe4702fab49a8a152a0c6f90856dadb6ac7/grpcio_status-1.83.0-py3-none-any.whl", hash = "sha256:f6a838a7c5fb84ae98833ec0ef81ed438c26e11e54b2ddb8e92ad328c861de69", size = 14636, upload-time = "2026-07-23T15:23:49.044Z" },
 ]
 
 [[package]]
@@ -1699,6 +2004,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastapi-cache2" },
     { name = "gitpython" },
+    { name = "google-cloud-aiplatform" },
     { name = "httpx" },
     { name = "idna" },
     { name = "itsdangerous" },
@@ -1751,6 +2057,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.136.0,!=0.136.3" },
     { name = "fastapi-cache2", specifier = ">=0.2.2" },
     { name = "gitpython", specifier = ">=3.1.55" },
+    { name = "google-cloud-aiplatform", specifier = ">=1.60.0" },
     { name = "httpx" },
     { name = "idna", specifier = ">=3.15" },
     { name = "itsdangerous" },
@@ -2109,6 +2416,33 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/3e/29e0d6a2c5adde6ab5772253fd16ab346324026b89a66e354689c86d0584/proto_plus-1.28.2.tar.gz", hash = "sha256:26d843eb99c1e32fdf1d20ff0faae56607f7748fe774acf9ecd5cfe6c6472501", size = 58063, upload-time = "2026-07-22T16:28:29.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/84/4e9a53a062d4073c74897a6bd20fff74d55307341b3e85c081002462b3ef/proto_plus-1.28.2-py3-none-any.whl", hash = "sha256:b874236fcac2358f601e4330bcb76cb8b89c851303ccf4078408b3d4774d1c52", size = 50693, upload-time = "2026-07-22T16:28:24.059Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2156,6 +2490,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]

--- a/observal-server/worker.py
+++ b/observal-server/worker.py
@@ -12,7 +12,7 @@
 from arq.cron import cron
 from loguru import logger as optic
 
-from jobs.catalog import batch_generate_insights, generate_insight_report
+from jobs.catalog import batch_generate_insights, generate_insight_report, refresh_user_profiles
 from jobs.maintenance import maintain_clickhouse, sync_component_sources
 from jobs.migration import purge_migration_artifacts, run_migration_job
 from logging_config import setup_logging
@@ -51,6 +51,7 @@ class WorkerSettings:
         batch_generate_insights,
         run_retention_purge,
         run_migration_job,
+        refresh_user_profiles,
     ]
     cron_jobs = [
         cron(sync_component_sources, hour={0, 6, 12, 18}),  # Every 6 hours
@@ -61,6 +62,7 @@ class WorkerSettings:
             run_retention_purge, hour={1, 7, 13, 19}, minute={30}, timeout=3600, unique=True
         ),  # Every 6 hours (retention)
         cron(purge_migration_artifacts, hour={2, 8, 14, 20}, timeout=300, unique=True),  # Every 6 hours (artifacts)
+        cron(refresh_user_profiles, hour={3}, minute={15}, timeout=600, unique=True),  # Daily 3:15AM
     ]
     on_startup = startup
     on_shutdown = shutdown

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -333,6 +333,9 @@ def post(path: str, json_data: dict | None = None) -> dict:
     base, headers = _client()
     try:
         r = _request_with_retry("post", f"{base}{path}", headers, json=json_data)
+        # Some endpoints answer 204 No Content; decoding that as JSON raises.
+        if r.status_code == 204 or not r.content:
+            return {}
         return r.json()
     except httpx.HTTPStatusError as e:
         _handle_error(e, path)

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.render import console, output_json, relative_time, spinner, status_badge
+from observal_cli.render import console, esc, output_json, relative_time, spinner, status_badge
 
 insights_app = typer.Typer(help="Agent insight reports")
 
@@ -216,7 +216,9 @@ def _render_section(name: str, data: dict | str | None):
     if not data:
         return
     title = _SECTION_TITLES.get(name, name.replace("_", " ").title())
-    renderer = _RENDERERS.get(name)
+    # Every typed renderer indexes into a mapping. Older reports stored some
+    # sections as a plain string or list, which would crash on `.get`.
+    renderer = _RENDERERS.get(name) if isinstance(data, dict) else None
     if renderer:
         renderer(title, data)
     elif isinstance(data, str):
@@ -228,15 +230,15 @@ def _render_section(name: str, data: dict | str | None):
 def _render_at_a_glance(title: str, data: dict):
     health = data.get("health", "unknown")
     color = _HEALTH_COLORS.get(health, "white")
-    lines = [f"[bold]Health:[/bold] [{color}]{health}[/{color}]", ""]
+    lines = [f"[bold]Health:[/bold] [{color}]{esc(health)}[/{color}]", ""]
     if data.get("whats_working"):
-        lines += [f"[green]What's working:[/green] {data['whats_working']}", ""]
+        lines += [f"[green]What's working:[/green] {esc(data['whats_working'])}", ""]
     if data.get("whats_hindering"):
-        lines += [f"[yellow]What's hindering:[/yellow] {data['whats_hindering']}", ""]
+        lines += [f"[yellow]What's hindering:[/yellow] {esc(data['whats_hindering'])}", ""]
     if data.get("quick_win"):
-        lines += [f"[cyan]Quick win:[/cyan] {data['quick_win']}", ""]
+        lines += [f"[cyan]Quick win:[/cyan] {esc(data['quick_win'])}", ""]
     if data.get("ambitious_workflows"):
-        lines += [f"[magenta]Ambitious workflows:[/magenta] {data['ambitious_workflows']}"]
+        lines += [f"[magenta]Ambitious workflows:[/magenta] {esc(data['ambitious_workflows'])}"]
     console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="bright_blue", expand=False))
 
 
@@ -249,7 +251,7 @@ def _render_what_they_work_on(title: str, data: dict):
     table.add_column("Sessions", justify="right")
     table.add_column("Description")
     for a in areas:
-        table.add_row(a.get("name", ""), str(a.get("sessions", "")), a.get("description", ""))
+        table.add_row(esc(a.get("name", "")), esc(a.get("sessions", "")), esc(a.get("description", "")))
     console.print(table)
     rprint()
 
@@ -257,9 +259,9 @@ def _render_what_they_work_on(title: str, data: dict):
 def _render_interaction_style(title: str, data: dict):
     lines = []
     if data.get("narrative"):
-        lines.append(data["narrative"])
+        lines.append(esc(data["narrative"]))
     if data.get("key_pattern"):
-        lines += ["", f"[bold]Key pattern:[/bold] [italic]{data['key_pattern']}[/italic]"]
+        lines += ["", f"[bold]Key pattern:[/bold] [italic]{esc(data['key_pattern'])}[/italic]"]
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
 
@@ -267,14 +269,14 @@ def _render_interaction_style(title: str, data: dict):
 def _render_usage_patterns(title: str, data: dict):
     lines = []
     if data.get("narrative"):
-        lines.append(data["narrative"])
+        lines.append(esc(data["narrative"]))
     sp = data.get("session_profile", {})
     if sp:
         lines += [
             "",
-            f"  Avg duration: [bold]{sp.get('avg_duration_minutes', '?')}m[/bold]"
-            f"  Tool calls: [bold]{sp.get('avg_tool_calls', '?')}[/bold]"
-            f"  Prompts: [bold]{sp.get('avg_prompts', '?')}[/bold]",
+            f"  Avg duration: [bold]{esc(sp.get('avg_duration_minutes', '?'))}m[/bold]"
+            f"  Tool calls: [bold]{esc(sp.get('avg_tool_calls', '?'))}[/bold]"
+            f"  Prompts: [bold]{esc(sp.get('avg_prompts', '?'))}[/bold]",
         ]
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
@@ -287,7 +289,7 @@ def _render_usage_patterns(title: str, data: dict):
         for tool in tools[:10]:
             err = tool.get("error_rate", 0)
             err_style = "red" if err > 0.1 else "yellow" if err > 0.01 else "green"
-            t.add_row(tool.get("tool", ""), str(tool.get("calls", "")), f"[{err_style}]{err:.1%}[/{err_style}]")
+            t.add_row(esc(tool.get("tool", "")), esc(tool.get("calls", "")), f"[{err_style}]{err:.1%}[/{err_style}]")
         console.print(t)
         rprint()
 
@@ -295,9 +297,13 @@ def _render_usage_patterns(title: str, data: dict):
 def _render_what_works(title: str, data: dict):
     lines = []
     if data.get("intro"):
-        lines.append(data["intro"])
+        lines.append(esc(data["intro"]))
     for s in data.get("strengths", []):
-        lines += ["", f"  [green]●[/green] [bold]{s.get('title', '')}[/bold]", f"    {s.get('description', '')}"]
+        lines += [
+            "",
+            f"  [green]●[/green] [bold]{esc(s.get('title', ''))}[/bold]",
+            f"    {esc(s.get('description', ''))}",
+        ]
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="green", expand=False))
 
@@ -305,18 +311,18 @@ def _render_what_works(title: str, data: dict):
 def _render_friction(title: str, data: dict):
     lines = []
     if data.get("intro"):
-        lines.append(data["intro"])
+        lines.append(esc(data["intro"]))
     sev_colors = {"high": "red", "medium": "yellow", "low": "dim"}
     for cat in data.get("categories", []):
         sev = cat.get("severity", "medium")
         color = sev_colors.get(sev, "white")
-        lines += ["", f"  [{color}]■ {cat.get('title', '')}[/{color}] [{color}]({sev})[/{color}]"]
+        lines += ["", f"  [{color}]■ {esc(cat.get('title', ''))}[/{color}] [{color}]({esc(sev)})[/{color}]"]
         if cat.get("description"):
-            lines.append(f"    {cat['description']}")
+            lines.append(f"    {esc(cat['description'])}")
         for ex in cat.get("examples", []):
-            lines.append(f"    [dim]• {ex}[/dim]")
+            lines.append(f"    [dim]• {esc(ex)}[/dim]")
         if cat.get("impact"):
-            lines.append(f"    [dim]Impact: {cat['impact']}[/dim]")
+            lines.append(f"    [dim]Impact: {esc(cat['impact'])}[/dim]")
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="yellow", expand=False))
 
@@ -327,36 +333,36 @@ def _render_suggestions(title: str, data: dict):
     if configs:
         rprint(f"\n  [bold]{title} > Config Additions[/bold]")
         for c in configs:
-            rprint(f"    [cyan]→[/cyan] {c.get('addition', '')}")
-            rprint(f"      [dim]Why: {c.get('why', '')} | Where: {c.get('where', '')}[/dim]")
+            rprint(f"    [cyan]→[/cyan] {esc(c.get('addition', ''))}")
+            rprint(f"      [dim]Why: {esc(c.get('why', ''))} | Where: {esc(c.get('where', ''))}[/dim]")
 
     # Features to try
     features = data.get("features_to_try", [])
     if features:
         rprint(f"\n  [bold]{title} > Features to Try[/bold]")
         for f in features:
-            rprint(f"    [magenta]{f.get('feature', '')}:[/magenta] [bold]{f.get('name', '')}[/bold]")
-            rprint(f"      {f.get('one_liner', '')}")
+            rprint(f"    [magenta]{esc(f.get('feature', ''))}:[/magenta] [bold]{esc(f.get('name', ''))}[/bold]")
+            rprint(f"      {esc(f.get('one_liner', ''))}")
             if f.get("why_for_you"):
-                rprint(f"      [dim]{f['why_for_you']}[/dim]")
+                rprint(f"      [dim]{esc(f['why_for_you'])}[/dim]")
 
     # Usage patterns
     patterns = data.get("usage_patterns", [])
     if patterns:
         rprint(f"\n  [bold]{title} > Usage Patterns[/bold]")
         for p in patterns:
-            rprint(f"    [cyan]●[/cyan] [bold]{p.get('title', '')}[/bold]: {p.get('suggestion', '')}")
+            rprint(f"    [cyan]●[/cyan] [bold]{esc(p.get('title', ''))}[/bold]: {esc(p.get('suggestion', ''))}")
             if p.get("detail"):
-                rprint(f"      [dim]{p['detail']}[/dim]")
+                rprint(f"      [dim]{esc(p['detail'])}[/dim]")
             if p.get("copyable_prompt"):
-                rprint(f"      [green]Try:[/green] {p['copyable_prompt']}")
+                rprint(f"      [green]Try:[/green] {esc(p['copyable_prompt'])}")
     rprint()
 
 
 def _render_cost(title: str, data: dict):
     lines = []
     if data.get("summary"):
-        lines.append(data["summary"])
+        lines.append(esc(data["summary"]))
     m = data.get("metrics", {})
     if m:
         parts = []
@@ -370,11 +376,11 @@ def _render_cost(title: str, data: dict):
             lines += ["", "  " + "  │  ".join(parts)]
     opps = data.get("opportunities", [])
     for o in opps:
-        lines += ["", f"  [yellow]●[/yellow] [bold]{o.get('title', '')}[/bold]"]
+        lines += ["", f"  [yellow]●[/yellow] [bold]{esc(o.get('title', ''))}[/bold]"]
         if o.get("description"):
-            lines.append(f"    {o['description']}")
+            lines.append(f"    {esc(o['description'])}")
         if o.get("estimated_savings"):
-            lines.append(f"    [green]Savings: {o['estimated_savings']}[/green]")
+            lines.append(f"    [green]Savings: {esc(o['estimated_savings'])}[/green]")
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
 
@@ -385,17 +391,17 @@ def _render_regression(title: str, data: dict):
         return
     lines = []
     if data.get("summary"):
-        lines.append(data["summary"])
+        lines.append(esc(data["summary"]))
     for c in data.get("changes", []):
         direction = c.get("direction", "stable")
         icon = {"improved": "[green]↑[/green]", "degraded": "[red]↓[/red]", "stable": "[dim]→[/dim]"}.get(
             direction, "→"
         )
         sig = c.get("significance", "")
-        sig_dim = f" [dim]({sig})[/dim]" if sig else ""
+        sig_dim = f" [dim]({esc(sig)})[/dim]" if sig else ""
         lines.append(
-            f"  {icon} [bold]{c.get('metric', '')}[/bold]: "
-            f"{c.get('previous_value', '?')} → {c.get('current_value', '?')}{sig_dim}"
+            f"  {icon} [bold]{esc(c.get('metric', ''))}[/bold]: "
+            f"{esc(c.get('previous_value', '?'))} → {esc(c.get('current_value', '?'))}{sig_dim}"
         )
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
@@ -404,13 +410,13 @@ def _render_regression(title: str, data: dict):
 def _render_horizon(title: str, data: dict):
     lines = []
     if data.get("intro"):
-        lines.append(data["intro"])
+        lines.append(esc(data["intro"]))
     for o in data.get("opportunities", []):
-        lines += ["", f"  [magenta]●[/magenta] [bold]{o.get('title', '')}[/bold]"]
+        lines += ["", f"  [magenta]●[/magenta] [bold]{esc(o.get('title', ''))}[/bold]"]
         if o.get("whats_possible"):
-            lines.append(f"    {o['whats_possible']}")
+            lines.append(f"    {esc(o['whats_possible'])}")
         if o.get("how_to_try"):
-            lines.append(f"    [cyan]Try:[/cyan] {o['how_to_try']}")
+            lines.append(f"    [cyan]Try:[/cyan] {esc(o['how_to_try'])}")
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="magenta", expand=False))
 
@@ -418,18 +424,18 @@ def _render_horizon(title: str, data: dict):
 def _render_version_comparison(title: str, data: dict):
     lines = []
     if data.get("summary"):
-        lines.append(data["summary"])
+        lines.append(esc(data["summary"]))
     if data.get("confidence"):
-        lines.append(f"[dim]Confidence: {data['confidence']}[/dim]")
+        lines.append(f"[dim]Confidence: {esc(data['confidence'])}[/dim]")
     for change in data.get("changes", [])[:6]:
         lines.append(
-            f"\n[bold]{change.get('metric', '')}[/bold]: {change.get('direction', '')} "
-            f"({change.get('prior_value', '?')} → {change.get('current_value', '?')})"
+            f"\n[bold]{esc(change.get('metric', ''))}[/bold]: {esc(change.get('direction', ''))} "
+            f"({esc(change.get('prior_value', '?'))} → {esc(change.get('current_value', '?'))})"
         )
         if change.get("attribution"):
-            lines.append(f"[dim]Attribution: {change['attribution']}[/dim]")
+            lines.append(f"[dim]Attribution: {esc(change['attribution'])}[/dim]")
         if change.get("evidence"):
-            lines.append(f"[dim]{change['evidence']}[/dim]")
+            lines.append(f"[dim]{esc(change['evidence'])}[/dim]")
     if lines:
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="blue", expand=False))
 
@@ -438,9 +444,9 @@ def _render_fun_ending(title: str, data: dict):
     headline = data.get("headline", "")
     detail = data.get("detail", "")
     if headline:
-        content = f"[italic]{headline}[/italic]"
+        content = f"[italic]{esc(headline)}[/italic]"
         if detail:
-            content += f"\n[dim]{detail}[/dim]"
+            content += f"\n[dim]{esc(detail)}[/dim]"
         console.print(Panel(content, title=f"[bold]{title}[/bold]", border_style="bright_yellow", expand=False))
 
 

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -15,6 +15,25 @@ from observal_cli.render import console, esc, output_json, relative_time, spinne
 
 insights_app = typer.Typer(help="Agent insight reports")
 
+_registry_name_cache: str | None = None
+
+
+def _registry_name() -> str:
+    """White-label name for this registry, for user-facing copy.
+
+    Best effort and cached per process: a cosmetic label must never be the
+    reason a report fails to render, so any error falls back to a neutral
+    phrase rather than hardcoding "Observal" over someone's branding.
+    """
+    global _registry_name_cache
+    if _registry_name_cache is None:
+        try:
+            data = client.get("/api/v1/config/public")
+            _registry_name_cache = str(data.get("branding_app_name") or "").strip() or "Observal"
+        except Exception:
+            _registry_name_cache = "your registry"
+    return _registry_name_cache
+
 
 def _resolve_agent_id(agent_id: str) -> str:
     """Resolve an agent UUID, name, or alias to the canonical UUID."""
@@ -144,12 +163,17 @@ def insights_show(
         return
 
     narrative = data.get("narrative") or {}
+    registry_match = narrative.get("registry_match")
+    if not isinstance(registry_match, dict):
+        registry_match = None
     if section:
         if section not in narrative:
             rprint(f"[red]Section '{section}' not found.[/red]")
             rprint(f"[dim]Available: {', '.join(narrative.keys())}[/dim]")
             raise typer.Exit(1)
         _render_section(section, narrative[section])
+        if section == "suggestions":
+            _render_registry_match_note(registry_match)
         return
 
     # Header
@@ -184,10 +208,16 @@ def insights_show(
         "on_the_horizon",
         "fun_ending",
     ]
+    note_rendered = False
     for key in order:
         section_data = narrative.get(key)
         if section_data:
             _render_section(key, section_data)
+            if key == "suggestions":
+                _render_registry_match_note(registry_match)
+                note_rendered = True
+    if not note_rendered:
+        _render_registry_match_note(registry_match)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -327,6 +357,75 @@ def _render_friction(title: str, data: dict):
         console.print(Panel("\n".join(lines), title=f"[bold]{title}[/bold]", border_style="yellow", expand=False))
 
 
+def _reuse_ref(feature: object) -> dict | None:
+    """The validated registry reference on a suggestion, if it has one.
+
+    The server strips this field from any suggestion whose component could
+    not be resolved, so its presence is the signal that the component is
+    genuinely in the registry and safe to point the user at.
+    """
+    if not isinstance(feature, dict):
+        return None
+    ref = feature.get("component_ref")
+    return ref if isinstance(ref, dict) else None
+
+
+def _render_reuse_feature(feature: dict, ref: dict):
+    """A suggestion to reuse something the registry already has.
+
+    Given prominence over "build this" suggestions, because installing an
+    approved component is cheaper and safer than writing a new one.
+    """
+    component_type = str(ref.get("type") or "skill")
+    name = ref.get("qualified_name") or ref.get("name", "")
+    version = ref.get("latest_version") or ""
+    version_suffix = f" [dim]v{esc(version)}[/dim]" if version else ""
+
+    rprint(f"    [green]✔ ALREADY IN {esc(_registry_name().upper())}[/green]  [dim]({esc(component_type)})[/dim]")
+    rprint(f"      [bold]{esc(name)}[/bold]{version_suffix}")
+    if feature.get("one_liner"):
+        rprint(f"      {esc(feature['one_liner'])}")
+    if feature.get("match_reason"):
+        rprint(f"      [dim]Why this fits: {esc(feature['match_reason'])}[/dim]")
+    elif feature.get("why_for_you"):
+        rprint(f"      [dim]{esc(feature['why_for_you'])}[/dim]")
+    rprint(f"      [cyan]observal registry {esc(component_type)} show {esc(name)} --output json[/cyan]")
+    rprint(f"      [dim]Attach to an agent: observal agent add {esc(component_type)} {esc(ref.get('id', ''))}[/dim]")
+
+
+def _render_registry_match_note(summary: dict | None):
+    """Say why a report suggested nothing to reuse.
+
+    An empty reuse list is ambiguous on its own: "we searched and nothing
+    fit" and "there was nothing to search" look identical but mean opposite
+    things to someone judging whether the feature works. Reports generated
+    before this existed carry no summary, and stay silent.
+    """
+    if not isinstance(summary, dict) or (summary.get("reused") or 0) > 0:
+        return
+
+    offered = summary.get("offered") or 0
+    if summary.get("enabled") is False:
+        message = "Reuse suggestions are turned off, so this report only proposes new components."
+    elif summary.get("registry_has_components") is False:
+        message = (
+            f"No components have been published to {_registry_name()} yet, so there was nothing to "
+            "reuse. Publish skills, hooks or prompts and future reports will point at them."
+        )
+    elif offered == 0:
+        message = (
+            f"Nothing in {_registry_name()} looked close enough to this agent's work to recommend. "
+            "More sessions give the match more to go on."
+        )
+    else:
+        message = (
+            f"Checked {offered} component{'' if offered == 1 else 's'} already in {_registry_name()}; "
+            "none fit this agent's problems closely enough to recommend."
+        )
+    rprint(f"  [dim]ⓘ {esc(message)}[/dim]")
+    rprint()
+
+
 def _render_suggestions(title: str, data: dict):
     # Config additions
     configs = data.get("config_additions", [])
@@ -337,11 +436,18 @@ def _render_suggestions(title: str, data: dict):
             rprint(f"      [dim]Why: {esc(c.get('why', ''))} | Where: {esc(c.get('where', ''))}[/dim]")
 
     # Features to try
-    features = data.get("features_to_try", [])
+    features = [f for f in data.get("features_to_try", []) or [] if isinstance(f, dict)]
     if features:
         rprint(f"\n  [bold]{title} > Features to Try[/bold]")
-        for f in features:
-            rprint(f"    [magenta]{esc(f.get('feature', ''))}:[/magenta] [bold]{esc(f.get('name', ''))}[/bold]")
+        # Reuse suggestions lead: "you already own this" is a better answer
+        # than "go build this", so it should be the first thing read.
+        for f in sorted(features, key=lambda item: not _reuse_ref(item)):
+            ref = _reuse_ref(f)
+            if ref:
+                _render_reuse_feature(f, ref)
+                continue
+            label = f.get("feature", "")
+            rprint(f"    [magenta]{esc(label)}:[/magenta] [bold]{esc(f.get('name', ''))}[/bold]")
             rprint(f"      {esc(f.get('one_liner', ''))}")
             if f.get("why_for_you"):
                 rprint(f"      [dim]{esc(f['why_for_you'])}[/dim]")

--- a/observal_cli/cmd_recommend.py
+++ b/observal_cli/cmd_recommend.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""observal registry recommend: components picked for the signed-in user.
+
+Recommendations are derived from the user's own session history, so this
+command is deliberately self-only — there is no flag to read someone else's
+profile, matching the server, which exposes no such route either.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich import print as rprint
+from rich.table import Table
+
+from observal_cli import client
+from observal_cli.render import console, esc, output_json, spinner
+
+recommend_app = typer.Typer(
+    name="recommend",
+    help="Components recommended for you, based on your own sessions",
+    no_args_is_help=False,
+    invoke_without_command=True,
+)
+
+# Singular is what the API accepts; the plural forms are what registry
+# commands and URLs use, so both are taken here to avoid a pointless error.
+_TYPES = {
+    "mcp": "mcps",
+    "skill": "skills",
+    "hook": "hooks",
+    "prompt": "prompts",
+    "sandbox": "sandboxes",
+}
+_TYPE_ALIASES = {**{t: t for t in _TYPES}, **{plural: t for t, plural in _TYPES.items()}}
+
+_VALID_ACTIONS = ("dismissed", "not_relevant", "installed")
+
+
+def _normalize_type(raw: str) -> str:
+    normalized = _TYPE_ALIASES.get(raw.strip().lower())
+    if normalized is None:
+        rprint(f"[red]Unknown component type '{raw}'.[/red]")
+        rprint(f"[dim]Choose one of: {', '.join(sorted(_TYPES))}[/dim]")
+        raise typer.Exit(1)
+    return normalized
+
+
+def _emit(limit: int, type_: str | None, refresh: bool, output: str) -> None:
+    params: dict[str, object] = {"limit": limit}
+    if type_:
+        params["type"] = _normalize_type(type_)
+    if refresh:
+        params["refresh"] = True
+
+    with spinner("Fetching recommendations..."):
+        data = client.get("/api/v1/recommendations/me", params=params)
+
+    if output == "json":
+        output_json(data)
+        return
+
+    items = data.get("items") or []
+    personalized = bool(data.get("personalized"))
+    sessions = data.get("profile_sessions") or 0
+    topics = [t for t in (data.get("topics") or []) if t]
+
+    if not items:
+        # Silence here would be indistinguishable from a broken feature, so
+        # say what the empty result actually means.
+        rprint("[dim]Nothing to recommend right now.[/dim]")
+        rprint(
+            "[dim]Either the registry has no components visible to you, or you have already "
+            "installed or dismissed them all.[/dim]"
+        )
+        return
+
+    if personalized:
+        heading = "Recommended for you"
+        plural = "" if sessions == 1 else "s"
+        subtitle = f"Based on {sessions} session{plural}"
+        if topics:
+            subtitle += f" — mostly {', '.join(topics[:3])}"
+    else:
+        # Never imply personalisation that did not happen.
+        heading = "Popular in your registry"
+        subtitle = "No session history yet, so these are simply the most-used components"
+
+    table = Table(title=f"{heading} ({len(items)})", show_lines=False, padding=(0, 1))
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Type")
+    table.add_column("Component", style="bold", overflow="fold")
+    table.add_column("Version")
+    table.add_column("Installs", justify="right")
+    table.add_column("Why")
+    # Descriptions and reasons are free text; Rich would read a stray "[...]"
+    # in them as a style tag and either swallow it or raise MarkupError.
+    for i, item in enumerate(items, 1):
+        table.add_row(
+            str(i),
+            esc(item.get("type", "")),
+            esc(item.get("qualified_name") or item.get("name", "")),
+            esc(item.get("latest_version") or "-"),
+            esc(item.get("download_count", 0)),
+            esc(item.get("reason", "")),
+        )
+    console.print(table)
+    rprint(f"[dim]{esc(subtitle)}.[/dim]")
+    rprint()
+
+    first = items[0]
+    first_type = esc(first.get("type", "skill"))
+    first_name = esc(first.get("qualified_name") or first.get("name", ""))
+    rprint(f"[dim]Inspect: [cyan]observal registry {first_type} show {first_name} --output json[/cyan][/dim]")
+    rprint(f"[dim]Hide one: [cyan]observal registry recommend dismiss {first_type} {first_name}[/cyan][/dim]")
+
+
+@recommend_app.callback(invoke_without_command=True)
+def recommend(
+    ctx: typer.Context,
+    limit: int = typer.Option(8, "--limit", "-n", min=1, max=24, help="How many to return"),
+    type_: str | None = typer.Option(None, "--type", "-t", help="Restrict to one component type"),
+    refresh: bool = typer.Option(False, "--refresh", help="Recompute your profile instead of using the cache"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+):
+    """Show components recommended for you.
+
+    Examples:
+
+        observal registry recommend
+
+        observal registry recommend --limit 12 --type mcp
+
+        observal registry recommend --refresh --output json
+    """
+    if ctx.invoked_subcommand is None:
+        _emit(limit, type_, refresh, output)
+
+
+@recommend_app.command(name="list")
+def recommend_list(
+    limit: int = typer.Option(8, "--limit", "-n", min=1, max=24, help="How many to return"),
+    type_: str | None = typer.Option(None, "--type", "-t", help="Restrict to one component type"),
+    refresh: bool = typer.Option(False, "--refresh", help="Recompute your profile instead of using the cache"),
+    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+):
+    """Show components recommended for you.
+
+    Examples:
+
+        observal registry recommend list --output json
+    """
+    _emit(limit, type_, refresh, output)
+
+
+@recommend_app.command(name="dismiss")
+def recommend_dismiss(
+    component_type: str = typer.Argument(..., help="Component type: mcp, skill, hook, prompt, sandbox"),
+    reference: str = typer.Argument(..., help="Component ID, namespace/slug, or @alias"),
+    action: str = typer.Option(
+        "dismissed",
+        "--action",
+        "-a",
+        help=f"Feedback to record: {', '.join(_VALID_ACTIONS)}",
+    ),
+):
+    """Stop recommending a component to you.
+
+    Examples:
+
+        observal registry recommend dismiss skill super/terraform-plan-review
+
+        observal registry recommend dismiss mcp 0f2b... --action installed
+    """
+    normalized = _normalize_type(component_type)
+    if action not in _VALID_ACTIONS:
+        rprint(f"[red]Unknown action '{action}'.[/red]")
+        rprint(f"[dim]Choose one of: {', '.join(_VALID_ACTIONS)}[/dim]")
+        raise typer.Exit(1)
+
+    with spinner("Recording feedback..."):
+        component_id = client.resolve_registry_reference(_TYPES[normalized], reference)
+        client.post(
+            "/api/v1/recommendations/feedback",
+            {"component_type": normalized, "component_id": component_id, "action": action},
+        )
+
+    if action == "installed":
+        rprint(f"[green]✓ Marked {normalized} {esc(reference)} as installed.[/green]")
+    else:
+        rprint(f"[green]✓ {normalized} {esc(reference)} will no longer be recommended to you.[/green]")

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -163,6 +163,7 @@ from observal_cli.cmd_ops import (
 from observal_cli.cmd_outdated import register_outdated
 from observal_cli.cmd_prompt import prompt_app
 from observal_cli.cmd_pull import register_pull
+from observal_cli.cmd_recommend import recommend_app
 from observal_cli.cmd_sandbox import sandbox_app
 from observal_cli.cmd_scan import register_scan
 from observal_cli.cmd_skill import skill_app
@@ -188,6 +189,7 @@ registry_app.add_typer(prompt_app, name="prompt")
 registry_app.add_typer(sandbox_app, name="sandbox")
 registry_app.add_typer(models_app, name="models")
 registry_app.add_typer(version_app, name="version")
+registry_app.add_typer(recommend_app, name="recommend")
 
 # ── Co-authors and ownership sub-commands ─────────────────
 mcp_app.add_typer(make_co_authors_typer("mcps"), name="co-authors")

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -13,10 +13,23 @@ from typing import Any
 
 from rich import print as rprint
 from rich.console import Console
+from rich.markup import escape as markup_escape
 from rich.panel import Panel
 from rich.table import Table  # noqa: TC002 - used at runtime
 
 console = Console()
+
+
+def esc(value: Any) -> str:
+    """Render untrusted text as literal characters, not Rich markup.
+
+    Anything the server or an LLM produced can contain square brackets —
+    ``array[0]``, ``[/tmp]``, ``[bold]``. Rich reads those as style tags:
+    a stray closing tag raises ``MarkupError`` and kills the command, and a
+    valid-looking one silently swallows the text. Escape before interpolating.
+    """
+    return markup_escape("" if value is None else str(value))
+
 
 # ── Status badges ────────────────────────────────────────
 

--- a/observal_cli/skills/observal-ops/SKILL.md
+++ b/observal_cli/skills/observal-ops/SKILL.md
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 name: observal-ops
 command: observal
-description: View traces, spans, metrics, feedback, telemetry health, and agent insight reports. Use when the user wants to see traces, check metrics, view top items, submit ratings, diagnose telemetry, or discuss how an agent is doing.
-version: 2.1.0
+description: View traces, spans, metrics, feedback, telemetry health, and agent insight reports, including suggestions that reuse components already in the registry. Use when the user wants to see traces, check metrics, view top items, submit ratings, diagnose telemetry, or discuss how an agent is doing.
+version: 2.2.0
 owner: observal
 ---
 
@@ -118,6 +118,63 @@ observal ops insights show AGENT_NAME latest --output json
 ```
 
 Answer like an analyst: cite the report period, session count, strengths, friction, cost, version notes, and two or three concrete next actions. If data is thin, say so.
+
+### Reuse suggestions: components the registry already has
+
+A suggestion under `suggestions.features_to_try` may point at a component that already exists in
+this registry instead of proposing a new one. Those entries carry a `component_ref`:
+
+```json
+{
+  "action_type": "reuse_existing_component",
+  "feature": "Skill",
+  "match_reason": "Sessions repeatedly hand-review terraform plans",
+  "component_ref": {
+    "type": "skill",
+    "id": "0f2b...",
+    "qualified_name": "super/terraform-plan-review",
+    "latest_version": "1.0.0"
+  }
+}
+```
+
+**`component_ref` is the only trustworthy registry reference in a report.** The server validates
+it against the registry and strips it from anything it cannot resolve, so:
+
+- **Lead with these.** "You already have this" beats "go build this". Report reuse suggestions
+  before create-new ones, whatever order the JSON happens to be in.
+- Use `component_ref.qualified_name` and `latest_version` verbatim. Never reconstruct a name or
+  version from prose elsewhere in the report.
+- If `component_ref` is absent or null, it is **not** a registry component. Do not tell the user
+  to install it, and do not go looking for a matching name in the registry to fill the gap.
+- Never treat `existing_component_id` as valid on its own — a suggestion whose reference failed
+  validation keeps its text but has its ids nulled.
+
+To act on one:
+
+```bash
+observal registry skill show NAMESPACE/SLUG --output json
+observal agent add skill COMPONENT_UUID
+```
+
+`observal agent add` writes to a local `observal-agent.yaml`, so it only applies when the user is
+authoring that agent locally. Otherwise use the harness install command from `observal-registry`.
+
+### When a report suggests nothing to reuse
+
+A completed report carries `narrative.registry_match`, which says whether reuse was even possible:
+
+| Field | Meaning |
+|-------|---------|
+| `enabled` | `false` = an operator turned reuse suggestions off |
+| `offered` | How many existing components were considered |
+| `reused` | How many suggestions ended up pointing at one |
+| `registry_has_components` | `false` = nothing published yet. `null` = not checked |
+
+Use it to answer "why didn't it recommend anything?" precisely: `offered > 0, reused: 0` means the
+match ran and nothing fit — a real answer, not a failure. `registry_has_components: false` means
+there was nothing to match against. A report generated before this feature has no `registry_match`
+key at all; say the report predates it rather than guessing.
 
 ---
 

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -19,7 +19,6 @@ owner: observal
 5. **`--from-file` does NOT exist on `mcp submit`**: that flag is on `mcp edit`.
 
 ---
-
 ## Procedure: Browse Registry
 
 Use natural-language keywords with `--search`; do not require exact whole-query matches.
@@ -49,7 +48,6 @@ After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--intera
 **Skill task types:** `code-review`, `code-generation`, `testing`, `documentation`, `debugging`, `refactoring`, `deployment`, `security-audit`, `performance`, `general`
 
 ---
-
 ## Procedure: Recommend Components For This User
 
 Use when the user asks what to install, what is worth trying, or what they are missing. Ranked against the signed-in user's own sessions, so check here before browsing — it beats guessing keywords for `list --search`. `--refresh` recomputes the profile instead of using the 24h cache: slower, so only when recent work changed and results look stale.
@@ -78,7 +76,6 @@ observal registry recommend dismiss hook NAMESPACE/SLUG --action installed
 Dismissals are per-user and permanent until overwritten, so confirm before dismissing. A work profile is visible only to its owner: no flag or server route exposes another user's recommendations, so if asked, say it is unavailable rather than improvising a workaround.
 
 ---
-
 ## Procedure: Submit Component
 
 ### MCP
@@ -150,7 +147,6 @@ observal registry sandbox submit --from-file sandbox.json
 All types support `--example` to print ready-to-edit example payloads, `--draft` to save without review, and `--submit NAME` to submit an existing draft.
 
 ---
-
 ## Procedure: Install Component
 
 ```bash

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 name: observal-registry
 command: observal
-description: Submit, browse, install, edit, archive, restore, transfer, and version MCPs, skills, hooks, prompts, and sandboxes in the Observal registry. Use when the user wants to submit a component, install one, edit a draft, publish a new version, or browse the component library.
-version: 2.0.0
+description: Submit, browse, install, edit, archive, restore, transfer, and version MCPs, skills, hooks, prompts, and sandboxes in the Observal registry, and get components recommended for the current user. Use when the user wants to submit a component, install one, edit a draft, publish a new version, browse the component library, or asks what they should install or are missing.
+version: 2.1.0
 owner: observal
 ---
 
@@ -47,6 +47,35 @@ After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--intera
 **MCP categories:** `browser-automation`, `cloud-platforms`, `code-execution`, `communication`, `databases`, `developer-tools`, `devops`, `file-systems`, `finance`, `knowledge-memory`, `monitoring`, `multimedia`, `productivity`, `search`, `security`, `version-control`, `ai-ml`, `data-analytics`, `general`
 
 **Skill task types:** `code-review`, `code-generation`, `testing`, `documentation`, `debugging`, `refactoring`, `deployment`, `security-audit`, `performance`, `general`
+
+---
+
+## Procedure: Recommend Components For This User
+
+Use when the user asks what to install, what is worth trying, or what they are missing. Ranked against the signed-in user's own sessions, so check here before browsing — it beats guessing keywords for `list --search`. `--refresh` recomputes the profile instead of using the 24h cache: slower, so only when recent work changed and results look stale.
+
+```bash
+observal registry recommend --output json
+observal registry recommend --limit 12 --type mcp --refresh --output json
+```
+
+| Field | Meaning |
+|-------|---------|
+| `personalized` | `true` = ranked against this user's sessions. `false` = popularity only |
+| `profile_sessions` | How many sessions the profile was built from |
+| `topics` | Dominant work areas detected (e.g. `databases`, `frontend`) |
+| `items[].reason` | Why this was picked. Quote it; do not invent a better reason |
+| `items[].matched_on` | The user's own terms that matched |
+
+**What you may claim:** `personalized: false` → say plainly there is no session history yet and these are simply the most-used components; never present them as tailored. `items: []` → say either nothing in the registry is visible to them or they already installed or dismissed it all; this is not an error, so do not report it as one. `profile_sessions` under ~5 → give the answer, and say the profile is thin.
+
+```bash
+observal registry recommend dismiss skill NAMESPACE/SLUG
+observal registry recommend dismiss mcp NAMESPACE/SLUG --action not_relevant
+observal registry recommend dismiss hook NAMESPACE/SLUG --action installed
+```
+
+Dismissals are per-user and permanent until overwritten, so confirm before dismissing. A work profile is visible only to its owner: no flag or server route exposes another user's recommendations, so if asked, say it is unavailable rather than improvising a workaround.
 
 ---
 

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -26,7 +26,6 @@ owner: observal
 11. **Never invent `OTEL_*` or `CLAUDE_CODE_ENABLE_TELEMETRY` environment variables.** Telemetry flows through session push hooks and reconciliation only.
 
 ---
-
 ## Procedure: Natural-Language Registry Search
 
 For requests like "find me an agent for incident resolution" or "what skill helps design good frontends", extract the useful keywords and search JSON first.
@@ -79,7 +78,6 @@ observal scan --harness kiro
 `scan` verifies MCPs, skills, hooks, and agents. Prompts/sandboxes are injected into rules/MCP config; use the pull output/lockfile for membership.
 
 ---
-
 ## Procedure: Outdated
 
 Check for newer versions of installed agents and components.
@@ -92,7 +90,6 @@ observal outdated --harness claude-code --output json
 Reads `~/.observal/lockfile.json` and compares each pinned version against the registry's latest. Reports a table of outdated items with current vs latest version.
 
 ---
-
 ## Procedure: Scan harnesses
 
 Read-only inventory of installed components across all detected harnesses. **Never modifies any file.**
@@ -106,7 +103,6 @@ observal scan --harness claude-code
 Reports: detected harnesses, MCP servers, skills, hooks, agents, and unregistered components.
 
 ---
-
 ## Procedure: Doctor
 
 Diagnose only. Does not fix anything.

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -5,7 +5,7 @@
 name: observal
 command: observal
 description: "Core Observal CLI operations: pull agents into your harness, scan installed components, diagnose and patch harness configs, authenticate, manage CLI settings, and discuss agent insights. Use when the user wants to install an agent, check setup, login, configure the CLI, or ask how an agent is doing."
-version: 2.3.0
+version: 2.4.0
 owner: observal
 ---
 
@@ -221,6 +221,8 @@ observal ops insights generate AGENT_NAME --version 1.2.0 --compare 1.1.0 --peri
 ```
 
 Keep the answer grounded in the JSON. Say when the report is missing a section or has low session count.
+
+**Reuse suggestions come first.** A `suggestions.features_to_try` entry carrying a `component_ref` object already exists in this registry — the server validated it and strips the field from anything it could not resolve. Report those ahead of create-new suggestions, quoting `component_ref.qualified_name` and `latest_version` verbatim. No `component_ref` means it is not a registry component: never tell the user to install it. When nothing is reused, `narrative.registry_match` says why; see `observal-ops` for its fields.
 
 ---
 

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 name: observal
 command: observal
-description: "Core Observal CLI operations: pull agents into your harness, scan installed components, diagnose and patch harness configs, authenticate, manage CLI settings, and discuss agent insights. Use when the user wants to install an agent, check setup, login, configure the CLI, or ask how an agent is doing."
-version: 2.4.0
+description: "Core Observal CLI operations: pull agents into your harness, scan installed components, diagnose and patch harness configs, authenticate, manage CLI settings, get components recommended for you, and discuss agent insights. Use when the user wants to install an agent, check setup, login, configure the CLI, ask what they should install, or ask how an agent is doing."
+version: 2.5.0
 owner: observal
 ---
 
@@ -39,6 +39,8 @@ observal registry mcp list --search 'github docker' --output json
 ```
 
 Summarize the top matches by `qualified_name`, description, and why they fit. If no results, retry with fewer keywords.
+
+For open-ended asks instead ("what am I missing", "what should I install"), do not guess keywords — ask what fits this user's own sessions with `observal registry recommend --output json`. Check `personalized` first: `false` means no session history yet, so these are merely the most-used components; say so rather than implying they were chosen for the user. Fields and dismissals are in the `observal-registry` skill.
 
 ## Procedure: Pull Agent
 

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -158,6 +158,9 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry prompt submit`: Submit a new prompt template for review.
   - `observal registry prompt transfer-owner`: Transfer ownership to another username.
   - `observal registry prompt unarchive`: Restore an archived component.
+- `observal registry recommend`: Components recommended for you, based on your own sessions
+  - `observal registry recommend dismiss`: Stop recommending a component to you.
+  - `observal registry recommend list`: Show components recommended for you.
 - `observal registry sandbox`: Sandbox registry commands
   - `observal registry sandbox co-authors`: Manage co-authors for sandboxes
     - `observal registry sandbox co-authors add`: Add a co-author.

--- a/scripts/seed_insight_report.py
+++ b/scripts/seed_insight_report.py
@@ -16,6 +16,66 @@ import sys
 sys.path.insert(0, "/app")
 
 
+async def _find_reusable_skill(db):
+    """Return (id, qualified_name, version) for an approved skill, if any."""
+    from sqlalchemy import select as _select
+
+    from models.mcp import ListingStatus
+    from models.skill import SkillListing, SkillVersion
+
+    row = (
+        await db.execute(
+            _select(SkillListing, SkillVersion)
+            .join(SkillVersion, SkillListing.latest_version_id == SkillVersion.id)
+            .where(SkillVersion.status == ListingStatus.approved)
+            .limit(1)
+        )
+    ).first()
+    if not row:
+        return None
+    listing, version = row
+    return {
+        "type": "skill",
+        "id": str(listing.id),
+        "name": listing.name,
+        "qualified_name": f"{listing.namespace}/{listing.slug}",
+        "latest_version": version.version,
+    }
+
+
+def _features_to_try(reuse_component):
+    """Suggestions covering both the reuse path and the create-new path."""
+    features = []
+    if reuse_component:
+        features.append(
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "name": reuse_component["name"],
+                "existing_component_id": reuse_component["id"],
+                "component_ref": reuse_component,
+                "match_reason": "You repeat this workflow by hand in 6 sessions; this skill already does it.",
+                "one_liner": f"Reuse {reuse_component['name']} instead of building it again",
+                "why_for_you": "It is already approved in your registry and matches what you keep doing manually.",
+                "confidence": "high",
+                "risk": "low",
+            }
+        )
+    features.append(
+        {
+            "action_type": "create_new_hook",
+            "feature": "Lifecycle hook",
+            "name": "pre-commit-gate",
+            "one_liner": "Pre-commit validation gate",
+            "why_for_you": "Catches forgotten test runs before they reach CI",
+            "example": "# Hook: before git commit\npytest --tb=short -q\nruff check .",
+            "confidence": "medium",
+            "risk": "low",
+        }
+    )
+    return features
+
+
 async def main():
     from datetime import UTC, datetime, timedelta
 
@@ -29,6 +89,10 @@ async def main():
         # Find any approved agent
         result = await db.execute(select(Agent).where(Agent.status == "approved").limit(1))
         agent = result.scalar_one_or_none()
+
+        # Pick a real approved skill so the reuse-suggestion path can be
+        # exercised end to end without an LLM call.
+        reuse_component = await _find_reusable_skill(db)
 
         if not agent:
             print("ERROR: No approved agent found. Create one first:")
@@ -194,20 +258,7 @@ async def main():
                             "where": "system_prompt",
                         },
                     ],
-                    "features_to_try": [
-                        {
-                            "feature": "Custom skill",
-                            "one_liner": "PR review workflow that checks tests, lint, and security",
-                            "why_for_you": "You do PR reviews in 40% of sessions",
-                            "example": "---\nname: pr-review\ndescription: Review PR for correctness, tests, and security\ntrigger: /review\n---\n\n1. Read the git diff\n2. Check all modified files have tests\n3. Run ruff check on changed Python files\n4. Look for security issues (SQL injection, path traversal)\n5. Summarize findings with severity ratings",
-                        },
-                        {
-                            "feature": "Lifecycle hook",
-                            "one_liner": "Pre-commit validation gate",
-                            "why_for_you": "Catches forgotten test runs before they reach CI",
-                            "example": "# Hook: before git commit\npytest --tb=short -q\nruff check .",
-                        },
-                    ],
+                    "features_to_try": _features_to_try(reuse_component),
                     "usage_patterns": [
                         {
                             "title": "Structured debugging",
@@ -260,7 +311,14 @@ async def main():
         print(f"  Agent: {agent.name} ({agent.id})")
         print("  Status: completed")
         print("  Sessions: 12")
-        print("  Suggestions: 4 config_additions, 2 features_to_try, 2 usage_patterns")
+        feature_count = len(_features_to_try(reuse_component))
+        print(f"  Suggestions: 4 config_additions, {feature_count} features_to_try, 2 usage_patterns")
+        if reuse_component:
+            print(
+                f"  Reuse suggestion points at {reuse_component['qualified_name']} v{reuse_component['latest_version']}"
+            )
+        else:
+            print("  No approved skill found, so no reuse suggestion was seeded")
         print(f"\n  → Go to: http://localhost:3000/insights/{report.id}")
         print("  → Click 'Apply Suggestions' to test self-learn!")
 

--- a/tests/test_cmd_insights_markup_safety.py
+++ b/tests/test_cmd_insights_markup_safety.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Insight text must never be parsed as Rich markup.
+
+Report narratives are written by an LLM and routinely contain square
+brackets — file paths like ``[/tmp]``, indexes like ``array[0]``, literal
+markup examples. Rich reads those as style tags: an unmatched closing tag
+raises ``MarkupError`` and kills ``observal ops insights show`` outright,
+while a well-formed one silently deletes the text. Both are wrong.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from observal_cli.cmd_insights import insights_app
+
+runner = CliRunner()
+
+AGENT_ID = "c6185803-8c32-4c39-b347-78f8281e306e"
+REPORT_ID = "be5aa083-d84a-49e7-8a35-b37b3e687780"
+
+# "[/tmp]" crashes Rich outright; "[bold]" is swallowed silently.
+HOSTILE = "Clean up [/tmp] and index array[0] with [bold] markers"
+
+
+@pytest.fixture(autouse=True)
+def _wide_terminal(monkeypatch):
+    monkeypatch.setenv("COLUMNS", "300")
+
+
+def _serve(monkeypatch, narrative: dict):
+    def fake_get(path: str, params: dict | None = None):
+        if path == "/api/v1/agents/ultra-pi":
+            return {"id": AGENT_ID, "name": "ultra-pi"}
+        if path == f"/api/v1/agents/{AGENT_ID}/insights/reports":
+            return [{"id": REPORT_ID, "status": "completed"}]
+        if path == f"/api/v1/agents/{AGENT_ID}/insights/reports/{REPORT_ID}":
+            return {
+                "id": REPORT_ID,
+                "agent_id": AGENT_ID,
+                "status": "completed",
+                "period_start": "2026-05-17T00:00:00Z",
+                "period_end": "2026-05-31T00:00:00Z",
+                "sessions_analyzed": 42,
+                "llm_model_used": "test-model",
+                "narrative": narrative,
+            }
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr("observal_cli.config.resolve_alias", lambda value: value)
+    monkeypatch.setattr("observal_cli.cmd_insights.client.get", fake_get)
+
+
+def _flat(output: str) -> str:
+    """Collapse Rich's wrapping so assertions test content, not terminal width."""
+    return " ".join(output.split())
+
+
+# Every section renderer, with the hostile string in a field it interpolates.
+SECTIONS = [
+    ("at_a_glance", {"health": "healthy", "whats_working": HOSTILE}),
+    ("at_a_glance", {"health": "healthy", "quick_win": HOSTILE}),
+    ("what_they_work_on", {"areas": [{"name": "infra", "sessions": 3, "description": HOSTILE}]}),
+    ("interaction_style", {"narrative": HOSTILE}),
+    ("interaction_style", {"narrative": "ok", "key_pattern": HOSTILE}),
+    ("usage_patterns", {"narrative": HOSTILE}),
+    ("usage_patterns", {"tool_distribution": [{"tool": HOSTILE, "calls": 4, "error_rate": 0.0}]}),
+    ("what_works", {"intro": HOSTILE}),
+    ("what_works", {"strengths": [{"title": "t", "description": HOSTILE}]}),
+    ("friction_analysis", {"categories": [{"title": "t", "severity": "high", "description": HOSTILE}]}),
+    ("friction_analysis", {"categories": [{"title": "t", "severity": "high", "examples": [HOSTILE]}]}),
+    ("suggestions", {"config_additions": [{"addition": HOSTILE, "why": "w", "where": "system_prompt"}]}),
+    ("suggestions", {"features_to_try": [{"feature": "Skill", "name": "n", "one_liner": HOSTILE}]}),
+    ("suggestions", {"usage_patterns": [{"title": "t", "suggestion": HOSTILE}]}),
+    ("suggestions", {"usage_patterns": [{"title": "t", "suggestion": "s", "copyable_prompt": HOSTILE}]}),
+    ("usage_cost_analysis", {"summary": HOSTILE}),
+    ("usage_cost_analysis", {"opportunities": [{"title": "t", "description": HOSTILE}]}),
+    ("regression_detection", {"has_previous_data": True, "summary": HOSTILE}),
+    ("on_the_horizon", {"opportunities": [{"title": "t", "whats_possible": HOSTILE}]}),
+    ("on_the_horizon", {"opportunities": [{"title": "t", "how_to_try": HOSTILE}]}),
+    ("version_comparison", {"summary": HOSTILE}),
+    ("version_comparison", {"summary": "s", "changes": [{"metric": "m", "evidence": HOSTILE}]}),
+    ("fun_ending", {"headline": HOSTILE}),
+    ("fun_ending", {"headline": "h", "detail": HOSTILE}),
+]
+
+
+@pytest.mark.parametrize(("section", "payload"), SECTIONS, ids=[f"{s}-{i}" for i, (s, _) in enumerate(SECTIONS)])
+def test_bracketed_text_renders_literally(monkeypatch, section, payload):
+    _serve(monkeypatch, {section: payload})
+
+    result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+    assert result.exit_code == 0, result.output
+    assert HOSTILE in _flat(result.output), f"{section} dropped or mangled bracketed text"
+
+
+class TestLegacySectionShapes:
+    def test_string_section_does_not_crash_typed_renderer(self, monkeypatch):
+        # Older reports stored some sections as prose; `.get` would explode.
+        _serve(monkeypatch, {"suggestions": "Try writing shorter prompts."})
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "Try writing shorter prompts." in result.output
+
+    def test_list_section_does_not_crash_typed_renderer(self, monkeypatch):
+        _serve(monkeypatch, {"suggestions": ["one", "two"]})
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output

--- a/tests/test_cmd_insights_registry_reuse.py
+++ b/tests/test_cmd_insights_registry_reuse.py
@@ -1,0 +1,376 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI rendering of registry reuse suggestions and the cold-start note.
+
+The web UI and the CLI must agree about when a component is safe to point a
+user at: only a server-validated ``component_ref`` counts. These tests pin
+that, plus the four "why was nothing reused" messages.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from observal_cli import cmd_insights
+from observal_cli.cmd_insights import insights_app
+
+runner = CliRunner()
+
+AGENT_ID = "c6185803-8c32-4c39-b347-78f8281e306e"
+REPORT_ID = "be5aa083-d84a-49e7-8a35-b37b3e687780"
+COMPONENT_ID = "0f2b8a1c-2f4d-4c0e-9f7a-1b2c3d4e5f60"
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_name(monkeypatch):
+    """The registry name is cached per process; keep tests independent."""
+    monkeypatch.setattr(cmd_insights, "_registry_name_cache", None)
+
+
+def _report(narrative: dict) -> dict:
+    return {
+        "id": REPORT_ID,
+        "agent_id": AGENT_ID,
+        "status": "completed",
+        "period_start": "2026-05-17T00:00:00Z",
+        "period_end": "2026-05-31T00:00:00Z",
+        "sessions_analyzed": 42,
+        "llm_model_used": "test-model",
+        "narrative": narrative,
+    }
+
+
+def _install_fake_get(monkeypatch, narrative: dict, *, branding: str | None = "Observal"):
+    """Serve the three calls `insights show` makes, plus the branding lookup."""
+
+    def fake_get(path: str, params: dict | None = None):
+        if path == "/api/v1/agents/ultra-pi":
+            return {"id": AGENT_ID, "name": "ultra-pi"}
+        if path == f"/api/v1/agents/{AGENT_ID}/insights/reports":
+            return [{"id": REPORT_ID, "status": "completed"}]
+        if path == f"/api/v1/agents/{AGENT_ID}/insights/reports/{REPORT_ID}":
+            return _report(narrative)
+        if path == "/api/v1/config/public":
+            if branding is None:
+                raise RuntimeError("config unavailable")
+            return {"branding_app_name": branding}
+        raise AssertionError(f"unexpected path: {path}")
+
+    monkeypatch.setattr("observal_cli.config.resolve_alias", lambda value: value)
+    monkeypatch.setattr("observal_cli.cmd_insights.client.get", fake_get)
+
+
+def _reuse_feature(**overrides) -> dict:
+    feature = {
+        "action_type": "reuse_existing_component",
+        "feature": "Skill",
+        "name": "terraform-review",
+        "one_liner": "Reviews terraform plans before apply.",
+        "match_reason": "Sessions repeatedly hand-review plan output.",
+        "existing_component_id": COMPONENT_ID,
+        "component_ref": {
+            "type": "skill",
+            "id": COMPONENT_ID,
+            "name": "terraform-plan-review",
+            "qualified_name": "super/terraform-plan-review",
+            "latest_version": "1.0.0",
+        },
+    }
+    feature.update(overrides)
+    return feature
+
+
+def _create_feature(name: str = "scope-guard") -> dict:
+    return {
+        "action_type": "create_new_skill",
+        "feature": "Skill",
+        "name": name,
+        "one_liner": "Keeps edits inside the requested scope.",
+        "why_for_you": "You corrected scope creep in 6 sessions.",
+    }
+
+
+# ── Reuse suggestions ──────────────────────────────────────────────────────
+
+
+class TestReuseRendering:
+    def test_validated_component_is_shown_as_already_in_registry(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {"suggestions": {"features_to_try": [_reuse_feature()]}},
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "ALREADY IN OBSERVAL" in result.output
+        assert "super/terraform-plan-review" in result.output
+        assert "v1.0.0" in result.output
+        assert "Sessions repeatedly hand-review plan output." in result.output
+
+    def test_reuse_is_rendered_before_create_new(self, monkeypatch):
+        # The model emits create-new first; "you already own this" must lead.
+        _install_fake_get(
+            monkeypatch,
+            {"suggestions": {"features_to_try": [_create_feature(), _reuse_feature()]}},
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert result.output.index("ALREADY IN OBSERVAL") < result.output.index("scope-guard")
+
+    def test_suggestion_without_component_ref_gets_no_install_instructions(self, monkeypatch):
+        # A rejected reuse keeps its text but loses its ids. Rendering it as a
+        # registry component would send the user to install something fake.
+        rejected = _reuse_feature(action_type="create_new_skill", component_ref=None, existing_component_id=None)
+        _install_fake_get(monkeypatch, {"suggestions": {"features_to_try": [rejected]}})
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "ALREADY IN" not in result.output
+        assert "observal agent add" not in result.output
+        assert COMPONENT_ID not in result.output
+
+    def test_non_dict_component_ref_is_ignored(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {"suggestions": {"features_to_try": [_reuse_feature(component_ref="super/thing")]}},
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "ALREADY IN" not in result.output
+
+    def test_non_dict_feature_entries_do_not_crash(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {"suggestions": {"features_to_try": ["just a string", None, _reuse_feature()]}},
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "super/terraform-plan-review" in result.output
+
+    def test_white_label_name_is_honoured(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {"suggestions": {"features_to_try": [_reuse_feature()]}},
+            branding="Acme Hub",
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "ALREADY IN ACME HUB" in result.output
+
+    def test_branding_lookup_failure_falls_back(self, monkeypatch):
+        # A cosmetic label must never be the reason a report fails to render.
+        _install_fake_get(
+            monkeypatch,
+            {"suggestions": {"features_to_try": [_reuse_feature()]}},
+            branding=None,
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "ALREADY IN YOUR REGISTRY" in result.output
+
+
+# ── Cold-start note ────────────────────────────────────────────────────────
+
+
+class TestRegistryMatchNote:
+    def test_searched_but_nothing_fit(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_create_feature()]},
+                "registry_match": {"enabled": True, "offered": 12, "reused": 0, "registry_has_components": None},
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "Checked 12 components already in Observal" in result.output
+
+    def test_singular_component_reads_correctly(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_create_feature()]},
+                "registry_match": {"enabled": True, "offered": 1, "reused": 0, "registry_has_components": None},
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert "Checked 1 component already in Observal" in result.output
+
+    def test_empty_registry_says_so(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_create_feature()]},
+                "registry_match": {"enabled": True, "offered": 0, "reused": 0, "registry_has_components": False},
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert "No components have been published to Observal yet" in result.output
+
+    def test_thin_signal_asks_for_more_sessions(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_create_feature()]},
+                "registry_match": {"enabled": True, "offered": 0, "reused": 0, "registry_has_components": True},
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert "More sessions give the match more to go on" in result.output
+
+    def test_disabled_feature_says_so(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_create_feature()]},
+                "registry_match": {"enabled": False, "offered": 0, "reused": 0, "registry_has_components": None},
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert "Reuse suggestions are turned off" in result.output
+
+    def test_no_note_when_something_was_reused(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_reuse_feature()]},
+                "registry_match": {"enabled": True, "offered": 2, "reused": 1, "registry_has_components": None},
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert "Checked" not in result.output
+        assert "super/terraform-plan-review" in result.output
+
+    def test_reports_predating_the_feature_stay_silent(self, monkeypatch):
+        # No registry_match key at all: say nothing rather than guess.
+        _install_fake_get(monkeypatch, {"suggestions": {"features_to_try": [_create_feature()]}})
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "Checked" not in result.output
+        assert "Reuse suggestions are turned off" not in result.output
+
+    def test_note_renders_for_section_scoped_output(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_create_feature()]},
+                "registry_match": {"enabled": True, "offered": 3, "reused": 0, "registry_has_components": None},
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi", "--section", "suggestions"])
+
+        assert result.exit_code == 0, result.output
+        assert "Checked 3 components already in Observal" in result.output
+
+    def test_malformed_summary_is_ignored(self, monkeypatch):
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {"features_to_try": [_create_feature()]},
+                "registry_match": "not a dict",
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "Checked" not in result.output
+
+    def test_json_output_is_untouched(self, monkeypatch):
+        narrative = {
+            "suggestions": {"features_to_try": [_reuse_feature()]},
+            "registry_match": {"enabled": True, "offered": 2, "reused": 1, "registry_has_components": None},
+        }
+        _install_fake_get(monkeypatch, narrative)
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi", "--output", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert COMPONENT_ID in result.output
+
+
+class TestLegacySectionShapes:
+    def test_string_section_does_not_crash_typed_renderer(self, monkeypatch):
+        # Older reports stored some sections as prose; `.get` would explode.
+        _install_fake_get(monkeypatch, {"suggestions": "Try writing shorter prompts."})
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "Try writing shorter prompts." in result.output
+
+    def test_list_section_does_not_crash_typed_renderer(self, monkeypatch):
+        _install_fake_get(monkeypatch, {"suggestions": ["one", "two"]})
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+
+
+class TestReuseBlockMarkupSafety:
+    """Reuse text is LLM-written and must render literally, not as Rich markup."""
+
+    HOSTILE = "Clean up [/tmp] and index array[0] with [bold] markers"
+
+    def test_reuse_suggestion_text_renders_literally(self, monkeypatch):
+        monkeypatch.setenv("COLUMNS", "300")
+        _install_fake_get(
+            monkeypatch,
+            {
+                "suggestions": {
+                    "features_to_try": [
+                        _reuse_feature(one_liner=self.HOSTILE, match_reason=self.HOSTILE),
+                    ]
+                }
+            },
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert self.HOSTILE in " ".join(result.output.split())
+        assert "ALREADY IN OBSERVAL" in result.output
+
+    def test_hostile_component_name_cannot_forge_styling(self, monkeypatch):
+        # Component names are server data, but must still never be able to
+        # close the CLI's own markup tags.
+        monkeypatch.setenv("COLUMNS", "300")
+        ref = dict(_reuse_feature()["component_ref"], qualified_name="super/[/bold]evil")
+        _install_fake_get(
+            monkeypatch,
+            {"suggestions": {"features_to_try": [_reuse_feature(component_ref=ref)]}},
+        )
+
+        result = runner.invoke(insights_app, ["show", "ultra-pi"])
+
+        assert result.exit_code == 0, result.output
+        assert "super/[/bold]evil" in " ".join(result.output.split())

--- a/tests/test_cmd_recommend.py
+++ b/tests/test_cmd_recommend.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""`observal registry recommend`: personal recommendations from the CLI.
+
+The value of this command depends on it never overstating what it knows, so
+most of these tests are about the wording of the cold-start cases rather than
+the happy path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from observal_cli.cmd_recommend import recommend_app
+
+runner = CliRunner()
+
+COMPONENT_ID = "0f2b8a1c-2f4d-4c0e-9f7a-1b2c3d4e5f60"
+
+
+@pytest.fixture(autouse=True)
+def _wide_terminal(monkeypatch):
+    """Assert on copy, not on where Rich happens to wrap an 80-column table."""
+    monkeypatch.setenv("COLUMNS", "200")
+
+
+def _flat(output: str) -> str:
+    """Collapse Rich's line wrapping so assertions test copy, not terminal width."""
+    return " ".join(output.split())
+
+
+def _item(**overrides) -> dict:
+    item = {
+        "type": "mcp",
+        "id": COMPONENT_ID,
+        "name": "postgres",
+        "namespace": "super",
+        "slug": "postgres",
+        "qualified_name": "super/postgres",
+        "description": "Query Postgres from your agent.",
+        "category": "databases",
+        "latest_version": "2.1.0",
+        "download_count": 37,
+        "matched_on": ["postgres", "sql"],
+        "score": 9.5,
+        "reason": "Matches your work on postgres, sql",
+    }
+    item.update(overrides)
+    return item
+
+
+def _install(monkeypatch, payload: dict):
+    captured: dict = {}
+
+    def fake_get(path: str, params: dict | None = None):
+        captured["path"] = path
+        captured["params"] = params
+        return payload
+
+    monkeypatch.setattr("observal_cli.cmd_recommend.client.get", fake_get)
+    return captured
+
+
+class TestListing:
+    def test_personalised_result_cites_sessions_and_topics(self, monkeypatch):
+        _install(
+            monkeypatch,
+            {"items": [_item()], "personalized": True, "profile_sessions": 33, "topics": ["databases", "devops"]},
+        )
+
+        result = runner.invoke(recommend_app, [])
+
+        assert result.exit_code == 0, result.output
+        assert "Recommended for you" in result.output
+        assert "Based on 33 sessions" in result.output
+        assert "databases, devops" in result.output
+        assert "super/postgres" in result.output
+        assert "Matches your work on postgres" in _flat(result.output)
+
+    def test_single_session_reads_correctly(self, monkeypatch):
+        _install(
+            monkeypatch,
+            {"items": [_item()], "personalized": True, "profile_sessions": 1, "topics": []},
+        )
+
+        result = runner.invoke(recommend_app, [])
+
+        assert "Based on 1 session." in result.output
+
+    def test_cold_start_never_claims_personalisation(self, monkeypatch):
+        _install(
+            monkeypatch,
+            {
+                "items": [_item(reason="Popular in your registry")],
+                "personalized": False,
+                "profile_sessions": 0,
+                "topics": [],
+            },
+        )
+
+        result = runner.invoke(recommend_app, [])
+
+        assert result.exit_code == 0, result.output
+        assert "Popular in your registry" in result.output
+        assert "Recommended for you" not in result.output
+        assert "No session history yet" in result.output
+
+    def test_empty_result_explains_itself(self, monkeypatch):
+        _install(monkeypatch, {"items": [], "personalized": True, "profile_sessions": 12, "topics": ["frontend"]})
+
+        result = runner.invoke(recommend_app, [])
+
+        assert result.exit_code == 0, result.output
+        assert "Nothing to recommend right now" in result.output
+        assert "already installed or dismissed them all" in _flat(result.output)
+
+    def test_json_output_is_the_raw_payload(self, monkeypatch):
+        payload = {"items": [_item()], "personalized": True, "profile_sessions": 4, "topics": ["databases"]}
+        _install(monkeypatch, payload)
+
+        result = runner.invoke(recommend_app, ["--output", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == payload
+
+    def test_list_subcommand_matches_the_bare_invocation(self, monkeypatch):
+        payload = {"items": [_item()], "personalized": True, "profile_sessions": 4, "topics": []}
+        _install(monkeypatch, payload)
+
+        bare = runner.invoke(recommend_app, ["--output", "json"])
+        explicit = runner.invoke(recommend_app, ["list", "--output", "json"])
+
+        assert json.loads(bare.output) == json.loads(explicit.output)
+
+    def test_filters_are_forwarded_to_the_server(self, monkeypatch):
+        captured = _install(monkeypatch, {"items": [], "personalized": False, "profile_sessions": 0, "topics": []})
+
+        result = runner.invoke(recommend_app, ["--limit", "12", "--type", "mcps", "--refresh"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["path"] == "/api/v1/recommendations/me"
+        # Plural in, singular out: the API only accepts the canonical form.
+        assert captured["params"] == {"limit": 12, "type": "mcp", "refresh": True}
+
+    def test_refresh_is_omitted_unless_asked_for(self, monkeypatch):
+        captured = _install(monkeypatch, {"items": [], "personalized": False, "profile_sessions": 0, "topics": []})
+
+        runner.invoke(recommend_app, [])
+
+        assert captured["params"] == {"limit": 8}
+
+    def test_limit_bounds_are_enforced_locally(self, monkeypatch):
+        _install(monkeypatch, {"items": [], "personalized": False, "profile_sessions": 0, "topics": []})
+
+        assert runner.invoke(recommend_app, ["--limit", "0"]).exit_code != 0
+        assert runner.invoke(recommend_app, ["--limit", "99"]).exit_code != 0
+
+    def test_unknown_type_is_rejected_before_any_request(self, monkeypatch):
+        def explode(*args, **kwargs):
+            raise AssertionError("must not reach the server")
+
+        monkeypatch.setattr("observal_cli.cmd_recommend.client.get", explode)
+
+        result = runner.invoke(recommend_app, ["--type", "../../etc/passwd"])
+
+        assert result.exit_code == 1
+        assert "Unknown component type" in result.output
+
+
+class TestDismiss:
+    def test_dismiss_resolves_a_qualified_name_and_posts(self, monkeypatch):
+        posted: dict = {}
+
+        monkeypatch.setattr(
+            "observal_cli.cmd_recommend.client.resolve_registry_reference",
+            lambda item_type, reference: (posted.setdefault("resolve", (item_type, reference)), COMPONENT_ID)[1],
+        )
+
+        def fake_post(path: str, body: dict | None = None):
+            posted["path"] = path
+            posted["body"] = body
+            return {}
+
+        monkeypatch.setattr("observal_cli.cmd_recommend.client.post", fake_post)
+
+        result = runner.invoke(recommend_app, ["dismiss", "skill", "super/terraform-plan-review"])
+
+        assert result.exit_code == 0, result.output
+        # Resolution needs the plural collection name, the API needs singular.
+        assert posted["resolve"] == ("skills", "super/terraform-plan-review")
+        assert posted["path"] == "/api/v1/recommendations/feedback"
+        assert posted["body"] == {
+            "component_type": "skill",
+            "component_id": COMPONENT_ID,
+            "action": "dismissed",
+        }
+        assert "no longer be recommended" in result.output
+
+    def test_installed_action_is_reported_differently(self, monkeypatch):
+        posted: dict = {}
+        monkeypatch.setattr(
+            "observal_cli.cmd_recommend.client.resolve_registry_reference",
+            lambda item_type, reference: COMPONENT_ID,
+        )
+        monkeypatch.setattr(
+            "observal_cli.cmd_recommend.client.post",
+            lambda path, body=None: posted.update(body=body) or {},
+        )
+
+        result = runner.invoke(recommend_app, ["dismiss", "mcp", "super/postgres", "--action", "installed"])
+
+        assert result.exit_code == 0, result.output
+        assert posted["body"]["action"] == "installed"
+        assert "as installed" in result.output
+
+    def test_unknown_action_is_rejected_before_any_request(self, monkeypatch):
+        def explode(*args, **kwargs):
+            raise AssertionError("must not reach the server")
+
+        monkeypatch.setattr("observal_cli.cmd_recommend.client.resolve_registry_reference", explode)
+        monkeypatch.setattr("observal_cli.cmd_recommend.client.post", explode)
+
+        result = runner.invoke(recommend_app, ["dismiss", "skill", "super/x", "--action", "delete-everything"])
+
+        assert result.exit_code == 1
+        assert "Unknown action" in result.output
+
+    def test_unknown_type_is_rejected_before_any_request(self, monkeypatch):
+        def explode(*args, **kwargs):
+            raise AssertionError("must not reach the server")
+
+        monkeypatch.setattr("observal_cli.cmd_recommend.client.resolve_registry_reference", explode)
+        monkeypatch.setattr("observal_cli.cmd_recommend.client.post", explode)
+
+        result = runner.invoke(recommend_app, ["dismiss", "sandbo", "super/x"])
+
+        assert result.exit_code == 1
+        assert "Unknown component type" in result.output
+
+    def test_sandbox_survives_type_normalisation(self, monkeypatch):
+        # "sandbox".rstrip("s") == "sandbo"; the alias map exists to avoid that.
+        posted: dict = {}
+        monkeypatch.setattr(
+            "observal_cli.cmd_recommend.client.resolve_registry_reference",
+            lambda item_type, reference: (posted.setdefault("resolve", item_type), COMPONENT_ID)[1],
+        )
+        monkeypatch.setattr(
+            "observal_cli.cmd_recommend.client.post",
+            lambda path, body=None: posted.update(body=body) or {},
+        )
+
+        result = runner.invoke(recommend_app, ["dismiss", "sandbox", "super/runner"])
+
+        assert result.exit_code == 0, result.output
+        assert posted["resolve"] == "sandboxes"
+        assert posted["body"]["component_type"] == "sandbox"
+
+
+class TestMarkupSafety:
+    """Descriptions and reasons are free text, not Rich markup."""
+
+    HOSTILE = "Clean up [/tmp] and index array[0] with [bold] markers"
+
+    def test_bracketed_reason_renders_literally(self, monkeypatch):
+        _install(
+            monkeypatch,
+            {
+                "items": [_item(description=self.HOSTILE, reason=self.HOSTILE)],
+                "personalized": True,
+                "profile_sessions": 3,
+                "topics": [],
+            },
+        )
+
+        result = runner.invoke(recommend_app, [])
+
+        assert result.exit_code == 0, result.output
+        assert self.HOSTILE in _flat(result.output)

--- a/tests/test_insights_registry_match.py
+++ b/tests/test_insights_registry_match.py
@@ -1,0 +1,469 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for registry-aware insight suggestions.
+
+The validation gate is the load-bearing piece: an id the model invented must
+never reach the UI as a real component link.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+import services.dynamic_settings as ds
+from models.base import Base
+from models.mcp import ListingStatus
+from models.organization import Organization
+from models.skill import SkillListing, SkillVersion
+from models.user import User
+from services.insights.registry_match import (
+    CatalogOffer,
+    RegistryScope,
+    build_catalog,
+    build_signals,
+    catalog_block,
+    count_reused,
+    validate_reuse_suggestions,
+)
+
+
+@pytest.fixture()
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+        await session.rollback()
+    await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache():
+    """Keep each test's setting overrides from leaking into the next."""
+    original = dict(ds._sync_cache)
+    yield
+    ds._sync_cache = original
+
+
+async def _user(db: AsyncSession, email: str = "a@example.com", org_id=None) -> User:
+    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _skill(
+    db: AsyncSession,
+    *,
+    name: str,
+    submitter: User,
+    description: str = "Database migrations",
+    status: ListingStatus = ListingStatus.approved,
+    is_private: bool = False,
+    org_id=None,
+) -> SkillListing:
+    listing = SkillListing(
+        name=name,
+        namespace="test",
+        slug=name,
+        owner="tester",
+        submitted_by=submitter.id,
+        is_private=is_private,
+        owner_org_id=org_id,
+    )
+    db.add(listing)
+    await db.flush()
+    version = SkillVersion(
+        listing_id=listing.id,
+        version="1.5.0",
+        description=description,
+        status=status,
+        task_type="general",
+        delivery_mode="registry_direct",
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+def _narrative(features: list[dict]) -> dict:
+    return {"suggestions": {"features_to_try": features}}
+
+
+# ── signal building ───────────────────────────────────────────────────────
+
+
+def test_build_signals_handles_mixed_aggregate_shapes():
+    signals = build_signals(
+        agg={
+            "top_languages": [["Python", 12], ["TypeScript", 4]],
+            "top_tools": [{"tool": "Bash"}, {"name": "Edit"}],
+            "tool_error_categories": {"permission_denied": 3},
+        },
+        facets_summary={
+            "goal_categories": [{"category": "database migrations"}],
+            "friction_types": [{"type": "wrong_approach"}],
+            "repeated_instructions": [{"instruction": "run ruff before finishing"}],
+        },
+    )
+
+    for expected in ("Python", "Bash", "Edit", "database migrations", "wrong_approach", "permission_denied"):
+        assert expected in signals
+
+
+def test_build_signals_survives_empty_input():
+    assert build_signals() == ""
+    assert build_signals(agg={}, facets_summary={}, agent_config={}) == ""
+
+
+def test_build_signals_extracts_mcp_server_names():
+    """`mcp__postgres__query` is one opaque token; the server name is the signal."""
+    signals = build_signals(agg={"top_tools": [["mcp__postgres__query", 40], ["Bash", 10]]})
+
+    assert "postgres" in signals.split()
+    assert "mcp__postgres__query" in signals
+
+
+def test_build_signals_includes_configured_mcps():
+    signals = build_signals(agent_config={"configured_mcps": ["github-mcp"]})
+    assert "github-mcp" in signals
+
+
+def test_build_signals_carries_domain_words_from_the_prompt():
+    """Tool names describe mechanics; the prompt is where the domain lives."""
+    signals = build_signals(
+        agg={"top_tools": [["Edit", 20], ["Read", 15]], "top_languages": [["TypeScript", 30]]},
+        agent_config={"system_prompt_excerpt": "You help build the React dashboard front end."},
+    )
+
+    lowered = signals.lower()
+    assert "react" in lowered
+    assert "dashboard" in lowered
+
+
+def test_build_signals_truncates_long_prompts():
+    signals = build_signals(agent_config={"system_prompt_excerpt": "x" * 5000})
+    assert len(signals) < 1000
+
+
+# ── catalog building ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_build_catalog_returns_matches(db: AsyncSession):
+    user = await _user(db)
+    skill = await _skill(db, name="db-migrator", submitter=user)
+
+    offer = await build_catalog(db, RegistryScope(), "database migrations")
+
+    assert offer.item_count == 1
+    assert skill.id in offer.offered_ids
+    assert offer.entries_by_type["skills"][0]["qualified_name"] == "test/db-migrator"
+
+
+@pytest.mark.asyncio
+async def test_build_catalog_excludes_already_attached(db: AsyncSession):
+    user = await _user(db)
+    attached = await _skill(db, name="db-attached", submitter=user)
+    await _skill(db, name="db-other", submitter=user)
+
+    offer = await build_catalog(db, RegistryScope(attached_ids=(attached.id,)), "database")
+
+    assert attached.id not in offer.offered_ids
+    assert offer.item_count == 1
+
+
+@pytest.mark.asyncio
+async def test_build_catalog_respects_kill_switch(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="db-migrator", submitter=user)
+    ds._sync_cache["insights.registry_match_enabled"] = "false"
+
+    offer = await build_catalog(db, RegistryScope(), "database migrations")
+
+    assert not offer
+    assert offer.item_count == 0
+
+
+@pytest.mark.asyncio
+async def test_build_catalog_respects_item_cap(db: AsyncSession):
+    user = await _user(db)
+    for i in range(8):
+        await _skill(db, name=f"db-{i}", submitter=user)
+    ds._sync_cache["insights.registry_match_max_items"] = "3"
+
+    offer = await build_catalog(db, RegistryScope(), "database")
+
+    assert offer.item_count == 3
+
+
+@pytest.mark.asyncio
+async def test_build_catalog_excludes_other_org_private(db: AsyncSession):
+    org_a = Organization(name="A", slug="org-a")
+    org_b = Organization(name="B", slug="org-b")
+    db.add_all([org_a, org_b])
+    await db.flush()
+    outsider = await _user(db, "b@example.com", org_id=org_b.id)
+    await _skill(db, name="their-db-tool", submitter=outsider, is_private=True, org_id=org_b.id)
+
+    offer = await build_catalog(db, RegistryScope(org_id=org_a.id), "database")
+
+    assert offer.item_count == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_is_distinguished_from_no_match(db: AsyncSession):
+    """The report says different things for these, so they must differ here."""
+    offer = await build_catalog(db, RegistryScope(), "database migrations")
+
+    assert offer.item_count == 0
+    assert offer.registry_has_components is False
+
+
+@pytest.mark.asyncio
+async def test_no_match_against_a_populated_registry(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="css-helper", submitter=user, description="Tailwind styling helper")
+
+    offer = await build_catalog(db, RegistryScope(), "kubernetes ingress certificates")
+
+    assert offer.item_count == 0
+    # Components exist, they just did not fit.
+    assert offer.registry_has_components is True
+
+
+@pytest.mark.asyncio
+async def test_successful_match_skips_the_probe(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="db-migrator", submitter=user)
+
+    offer = await build_catalog(db, RegistryScope(), "database migrations")
+
+    assert offer.item_count == 1
+    # No need to ask whether the registry is populated; we found something.
+    assert offer.registry_has_components is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_feature_is_reported_as_disabled(db: AsyncSession):
+    ds._sync_cache["insights.registry_match_enabled"] = "false"
+
+    offer = await build_catalog(db, RegistryScope(), "database")
+
+    assert offer.enabled is False
+    assert offer.to_summary()["enabled"] is False
+
+
+def test_summary_reports_reuse_count():
+    offer = CatalogOffer(entries_by_type={"skills": [{"id": "a"}, {"id": "b"}]})
+
+    summary = offer.to_summary(reused=1)
+
+    assert summary == {
+        "enabled": True,
+        "offered": 2,
+        "reused": 1,
+        "registry_has_components": None,
+    }
+
+
+def test_count_reused_only_counts_validated_refs():
+    narrative = {
+        "suggestions": {
+            "features_to_try": [
+                {"component_ref": {"id": "x"}},
+                {"component_ref": None},
+                {"action_type": "create_new_skill"},
+                "not a dict",
+            ]
+        }
+    }
+
+    assert count_reused(narrative) == 1
+
+
+@pytest.mark.parametrize(
+    "narrative",
+    [{}, {"suggestions": None}, {"suggestions": {"features_to_try": "nope"}}],
+)
+def test_count_reused_tolerates_malformed(narrative):
+    assert count_reused(narrative) == 0
+
+
+def test_catalog_block_is_empty_without_offer():
+    assert catalog_block(CatalogOffer()) == ""
+
+
+def test_catalog_block_instructs_verbatim_ids():
+    offer = CatalogOffer(entries_by_type={"skills": [{"id": "x", "name": "y"}]}, offered_ids={uuid.uuid4()})
+    block = catalog_block(offer)
+    assert "never invent an id" in block.lower()
+
+
+# ── validation gate ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_valid_reuse_is_kept_and_enriched(db: AsyncSession):
+    user = await _user(db)
+    skill = await _skill(db, name="db-migrator", submitter=user)
+    offer = CatalogOffer(offered_ids={skill.id})
+    narrative = _narrative(
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(skill.id),
+            }
+        ]
+    )
+
+    result = await validate_reuse_suggestions(narrative, offer, db, RegistryScope())
+
+    feature = result["suggestions"]["features_to_try"][0]
+    assert feature["action_type"] == "reuse_existing_component"
+    assert feature["component_ref"]["qualified_name"] == "test/db-migrator"
+    assert feature["component_ref"]["latest_version"] == "1.5.0"
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_id_is_stripped(db: AsyncSession):
+    """An id that was never offered must not survive, however plausible."""
+    await _user(db)
+    offer = CatalogOffer(offered_ids=set())
+    narrative = _narrative(
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(uuid.uuid4()),
+                "one_liner": "Invented",
+            }
+        ]
+    )
+
+    result = await validate_reuse_suggestions(narrative, offer, db, RegistryScope())
+
+    feature = result["suggestions"]["features_to_try"][0]
+    assert feature["existing_component_id"] is None
+    assert feature["component_ref"] is None
+    assert feature["action_type"] != "reuse_existing_component"
+    # The idea survives even though the fake reference does not.
+    assert feature["one_liner"] == "Invented"
+
+
+@pytest.mark.asyncio
+async def test_offered_but_unresolvable_id_is_stripped(db: AsyncSession):
+    """Offered ids still get re-checked: the listing may have been archived."""
+    user = await _user(db)
+    pending = await _skill(db, name="not-approved", submitter=user, status=ListingStatus.pending)
+    offer = CatalogOffer(offered_ids={pending.id})
+    narrative = _narrative(
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(pending.id),
+            }
+        ]
+    )
+
+    result = await validate_reuse_suggestions(narrative, offer, db, RegistryScope())
+
+    assert result["suggestions"]["features_to_try"][0]["component_ref"] is None
+
+
+@pytest.mark.asyncio
+async def test_reuse_across_org_boundary_is_stripped(db: AsyncSession):
+    org_a = Organization(name="A", slug="org-a")
+    org_b = Organization(name="B", slug="org-b")
+    db.add_all([org_a, org_b])
+    await db.flush()
+    outsider = await _user(db, "b@example.com", org_id=org_b.id)
+    foreign = await _skill(db, name="theirs", submitter=outsider, is_private=True, org_id=org_b.id)
+    # Even if the id somehow ends up in the offer, resolution is org-scoped.
+    offer = CatalogOffer(offered_ids={foreign.id})
+    narrative = _narrative(
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(foreign.id),
+            }
+        ]
+    )
+
+    result = await validate_reuse_suggestions(narrative, offer, db, RegistryScope(org_id=org_a.id))
+
+    assert result["suggestions"]["features_to_try"][0]["component_ref"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_new_suggestions_are_untouched(db: AsyncSession):
+    await _user(db)
+    narrative = _narrative(
+        [
+            {
+                "action_type": "create_new_skill",
+                "feature": "Skill",
+                "name": "scope-guard",
+                "example": "---\nname: scope-guard\n---\nSteps",
+            }
+        ]
+    )
+
+    result = await validate_reuse_suggestions(narrative, CatalogOffer(), db, RegistryScope())
+
+    feature = result["suggestions"]["features_to_try"][0]
+    assert feature["action_type"] == "create_new_skill"
+    assert "component_ref" not in feature
+
+
+@pytest.mark.asyncio
+async def test_non_uuid_reference_is_ignored(db: AsyncSession):
+    await _user(db)
+    narrative = _narrative(
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": "registry/db-migrator",
+            }
+        ]
+    )
+
+    result = await validate_reuse_suggestions(narrative, CatalogOffer(), db, RegistryScope())
+
+    # Not a uuid, so there is nothing to validate or enrich.
+    assert result["suggestions"]["features_to_try"][0].get("component_ref") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "narrative",
+    [
+        {},
+        {"suggestions": None},
+        {"suggestions": {}},
+        {"suggestions": {"features_to_try": None}},
+        {"suggestions": {"features_to_try": []}},
+        {"suggestions": {"features_to_try": ["not a dict"]}},
+        {"suggestions": "a string"},
+    ],
+)
+async def test_validation_tolerates_malformed_narratives(db: AsyncSession, narrative):
+    """Old reports and partial LLM output must not raise."""
+    result = await validate_reuse_suggestions(narrative, CatalogOffer(), db, RegistryScope())
+    assert result is narrative

--- a/tests/test_insights_registry_match.py
+++ b/tests/test_insights_registry_match.py
@@ -19,7 +19,6 @@ from sqlalchemy.orm import sessionmaker
 import services.dynamic_settings as ds
 from models.base import Base
 from models.mcp import ListingStatus
-from models.organization import Organization
 from models.skill import SkillListing, SkillVersion
 from models.user import User
 from services.insights.registry_match import (
@@ -53,8 +52,8 @@ def _reset_settings_cache():
     ds._sync_cache = original
 
 
-async def _user(db: AsyncSession, email: str = "a@example.com", org_id=None) -> User:
-    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+async def _user(db: AsyncSession, email: str = "a@example.com") -> User:
+    user = User(email=email, username=email.split("@")[0], name=email)
     db.add(user)
     await db.flush()
     return user
@@ -68,7 +67,6 @@ async def _skill(
     description: str = "Database migrations",
     status: ListingStatus = ListingStatus.approved,
     is_private: bool = False,
-    org_id=None,
 ) -> SkillListing:
     listing = SkillListing(
         name=name,
@@ -77,7 +75,6 @@ async def _skill(
         owner="tester",
         submitted_by=submitter.id,
         is_private=is_private,
-        owner_org_id=org_id,
     )
     db.add(listing)
     await db.flush()
@@ -210,15 +207,12 @@ async def test_build_catalog_respects_item_cap(db: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_build_catalog_excludes_other_org_private(db: AsyncSession):
-    org_a = Organization(name="A", slug="org-a")
-    org_b = Organization(name="B", slug="org-b")
-    db.add_all([org_a, org_b])
-    await db.flush()
-    outsider = await _user(db, "b@example.com", org_id=org_b.id)
-    await _skill(db, name="their-db-tool", submitter=outsider, is_private=True, org_id=org_b.id)
+async def test_build_catalog_excludes_other_user_private(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    outsider = await _user(db, "outsider@example.com")
+    await _skill(db, name="their-db-tool", submitter=outsider, is_private=True)
 
-    offer = await build_catalog(db, RegistryScope(org_id=org_a.id), "database")
+    offer = await build_catalog(db, RegistryScope(user_id=owner.id), "database")
 
     assert offer.item_count == 0
 
@@ -386,14 +380,11 @@ async def test_offered_but_unresolvable_id_is_stripped(db: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_reuse_across_org_boundary_is_stripped(db: AsyncSession):
-    org_a = Organization(name="A", slug="org-a")
-    org_b = Organization(name="B", slug="org-b")
-    db.add_all([org_a, org_b])
-    await db.flush()
-    outsider = await _user(db, "b@example.com", org_id=org_b.id)
-    foreign = await _skill(db, name="theirs", submitter=outsider, is_private=True, org_id=org_b.id)
-    # Even if the id somehow ends up in the offer, resolution is org-scoped.
+async def test_reuse_across_user_boundary_is_stripped(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    outsider = await _user(db, "outsider@example.com")
+    foreign = await _skill(db, name="theirs", submitter=outsider, is_private=True)
+    # Even if the id somehow ends up in the offer, resolution is visibility-scoped.
     offer = CatalogOffer(offered_ids={foreign.id})
     narrative = _narrative(
         [
@@ -405,7 +396,7 @@ async def test_reuse_across_org_boundary_is_stripped(db: AsyncSession):
         ]
     )
 
-    result = await validate_reuse_suggestions(narrative, offer, db, RegistryScope(org_id=org_a.id))
+    result = await validate_reuse_suggestions(narrative, offer, db, RegistryScope(user_id=owner.id))
 
     assert result["suggestions"]["features_to_try"][0]["component_ref"] is None
 

--- a/tests/test_insights_self_learn_reuse.py
+++ b/tests/test_insights_self_learn_reuse.py
@@ -5,7 +5,7 @@
 
 The reuse path writes AgentComponent rows directly, so the things that matter
 are: the pinned version is real, the component name is populated, another
-tenant's private components are unreachable, and harness capability inference
+user's private components are unreachable, and harness capability inference
 is refreshed so pull-time warnings survive.
 """
 
@@ -25,7 +25,6 @@ from models.base import Base
 from models.hook import HookListing, HookVersion
 from models.insight_report import InsightReport, InsightReportStatus
 from models.mcp import ListingStatus, McpListing, McpVersion
-from models.organization import Organization
 from models.skill import SkillListing, SkillVersion
 from models.user import User
 from services.insights.self_learn import apply_insight_suggestions
@@ -43,21 +42,14 @@ async def db():
     await engine.dispose()
 
 
-async def _org(db: AsyncSession, slug: str) -> Organization:
-    org = Organization(name=slug, slug=slug)
-    db.add(org)
-    await db.flush()
-    return org
-
-
-async def _user(db: AsyncSession, email: str, org_id: uuid.UUID | None = None) -> User:
-    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+async def _user(db: AsyncSession, email: str) -> User:
+    user = User(email=email, username=email.split("@")[0], name=email)
     db.add(user)
     await db.flush()
     return user
 
 
-async def _agent(db: AsyncSession, owner: User, org_id: uuid.UUID | None = None) -> Agent:
+async def _agent(db: AsyncSession, owner: User) -> Agent:
     # `description` and `status` are delegating properties on Agent, not
     # columns — they live on the version.
     agent = Agent(
@@ -66,7 +58,6 @@ async def _agent(db: AsyncSession, owner: User, org_id: uuid.UUID | None = None)
         slug="test-agent",
         owner="tester",
         created_by=owner.id,
-        owner_org_id=org_id,
     )
     db.add(agent)
     await db.flush()
@@ -96,7 +87,6 @@ async def _skill(
     version: str = "3.2.0",
     status: ListingStatus = ListingStatus.approved,
     is_private: bool = False,
-    org_id: uuid.UUID | None = None,
     slash_command: str | None = None,
 ) -> SkillListing:
     listing = SkillListing(
@@ -106,7 +96,6 @@ async def _skill(
         owner="tester",
         submitted_by=submitter.id,
         is_private=is_private,
-        owner_org_id=org_id,
     )
     db.add(listing)
     await db.flush()
@@ -300,22 +289,19 @@ async def test_created_skill_keeps_component_name(db: AsyncSession):
     assert created[0].component_name != ""
 
 
-# ── cross-tenant isolation ────────────────────────────────────────────────
+# ── private visibility isolation ──────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_private_component_from_another_org_is_not_attached(db: AsyncSession):
-    org_a = await _org(db, "org-a")
-    org_b = await _org(db, "org-b")
-    owner = await _user(db, "owner@a.com", org_id=org_a.id)
-    outsider = await _user(db, "outsider@b.com", org_id=org_b.id)
-    agent = await _agent(db, owner, org_id=org_a.id)
+async def test_private_component_from_another_user_is_not_attached(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    outsider = await _user(db, "outsider@example.com")
+    agent = await _agent(db, owner)
     foreign = await _skill(
         db,
         name="their-secret",
         submitter=outsider,
         is_private=True,
-        org_id=org_b.id,
     )
     report = await _report(
         db,
@@ -338,11 +324,10 @@ async def test_private_component_from_another_org_is_not_attached(db: AsyncSessi
 
 
 @pytest.mark.asyncio
-async def test_same_org_private_component_is_attachable(db: AsyncSession):
-    org = await _org(db, "org-a")
-    owner = await _user(db, "owner@a.com", org_id=org.id)
-    agent = await _agent(db, owner, org_id=org.id)
-    internal = await _skill(db, name="internal-tool", submitter=owner, is_private=True, org_id=org.id, version="1.7.2")
+async def test_personal_private_component_is_attachable(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    internal = await _skill(db, name="internal-tool", submitter=owner, is_private=True, version="1.7.2")
     report = await _report(
         db,
         agent,

--- a/tests/test_insights_self_learn_reuse.py
+++ b/tests/test_insights_self_learn_reuse.py
@@ -221,6 +221,57 @@ async def test_reused_skill_is_pinned_to_its_actual_version(db: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_reusing_an_already_attached_component_does_not_duplicate_it(db: AsyncSession):
+    """A component the agent already carries must not be linked twice.
+
+    The insights shortlist excludes attached components, but the
+    existing-skill fallback does not, and an agent can gain a component
+    between report generation and apply. Two AgentComponent rows for one
+    component -- at differing resolved_versions -- break agent pulls.
+    """
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    skill = await _skill(db, name="pr-review", submitter=owner, version="3.2.0")
+
+    # The agent already carries this component, pinned at an older version.
+    db.add(
+        AgentComponent(
+            agent_version_id=agent.latest_version_id,
+            component_type="skill",
+            component_id=skill.id,
+            component_name="pr-review",
+            resolved_version="2.0.0",
+            order_index=0,
+        )
+    )
+    await db.flush()
+
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "name": "pr-review",
+                "existing_component_id": str(skill.id),
+                "one_liner": "Reviews PRs",
+                "why_for_you": "You review PRs often",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+    assert applied is not None
+
+    version = await _new_version(db, agent)
+    linked = [c for c in await _components_of(db, version.id) if c.component_id == skill.id]
+    assert len(linked) == 1, f"component linked {len(linked)} times"
+    # The carried row wins: it is the pin the agent was already using.
+    assert linked[0].resolved_version == "2.0.0"
+
+
+@pytest.mark.asyncio
 async def test_created_skill_keeps_component_name(db: AsyncSession):
     owner = await _user(db, "owner@example.com")
     agent = await _agent(db, owner)

--- a/tests/test_insights_self_learn_reuse.py
+++ b/tests/test_insights_self_learn_reuse.py
@@ -1,0 +1,543 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the self-learn apply path when reusing existing registry components.
+
+The reuse path writes AgentComponent rows directly, so the things that matter
+are: the pinned version is real, the component name is populated, another
+tenant's private components are unreachable, and harness capability inference
+is refreshed so pull-time warnings survive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.agent import Agent, AgentStatus, AgentVersion
+from models.agent_component import AgentComponent
+from models.base import Base
+from models.hook import HookListing, HookVersion
+from models.insight_report import InsightReport, InsightReportStatus
+from models.mcp import ListingStatus, McpListing, McpVersion
+from models.organization import Organization
+from models.skill import SkillListing, SkillVersion
+from models.user import User
+from services.insights.self_learn import apply_insight_suggestions
+
+
+@pytest.fixture()
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+        await session.rollback()
+    await engine.dispose()
+
+
+async def _org(db: AsyncSession, slug: str) -> Organization:
+    org = Organization(name=slug, slug=slug)
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _user(db: AsyncSession, email: str, org_id: uuid.UUID | None = None) -> User:
+    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _agent(db: AsyncSession, owner: User, org_id: uuid.UUID | None = None) -> Agent:
+    # `description` and `status` are delegating properties on Agent, not
+    # columns — they live on the version.
+    agent = Agent(
+        name="test-agent",
+        namespace="test",
+        slug="test-agent",
+        owner="tester",
+        created_by=owner.id,
+        owner_org_id=org_id,
+    )
+    db.add(agent)
+    await db.flush()
+    version = AgentVersion(
+        agent_id=agent.id,
+        version="1.4.0",
+        description="Base",
+        prompt="You are a test agent.",
+        model_name="claude-sonnet-4",
+        supported_harnesses=["claude-code", "cursor"],
+        status=AgentStatus.approved,
+        released_by=owner.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    agent.latest_version_id = version.id
+    await db.flush()
+    return agent
+
+
+async def _skill(
+    db: AsyncSession,
+    *,
+    name: str,
+    submitter: User,
+    version: str = "3.2.0",
+    status: ListingStatus = ListingStatus.approved,
+    is_private: bool = False,
+    org_id: uuid.UUID | None = None,
+    slash_command: str | None = None,
+) -> SkillListing:
+    listing = SkillListing(
+        name=name,
+        namespace="test",
+        slug=name,
+        owner="tester",
+        submitted_by=submitter.id,
+        is_private=is_private,
+        owner_org_id=org_id,
+    )
+    db.add(listing)
+    await db.flush()
+    ver = SkillVersion(
+        listing_id=listing.id,
+        version=version,
+        description=f"{name} does useful things",
+        status=status,
+        task_type="general",
+        delivery_mode="registry_direct",
+        slash_command=slash_command,
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(ver)
+    await db.flush()
+    listing.latest_version_id = ver.id
+    await db.flush()
+    return listing
+
+
+async def _mcp(db: AsyncSession, *, name: str, submitter: User, version: str = "2.0.0") -> McpListing:
+    listing = McpListing(
+        name=name,
+        namespace="test",
+        slug=name,
+        owner="tester",
+        category="databases",
+        submitted_by=submitter.id,
+    )
+    db.add(listing)
+    await db.flush()
+    ver = McpVersion(
+        listing_id=listing.id,
+        version=version,
+        description=f"{name} database access",
+        status=ListingStatus.approved,
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(ver)
+    await db.flush()
+    listing.latest_version_id = ver.id
+    await db.flush()
+    return listing
+
+
+async def _report(db: AsyncSession, agent: Agent, features: list[dict]) -> InsightReport:
+    now = datetime.now(UTC)
+    report = InsightReport(
+        agent_id=agent.id,
+        status=InsightReportStatus.completed,
+        period_start=now,
+        period_end=now,
+        started_at=now,
+        created_at=now,
+        narrative={"suggestions": {"features_to_try": features}},
+    )
+    db.add(report)
+    await db.flush()
+    return report
+
+
+async def _components_of(db: AsyncSession, version_id: uuid.UUID) -> list[AgentComponent]:
+    rows = await db.execute(select(AgentComponent).where(AgentComponent.agent_version_id == version_id))
+    return list(rows.scalars().all())
+
+
+async def _new_version(db: AsyncSession, agent: Agent) -> AgentVersion:
+    rows = await db.execute(
+        select(AgentVersion).where(
+            AgentVersion.agent_id == agent.id,
+            AgentVersion.status == AgentStatus.pending,
+        )
+    )
+    return rows.scalars().one()
+
+
+# ── version pinning ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reused_skill_is_pinned_to_its_actual_version(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    skill = await _skill(db, name="pr-review", submitter=owner, version="3.2.0")
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "name": "pr-review",
+                "existing_component_id": str(skill.id),
+                "one_liner": "Reviews PRs",
+                "why_for_you": "You review PRs often",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    version = await _new_version(db, agent)
+    components = await _components_of(db, version.id)
+    linked = [c for c in components if c.component_id == skill.id]
+    assert len(linked) == 1
+    # The bug this guards: a hardcoded "1.0.0" pin that does not exist.
+    assert linked[0].resolved_version == "3.2.0"
+    assert linked[0].component_name == "pr-review"
+    assert applied["linked_existing"][0]["version"] == "3.2.0"
+
+
+@pytest.mark.asyncio
+async def test_created_skill_keeps_component_name(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "create_new_skill",
+                "feature": "Skill",
+                "name": "scope-guard",
+                "one_liner": "Keeps edits in scope",
+                "why_for_you": "You often over-edit",
+                "example": "1. Read the diff\n2. Reject out-of-scope files",
+            }
+        ],
+    )
+
+    await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    version = await _new_version(db, agent)
+    created = [c for c in await _components_of(db, version.id) if c.component_type == "skill"]
+    assert len(created) == 1
+    assert created[0].resolved_version == "1.0.0"
+    # Empty names degrade the next insight report into showing UUID stubs.
+    assert created[0].component_name != ""
+
+
+# ── cross-tenant isolation ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_private_component_from_another_org_is_not_attached(db: AsyncSession):
+    org_a = await _org(db, "org-a")
+    org_b = await _org(db, "org-b")
+    owner = await _user(db, "owner@a.com", org_id=org_a.id)
+    outsider = await _user(db, "outsider@b.com", org_id=org_b.id)
+    agent = await _agent(db, owner, org_id=org_a.id)
+    foreign = await _skill(
+        db,
+        name="their-secret",
+        submitter=outsider,
+        is_private=True,
+        org_id=org_b.id,
+    )
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(foreign.id),
+                "one_liner": "Secret",
+                "why_for_you": "no",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["linked_existing"] == []
+    assert applied["agent_version"] is None
+
+
+@pytest.mark.asyncio
+async def test_same_org_private_component_is_attachable(db: AsyncSession):
+    org = await _org(db, "org-a")
+    owner = await _user(db, "owner@a.com", org_id=org.id)
+    agent = await _agent(db, owner, org_id=org.id)
+    internal = await _skill(db, name="internal-tool", submitter=owner, is_private=True, org_id=org.id, version="1.7.2")
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(internal.id),
+                "one_liner": "Internal",
+                "why_for_you": "yours",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["linked_existing"][0]["id"] == str(internal.id)
+    assert applied["linked_existing"][0]["version"] == "1.7.2"
+
+
+# ── validation of untrusted ids ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_component_id_is_dropped(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(uuid.uuid4()),
+                "one_liner": "Imaginary",
+                "why_for_you": "nope",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["linked_existing"] == []
+
+
+@pytest.mark.asyncio
+async def test_non_uuid_component_id_is_dropped(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": "registry/some-skill",
+                "one_liner": "Bad id",
+                "why_for_you": "nope",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["linked_existing"] == []
+
+
+@pytest.mark.asyncio
+async def test_unapproved_component_is_not_attached(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    pending = await _skill(db, name="not-ready", submitter=owner, status=ListingStatus.pending)
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(pending.id),
+                "one_liner": "Pending",
+                "why_for_you": "nope",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["linked_existing"] == []
+
+
+@pytest.mark.asyncio
+async def test_mislabelled_type_still_resolves_by_id(db: AsyncSession):
+    """The declared type is a hint; the id is authoritative."""
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    listing = HookListing(name="scope-guard", namespace="test", slug="scope-guard", owner="t", submitted_by=owner.id)
+    db.add(listing)
+    await db.flush()
+    ver = HookVersion(
+        listing_id=listing.id,
+        version="4.1.0",
+        description="Guards scope",
+        status=ListingStatus.approved,
+        event="PreToolUse",
+        handler_type="script",
+        released_by=owner.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(ver)
+    await db.flush()
+    listing.latest_version_id = ver.id
+    await db.flush()
+
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",  # wrong label on purpose
+                "existing_component_id": str(listing.id),
+                "one_liner": "Guards scope",
+                "why_for_you": "you over-edit",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["linked_existing"][0]["type"] == "hook"
+    assert applied["linked_existing"][0]["version"] == "4.1.0"
+
+
+# ── MCP handling ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_existing_mcp_can_be_reused(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    mcp = await _mcp(db, name="postgres-mcp", submitter=owner, version="2.0.0")
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "MCP server",
+                "existing_component_id": str(mcp.id),
+                "one_liner": "Postgres access",
+                "why_for_you": "You query databases constantly",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["linked_existing"][0]["type"] == "mcp"
+    version = await _new_version(db, agent)
+    linked = [c for c in await _components_of(db, version.id) if c.component_type == "mcp"]
+    assert linked[0].resolved_version == "2.0.0"
+
+
+@pytest.mark.asyncio
+async def test_new_mcp_is_never_created(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "create_new_skill",
+                "feature": "MCP server",
+                "name": "sketchy-mcp",
+                "one_liner": "Runs arbitrary commands",
+                "why_for_you": "no",
+                "example": "npx some-server",
+            }
+        ],
+    )
+
+    applied = await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    assert applied["skills"] == []
+    assert applied["hooks"] == []
+    assert applied["agent_version"] is None
+
+
+# ── capability inference ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_capabilities_are_recomputed_for_linked_components(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    skill = await _skill(db, name="slash-skill", submitter=owner, slash_command="/review")
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "Skill",
+                "existing_component_id": str(skill.id),
+                "one_liner": "Slash command skill",
+                "why_for_you": "you review a lot",
+            }
+        ],
+    )
+
+    await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    version = await _new_version(db, agent)
+    assert "skills" in version.required_capabilities
+    # cursor has no `skills` capability, so it must drop out of the inferred set.
+    assert "cursor" not in version.inferred_supported_harnesses
+    assert "claude-code" in version.inferred_supported_harnesses
+
+
+@pytest.mark.asyncio
+async def test_mcp_reuse_does_not_shrink_harness_support(db: AsyncSession):
+    """Every harness supports MCP, so attaching one must not narrow the set."""
+    owner = await _user(db, "owner@example.com")
+    agent = await _agent(db, owner)
+    mcp = await _mcp(db, name="pg-mcp", submitter=owner)
+    report = await _report(
+        db,
+        agent,
+        [
+            {
+                "action_type": "reuse_existing_component",
+                "feature": "MCP server",
+                "existing_component_id": str(mcp.id),
+                "one_liner": "Postgres",
+                "why_for_you": "databases",
+            }
+        ],
+    )
+
+    await apply_insight_suggestions(str(report.id), db, owner.id)
+
+    version = await _new_version(db, agent)
+    assert version.required_capabilities == ["mcp_servers"]
+    assert "cursor" in version.inferred_supported_harnesses
+    assert "claude-code" in version.inferred_supported_harnesses

--- a/tests/test_registry_recommender.py
+++ b/tests/test_registry_recommender.py
@@ -20,7 +20,6 @@ from sqlalchemy.orm import sessionmaker
 from models.base import Base
 from models.hook import HookListing, HookVersion
 from models.mcp import ListingStatus, McpListing, McpVersion
-from models.organization import Organization
 from models.prompt import PromptListing, PromptVersion
 from models.skill import SkillListing, SkillVersion
 from models.user import User
@@ -47,18 +46,11 @@ async def db():
     await engine.dispose()
 
 
-async def _user(db: AsyncSession, email: str, org_id: uuid.UUID | None = None) -> User:
-    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+async def _user(db: AsyncSession, email: str) -> User:
+    user = User(email=email, username=email.split("@")[0], name=email)
     db.add(user)
     await db.flush()
     return user
-
-
-async def _org(db: AsyncSession, slug: str) -> Organization:
-    org = Organization(name=slug.title(), slug=slug)
-    db.add(org)
-    await db.flush()
-    return org
 
 
 async def _skill(
@@ -69,7 +61,6 @@ async def _skill(
     submitter: User,
     status: ListingStatus = ListingStatus.approved,
     is_private: bool = False,
-    org_id: uuid.UUID | None = None,
     downloads: int = 0,
     task_type: str = "general",
 ) -> SkillListing:
@@ -80,7 +71,6 @@ async def _skill(
         owner="tester",
         submitted_by=submitter.id,
         is_private=is_private,
-        owner_org_id=org_id,
     )
     db.add(listing)
     await db.flush()
@@ -200,42 +190,38 @@ async def test_shortlist_returns_public_components(db: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_shortlist_hides_private_components_from_other_orgs(db: AsyncSession):
-    org_a = await _org(db, "org-a")
-    org_b = await _org(db, "org-b")
-    owner = await _user(db, "owner@a.com", org_id=org_a.id)
+async def test_shortlist_hides_private_components_from_other_users(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    outsider = await _user(db, "outsider@example.com")
     await _skill(
         db,
         name="secret-db-tool",
         description="Internal database tooling",
         submitter=owner,
         is_private=True,
-        org_id=org_a.id,
     )
 
-    same_org = await shortlist(db, signals="database", component_types=["skill"], org_id=org_a.id)
-    other_org = await shortlist(db, signals="database", component_types=["skill"], org_id=org_b.id)
-    no_org = await shortlist(db, signals="database", component_types=["skill"], org_id=None)
+    owner_results = await shortlist(db, signals="database", component_types=["skill"], user_id=owner.id)
+    outsider_results = await shortlist(db, signals="database", component_types=["skill"], user_id=outsider.id)
+    anonymous_results = await shortlist(db, signals="database", component_types=["skill"])
 
-    assert [c.name for c in same_org] == ["secret-db-tool"]
-    assert other_org == []
-    assert no_org == []
+    assert [c.name for c in owner_results] == ["secret-db-tool"]
+    assert outsider_results == []
+    assert anonymous_results == []
 
 
 @pytest.mark.asyncio
 async def test_shortlist_shows_private_component_to_its_submitter(db: AsyncSession):
-    org = await _org(db, "org-a")
-    owner = await _user(db, "owner@a.com", org_id=org.id)
+    owner = await _user(db, "owner@example.com")
     await _skill(
         db,
         name="my-db-tool",
         description="Personal database helper",
         submitter=owner,
         is_private=True,
-        org_id=org.id,
     )
 
-    results = await shortlist(db, signals="database", component_types=["skill"], org_id=None, user_id=owner.id)
+    results = await shortlist(db, signals="database", component_types=["skill"], user_id=owner.id)
 
     assert [c.name for c in results] == ["my-db-tool"]
 
@@ -415,21 +401,13 @@ async def test_resolve_components_rejects_unapproved(db: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_resolve_components_rejects_other_org_private(db: AsyncSession):
-    org_a = await _org(db, "org-a")
-    org_b = await _org(db, "org-b")
-    owner = await _user(db, "owner@a.com", org_id=org_a.id)
-    skill = await _skill(
-        db,
-        name="secret",
-        description="Private",
-        submitter=owner,
-        is_private=True,
-        org_id=org_a.id,
-    )
+async def test_resolve_components_rejects_private_listing_for_other_user(db: AsyncSession):
+    owner = await _user(db, "owner@example.com")
+    outsider = await _user(db, "outsider@example.com")
+    skill = await _skill(db, name="secret", description="Private", submitter=owner, is_private=True)
 
-    assert await resolve_components(db, [("skill", skill.id)], org_id=org_b.id) == {}
-    assert await resolve_components(db, [("skill", skill.id)], org_id=org_a.id) != {}
+    assert await resolve_components(db, [("skill", skill.id)], user_id=outsider.id) == {}
+    assert await resolve_components(db, [("skill", skill.id)], user_id=owner.id) != {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_registry_recommender.py
+++ b/tests/test_registry_recommender.py
@@ -1,0 +1,494 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared registry recommender.
+
+Covers the three things every caller depends on: visibility never leaks
+across orgs, ranking puts relevance ahead of popularity, and reference
+resolution rejects anything unapproved, invisible, or mistyped.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.base import Base
+from models.hook import HookListing, HookVersion
+from models.mcp import ListingStatus, McpListing, McpVersion
+from models.organization import Organization
+from models.prompt import PromptListing, PromptVersion
+from models.skill import SkillListing, SkillVersion
+from models.user import User
+from services.registry_recommender import (
+    ComponentCandidate,
+    build_signal_query,
+    coerce_uuid,
+    resolve_component_any_type,
+    resolve_components,
+    shortlist,
+    visibility_clause,
+)
+
+
+@pytest.fixture()
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+        await session.rollback()
+    await engine.dispose()
+
+
+async def _user(db: AsyncSession, email: str, org_id: uuid.UUID | None = None) -> User:
+    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _org(db: AsyncSession, slug: str) -> Organization:
+    org = Organization(name=slug.title(), slug=slug)
+    db.add(org)
+    await db.flush()
+    return org
+
+
+async def _skill(
+    db: AsyncSession,
+    *,
+    name: str,
+    description: str,
+    submitter: User,
+    status: ListingStatus = ListingStatus.approved,
+    is_private: bool = False,
+    org_id: uuid.UUID | None = None,
+    downloads: int = 0,
+    task_type: str = "general",
+) -> SkillListing:
+    listing = SkillListing(
+        name=name,
+        namespace="test",
+        slug=name.lower().replace(" ", "-"),
+        owner="tester",
+        submitted_by=submitter.id,
+        is_private=is_private,
+        owner_org_id=org_id,
+    )
+    db.add(listing)
+    await db.flush()
+    version = SkillVersion(
+        listing_id=listing.id,
+        version="2.3.1",
+        description=description,
+        status=status,
+        task_type=task_type,
+        delivery_mode="registry_direct",
+        download_count=downloads,
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+async def _hook(db: AsyncSession, *, name: str, description: str, submitter: User) -> HookListing:
+    listing = HookListing(
+        name=name,
+        namespace="test",
+        slug=name.lower().replace(" ", "-"),
+        owner="tester",
+        submitted_by=submitter.id,
+    )
+    db.add(listing)
+    await db.flush()
+    version = HookVersion(
+        listing_id=listing.id,
+        version="1.0.0",
+        description=description,
+        status=ListingStatus.approved,
+        event="PreToolUse",
+        handler_type="script",
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+async def _mcp(
+    db: AsyncSession, *, name: str, description: str, submitter: User, category: str = "databases"
+) -> McpListing:
+    listing = McpListing(
+        name=name,
+        namespace="test",
+        slug=name.lower().replace(" ", "-"),
+        owner="tester",
+        category=category,
+        submitted_by=submitter.id,
+    )
+    db.add(listing)
+    await db.flush()
+    version = McpVersion(
+        listing_id=listing.id,
+        version="1.4.0",
+        description=description,
+        status=ListingStatus.approved,
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+async def _prompt(db: AsyncSession, *, name: str, description: str, submitter: User) -> PromptListing:
+    listing = PromptListing(
+        name=name,
+        namespace="test",
+        slug=name.lower().replace(" ", "-"),
+        owner="tester",
+        submitted_by=submitter.id,
+    )
+    db.add(listing)
+    await db.flush()
+    version = PromptVersion(
+        listing_id=listing.id,
+        version="1.0.0",
+        description=description,
+        status=ListingStatus.approved,
+        category="general",
+        template="do the thing",
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+# ── visibility ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shortlist_returns_public_components(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    await _skill(db, name="db-migrator", description="Run database migrations safely", submitter=user)
+
+    results = await shortlist(db, signals="database migrations", component_types=["skill"])
+
+    assert [c.name for c in results] == ["db-migrator"]
+    assert results[0].qualified_name == "test/db-migrator"
+    assert results[0].latest_version == "2.3.1"
+
+
+@pytest.mark.asyncio
+async def test_shortlist_hides_private_components_from_other_orgs(db: AsyncSession):
+    org_a = await _org(db, "org-a")
+    org_b = await _org(db, "org-b")
+    owner = await _user(db, "owner@a.com", org_id=org_a.id)
+    await _skill(
+        db,
+        name="secret-db-tool",
+        description="Internal database tooling",
+        submitter=owner,
+        is_private=True,
+        org_id=org_a.id,
+    )
+
+    same_org = await shortlist(db, signals="database", component_types=["skill"], org_id=org_a.id)
+    other_org = await shortlist(db, signals="database", component_types=["skill"], org_id=org_b.id)
+    no_org = await shortlist(db, signals="database", component_types=["skill"], org_id=None)
+
+    assert [c.name for c in same_org] == ["secret-db-tool"]
+    assert other_org == []
+    assert no_org == []
+
+
+@pytest.mark.asyncio
+async def test_shortlist_shows_private_component_to_its_submitter(db: AsyncSession):
+    org = await _org(db, "org-a")
+    owner = await _user(db, "owner@a.com", org_id=org.id)
+    await _skill(
+        db,
+        name="my-db-tool",
+        description="Personal database helper",
+        submitter=owner,
+        is_private=True,
+        org_id=org.id,
+    )
+
+    results = await shortlist(db, signals="database", component_types=["skill"], org_id=None, user_id=owner.id)
+
+    assert [c.name for c in results] == ["my-db-tool"]
+
+
+@pytest.mark.asyncio
+async def test_visibility_clause_returns_none_for_models_without_privacy():
+    class Bare:
+        pass
+
+    assert visibility_clause(Bare, uuid.uuid4()) is None
+
+
+# ── filtering ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shortlist_skips_unapproved_versions(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    await _skill(
+        db,
+        name="pending-db-tool",
+        description="Database tooling",
+        submitter=user,
+        status=ListingStatus.pending,
+    )
+
+    assert await shortlist(db, signals="database", component_types=["skill"]) == []
+
+
+@pytest.mark.asyncio
+async def test_shortlist_skips_listing_without_latest_version(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    listing = SkillListing(
+        name="orphan-db",
+        namespace="test",
+        slug="orphan-db",
+        owner="tester",
+        submitted_by=user.id,
+    )
+    db.add(listing)
+    await db.flush()
+
+    assert await shortlist(db, signals="database", component_types=["skill"]) == []
+
+
+@pytest.mark.asyncio
+async def test_shortlist_honours_exclude_ids(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    attached = await _skill(db, name="db-attached", description="Database work", submitter=user)
+    await _skill(db, name="db-available", description="Database work", submitter=user)
+
+    results = await shortlist(db, signals="database", component_types=["skill"], exclude_ids=[attached.id])
+
+    assert [c.name for c in results] == ["db-available"]
+
+
+@pytest.mark.asyncio
+async def test_shortlist_caps_results_per_type_and_total(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    for i in range(10):
+        await _skill(db, name=f"db-skill-{i}", description="Database tooling", submitter=user)
+
+    results = await shortlist(
+        db,
+        signals="database",
+        component_types=["skill"],
+        per_type_limit=3,
+        total_limit=2,
+    )
+
+    assert len(results) == 2
+
+
+# ── ranking ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_relevance_outranks_popularity(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    await _skill(
+        db,
+        name="popular-linter",
+        description="Lint your code",
+        submitter=user,
+        downloads=100_000,
+    )
+    await _skill(
+        db,
+        name="postgres-migration-runner",
+        description="Run postgres database migrations",
+        submitter=user,
+        downloads=0,
+    )
+
+    results = await shortlist(db, signals="postgres database migrations", component_types=["skill"])
+
+    assert results[0].name == "postgres-migration-runner"
+
+
+@pytest.mark.asyncio
+async def test_popularity_breaks_ties_between_equally_relevant(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    await _skill(db, name="db-tool-quiet", description="Database tooling", submitter=user, downloads=0)
+    await _skill(db, name="db-tool-loud", description="Database tooling", submitter=user, downloads=500)
+
+    results = await shortlist(db, signals="database tooling", component_types=["skill"])
+
+    assert results[0].name == "db-tool-loud"
+
+
+@pytest.mark.asyncio
+async def test_empty_signals_fall_back_to_popularity(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    await _skill(db, name="quiet", description="Something", submitter=user, downloads=1)
+    await _skill(db, name="loud", description="Something", submitter=user, downloads=99)
+
+    # "the" and "a" are stop words, so no usable tokens survive.
+    results = await shortlist(db, signals="the a", component_types=["skill"])
+
+    assert [c.name for c in results] == ["loud", "quiet"]
+
+
+@pytest.mark.asyncio
+async def test_shortlist_spans_multiple_component_types(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    await _skill(db, name="db-skill", description="Database migrations", submitter=user)
+    await _mcp(db, name="db-mcp", description="Database access server", submitter=user)
+    await _prompt(db, name="db-prompt", description="Database review prompt", submitter=user)
+
+    results = await shortlist(db, signals="database", component_types=["skill", "mcp", "prompt"])
+
+    assert {c.component_type for c in results} == {"skill", "mcp", "prompt"}
+
+
+@pytest.mark.asyncio
+async def test_matched_terms_are_recorded(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    await _skill(db, name="db-migrator", description="Handles postgres migrations", submitter=user)
+
+    results = await shortlist(db, signals="postgres migration", component_types=["skill"])
+
+    assert "postgres" in results[0].matched_terms
+
+
+# ── reference resolution ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_components_returns_validated_reference(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    skill = await _skill(db, name="db-migrator", description="Database migrations", submitter=user)
+
+    resolved = await resolve_components(db, [("skill", skill.id)])
+
+    hit = resolved[("skill", skill.id)]
+    assert hit.qualified_name == "test/db-migrator"
+    assert hit.latest_version == "2.3.1"
+    assert hit.to_ref()["type"] == "skill"
+
+
+@pytest.mark.asyncio
+async def test_resolve_components_rejects_wrong_type(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    skill = await _skill(db, name="db-migrator", description="Database migrations", submitter=user)
+
+    resolved = await resolve_components(db, [("hook", skill.id)])
+
+    assert resolved == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_components_rejects_unapproved(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    skill = await _skill(db, name="db-migrator", description="Database", submitter=user, status=ListingStatus.pending)
+
+    assert await resolve_components(db, [("skill", skill.id)]) == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_components_rejects_other_org_private(db: AsyncSession):
+    org_a = await _org(db, "org-a")
+    org_b = await _org(db, "org-b")
+    owner = await _user(db, "owner@a.com", org_id=org_a.id)
+    skill = await _skill(
+        db,
+        name="secret",
+        description="Private",
+        submitter=owner,
+        is_private=True,
+        org_id=org_a.id,
+    )
+
+    assert await resolve_components(db, [("skill", skill.id)], org_id=org_b.id) == {}
+    assert await resolve_components(db, [("skill", skill.id)], org_id=org_a.id) != {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_components_ignores_unknown_type(db: AsyncSession):
+    assert await resolve_components(db, [("nonsense", uuid.uuid4())]) == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_component_any_type_finds_correct_type(db: AsyncSession):
+    user = await _user(db, "a@example.com")
+    hook = await _hook(db, name="guard", description="Scope guard", submitter=user)
+
+    hit = await resolve_component_any_type(db, hook.id)
+
+    assert hit is not None
+    assert hit.component_type == "hook"
+
+
+@pytest.mark.asyncio
+async def test_resolve_component_any_type_returns_none_for_unknown_id(db: AsyncSession):
+    assert await resolve_component_any_type(db, uuid.uuid4()) is None
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def test_coerce_uuid_accepts_valid_forms():
+    value = uuid.uuid4()
+    assert coerce_uuid(value) == value
+    assert coerce_uuid(str(value)) == value
+    assert coerce_uuid(f"  {value}  ") == value
+
+
+@pytest.mark.parametrize("bad", ["", None, "not-a-uuid", "registry/skill-name", 42, [], {}])
+def test_coerce_uuid_rejects_junk(bad):
+    assert coerce_uuid(bad) is None
+
+
+def test_build_signal_query_flattens_and_dedupes():
+    query = build_signal_query("database", ["Database", "migrations"], None, "", ["testing"])
+    assert query == "database migrations testing"
+
+
+def test_catalog_entry_stays_compact():
+    candidate = ComponentCandidate(
+        component_type="skill",
+        id=uuid.uuid4(),
+        name="db-migrator",
+        namespace="test",
+        slug="db-migrator",
+        description="x" * 500,
+        latest_version="1.0.0",
+        download_count=3,
+        score=1.0,
+        matched_terms=["database"],
+    )
+
+    entry = candidate.to_catalog_entry()
+
+    assert len(entry["description"]) == 160
+    assert entry["qualified_name"] == "test/db-migrator"
+    assert entry["matched_on"] == ["database"]

--- a/tests/test_registry_recommender_stress.py
+++ b/tests/test_registry_recommender_stress.py
@@ -15,7 +15,7 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from models.base import Base
@@ -47,6 +47,22 @@ async def db():
     async with async_session() as session:
         yield session
         await session.rollback()
+    await engine.dispose()
+
+
+@pytest.fixture()
+async def session_factory(tmp_path):
+    """A file-backed engine, so each task can hold its own session.
+
+    An ``AsyncSession`` is stateful and unsafe to share across concurrent
+    tasks. A ``:memory:`` database cannot substitute here either: every
+    connection would get its own empty database, so the seeded rows would be
+    invisible to the tasks under test.
+    """
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'stress.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     await engine.dispose()
 
 
@@ -176,20 +192,28 @@ async def test_no_org_leak_across_many_orgs(db: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_shortlists_stay_isolated(db: AsyncSession):
+async def test_concurrent_shortlists_stay_isolated(session_factory):
     """Concurrency must not bleed one org's results into another's."""
-    org_a = Organization(name="A", slug="a")
-    org_b = Organization(name="B", slug="b")
-    db.add_all([org_a, org_b])
-    await db.flush()
-    ua = await _user(db, "a@a.com", org_id=org_a.id)
-    ub = await _user(db, "b@b.com", org_id=org_b.id)
-    await _skill(db, name="a-secret", description="database", submitter=ua, is_private=True, org_id=org_a.id)
-    await _skill(db, name="b-secret", description="database", submitter=ub, is_private=True, org_id=org_b.id)
+    async with session_factory() as seed:
+        org_a = Organization(name="A", slug="a")
+        org_b = Organization(name="B", slug="b")
+        seed.add_all([org_a, org_b])
+        await seed.flush()
+        ua = await _user(seed, "a@a.com", org_id=org_a.id)
+        ub = await _user(seed, "b@b.com", org_id=org_b.id)
+        await _skill(seed, name="a-secret", description="database", submitter=ua, is_private=True, org_id=org_a.id)
+        await _skill(seed, name="b-secret", description="database", submitter=ub, is_private=True, org_id=org_b.id)
+        await seed.commit()
+        org_a_id, org_b_id = org_a.id, org_b.id
+
+    async def run(org_id):
+        # Each task gets its own session; sharing one would be a data race.
+        async with session_factory() as session:
+            return await shortlist(session, signals="database", org_id=org_id)
 
     results = await asyncio.gather(
-        *[shortlist(db, signals="database", org_id=org_a.id) for _ in range(5)],
-        *[shortlist(db, signals="database", org_id=org_b.id) for _ in range(5)],
+        *[run(org_a_id) for _ in range(5)],
+        *[run(org_b_id) for _ in range(5)],
     )
 
     for r in results[:5]:

--- a/tests/test_registry_recommender_stress.py
+++ b/tests/test_registry_recommender_stress.py
@@ -5,7 +5,7 @@
 
 Two untrusted inputs reach this code: registry text written by publishers
 (names, descriptions) and the signal string derived from telemetry. Neither
-may crash the caller, leak across tenants, or alter a query.
+may crash the caller, leak across users, or alter a query.
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from sqlalchemy.orm import sessionmaker
 
 from models.base import Base
 from models.mcp import ListingStatus
-from models.organization import Organization
 from models.skill import SkillListing, SkillVersion
 from models.user import User
 from services.insights.registry_match import (
@@ -66,22 +65,28 @@ async def session_factory(tmp_path):
     await engine.dispose()
 
 
-async def _user(db: AsyncSession, email: str = "a@example.com", org_id=None) -> User:
-    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+async def _user(db: AsyncSession, email: str = "a@example.com") -> User:
+    user = User(email=email, username=email.split("@")[0], name=email)
     db.add(user)
     await db.flush()
     return user
 
 
-async def _skill(db: AsyncSession, *, name: str, description: str, submitter: User, **kw) -> SkillListing:
+async def _skill(
+    db: AsyncSession,
+    *,
+    name: str,
+    description: str,
+    submitter: User,
+    is_private: bool = False,
+) -> SkillListing:
     listing = SkillListing(
         name=name,
         namespace="test",
         slug=name.lower().replace(" ", "-")[:60],
         owner="t",
         submitted_by=submitter.id,
-        is_private=kw.get("is_private", False),
-        owner_org_id=kw.get("org_id"),
+        is_private=is_private,
     )
     db.add(listing)
     await db.flush()
@@ -164,56 +169,48 @@ async def test_hostile_registry_text_is_returned_verbatim_not_executed(db: Async
     assert await shortlist(db, signals="database", component_types=["skill"])
 
 
-# ── tenant isolation under stress ─────────────────────────────────────────
+# ── private visibility under stress ───────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_no_org_leak_across_many_orgs(db: AsyncSession):
-    orgs = []
+async def test_no_private_leak_across_many_users(db: AsyncSession):
+    users = []
     for i in range(6):
-        org = Organization(name=f"org{i}", slug=f"org-{i}")
-        db.add(org)
-        await db.flush()
-        orgs.append(org)
-        owner = await _user(db, f"o{i}@x.com", org_id=org.id)
+        owner = await _user(db, f"o{i}@x.com")
+        users.append(owner)
         await _skill(
             db,
             name=f"secret-db-{i}",
             description="Database migrations internal",
             submitter=owner,
             is_private=True,
-            org_id=org.id,
         )
 
-    for i, org in enumerate(orgs):
-        results = await shortlist(db, signals="database migrations", org_id=org.id)
+    for i, user in enumerate(users):
+        results = await shortlist(db, signals="database migrations", user_id=user.id)
         names = {c.name for c in results}
-        assert names == {f"secret-db-{i}"}, f"org {i} saw {names}"
+        assert names == {f"secret-db-{i}"}, f"user {i} saw {names}"
 
 
 @pytest.mark.asyncio
 async def test_concurrent_shortlists_stay_isolated(session_factory):
-    """Concurrency must not bleed one org's results into another's."""
+    """Concurrency must not bleed one user's results into another's."""
     async with session_factory() as seed:
-        org_a = Organization(name="A", slug="a")
-        org_b = Organization(name="B", slug="b")
-        seed.add_all([org_a, org_b])
-        await seed.flush()
-        ua = await _user(seed, "a@a.com", org_id=org_a.id)
-        ub = await _user(seed, "b@b.com", org_id=org_b.id)
-        await _skill(seed, name="a-secret", description="database", submitter=ua, is_private=True, org_id=org_a.id)
-        await _skill(seed, name="b-secret", description="database", submitter=ub, is_private=True, org_id=org_b.id)
+        ua = await _user(seed, "a@example.com")
+        ub = await _user(seed, "b@example.com")
+        await _skill(seed, name="a-secret", description="database", submitter=ua, is_private=True)
+        await _skill(seed, name="b-secret", description="database", submitter=ub, is_private=True)
         await seed.commit()
-        org_a_id, org_b_id = org_a.id, org_b.id
+        user_a_id, user_b_id = ua.id, ub.id
 
-    async def run(org_id):
+    async def run(user_id):
         # Each task gets its own session; sharing one would be a data race.
         async with session_factory() as session:
-            return await shortlist(session, signals="database", org_id=org_id)
+            return await shortlist(session, signals="database", user_id=user_id)
 
     results = await asyncio.gather(
-        *[run(org_a_id) for _ in range(5)],
-        *[run(org_b_id) for _ in range(5)],
+        *[run(user_a_id) for _ in range(5)],
+        *[run(user_b_id) for _ in range(5)],
     )
 
     for r in results[:5]:

--- a/tests/test_registry_recommender_stress.py
+++ b/tests/test_registry_recommender_stress.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stress and adversarial tests for the shared recommender.
+
+Two untrusted inputs reach this code: registry text written by publishers
+(names, descriptions) and the signal string derived from telemetry. Neither
+may crash the caller, leak across tenants, or alter a query.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.base import Base
+from models.mcp import ListingStatus
+from models.organization import Organization
+from models.skill import SkillListing, SkillVersion
+from models.user import User
+from services.insights.registry_match import (
+    CatalogOffer,
+    RegistryScope,
+    build_signals,
+    catalog_block,
+    validate_reuse_suggestions,
+)
+from services.registry_recommender import (
+    build_signal_query,
+    coerce_uuid,
+    resolve_components,
+    shortlist,
+)
+
+
+@pytest.fixture()
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+        await session.rollback()
+    await engine.dispose()
+
+
+async def _user(db: AsyncSession, email: str = "a@example.com", org_id=None) -> User:
+    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _skill(db: AsyncSession, *, name: str, description: str, submitter: User, **kw) -> SkillListing:
+    listing = SkillListing(
+        name=name,
+        namespace="test",
+        slug=name.lower().replace(" ", "-")[:60],
+        owner="t",
+        submitted_by=submitter.id,
+        is_private=kw.get("is_private", False),
+        owner_org_id=kw.get("org_id"),
+    )
+    db.add(listing)
+    await db.flush()
+    version = SkillVersion(
+        listing_id=listing.id,
+        version="1.0.0",
+        description=description,
+        status=ListingStatus.approved,
+        task_type="general",
+        delivery_mode="registry_direct",
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+# ── hostile signal strings ────────────────────────────────────────────────
+
+HOSTILE_SIGNALS = [
+    "'; DROP TABLE skill_listings; --",
+    "%%%%%%",  # LIKE wildcards
+    "_" * 200,  # LIKE single-char wildcards
+    "\\%\\_",  # escaped wildcards
+    "' OR '1'='1",
+    "<script>alert(1)</script>",
+    "../../etc/passwd",
+    "\x00\x01\x02",
+    "ünïcodé ✨ 中文",
+    "a" * 20000,  # very long
+    "\n\r\t",
+    "{}{}{}",  # format-string shaped
+    "{ids:Array(String)}",  # clickhouse param shaped
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signals", HOSTILE_SIGNALS)
+async def test_shortlist_survives_hostile_signals(db: AsyncSession, signals):
+    user = await _user(db)
+    await _skill(db, name="db-tool", description="Database migrations", submitter=user)
+
+    results = await shortlist(db, signals=signals, component_types=["skill"])
+
+    assert isinstance(results, list)
+
+
+@pytest.mark.asyncio
+async def test_wildcards_do_not_match_everything(db: AsyncSession):
+    """A LIKE wildcard in the signal must not turn into 'select all'."""
+    user = await _user(db)
+    await _skill(db, name="alpha", description="Totally unrelated thing", submitter=user)
+    await _skill(db, name="beta", description="Also unrelated", submitter=user)
+
+    results = await shortlist(db, signals="%", component_types=["skill"])
+
+    # "%" yields no usable tokens, so this falls back to popularity ordering
+    # rather than a wildcard match. Either way it must not error.
+    assert isinstance(results, list)
+
+
+@pytest.mark.asyncio
+async def test_hostile_registry_text_is_returned_verbatim_not_executed(db: AsyncSession):
+    user = await _user(db)
+    await _skill(
+        db,
+        name="evil",
+        description="'; DROP TABLE skill_listings; -- database",
+        submitter=user,
+    )
+
+    results = await shortlist(db, signals="database", component_types=["skill"])
+
+    assert len(results) == 1
+    assert "DROP TABLE" in results[0].description
+    # The table still exists.
+    assert await shortlist(db, signals="database", component_types=["skill"])
+
+
+# ── tenant isolation under stress ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_org_leak_across_many_orgs(db: AsyncSession):
+    orgs = []
+    for i in range(6):
+        org = Organization(name=f"org{i}", slug=f"org-{i}")
+        db.add(org)
+        await db.flush()
+        orgs.append(org)
+        owner = await _user(db, f"o{i}@x.com", org_id=org.id)
+        await _skill(
+            db,
+            name=f"secret-db-{i}",
+            description="Database migrations internal",
+            submitter=owner,
+            is_private=True,
+            org_id=org.id,
+        )
+
+    for i, org in enumerate(orgs):
+        results = await shortlist(db, signals="database migrations", org_id=org.id)
+        names = {c.name for c in results}
+        assert names == {f"secret-db-{i}"}, f"org {i} saw {names}"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_shortlists_stay_isolated(db: AsyncSession):
+    """Concurrency must not bleed one org's results into another's."""
+    org_a = Organization(name="A", slug="a")
+    org_b = Organization(name="B", slug="b")
+    db.add_all([org_a, org_b])
+    await db.flush()
+    ua = await _user(db, "a@a.com", org_id=org_a.id)
+    ub = await _user(db, "b@b.com", org_id=org_b.id)
+    await _skill(db, name="a-secret", description="database", submitter=ua, is_private=True, org_id=org_a.id)
+    await _skill(db, name="b-secret", description="database", submitter=ub, is_private=True, org_id=org_b.id)
+
+    results = await asyncio.gather(
+        *[shortlist(db, signals="database", org_id=org_a.id) for _ in range(5)],
+        *[shortlist(db, signals="database", org_id=org_b.id) for _ in range(5)],
+    )
+
+    for r in results[:5]:
+        assert {c.name for c in r} == {"a-secret"}
+    for r in results[5:]:
+        assert {c.name for c in r} == {"b-secret"}
+
+
+# ── validation gate under hostile LLM output ──────────────────────────────
+
+HOSTILE_REFS = [
+    "'; DROP TABLE agents; --",
+    "../../../etc/passwd",
+    "<script>alert(1)</script>",
+    "00000000-0000-0000-0000-000000000000",
+    "not-a-uuid",
+    "",
+    None,
+    12345,
+    {"nested": "object"},
+    ["a", "list"],
+    "  " + str(uuid.uuid4()) + "  ",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_ref", HOSTILE_REFS)
+async def test_validation_gate_rejects_hostile_refs(db: AsyncSession, bad_ref):
+    await _user(db)
+    narrative = {
+        "suggestions": {
+            "features_to_try": [
+                {
+                    "action_type": "reuse_existing_component",
+                    "feature": "Skill",
+                    "existing_component_id": bad_ref,
+                }
+            ]
+        }
+    }
+
+    result = await validate_reuse_suggestions(narrative, CatalogOffer(), db, RegistryScope())
+
+    feature = result["suggestions"]["features_to_try"][0]
+    assert feature.get("component_ref") is None
+
+
+@pytest.mark.asyncio
+async def test_validation_gate_handles_many_features(db: AsyncSession):
+    user = await _user(db)
+    skill = await _skill(db, name="real", description="database", submitter=user)
+    features = [
+        {
+            "action_type": "reuse_existing_component",
+            "feature": "Skill",
+            "existing_component_id": str(uuid.uuid4()),
+        }
+        for _ in range(200)
+    ]
+    features.append(
+        {
+            "action_type": "reuse_existing_component",
+            "feature": "Skill",
+            "existing_component_id": str(skill.id),
+        }
+    )
+    narrative = {"suggestions": {"features_to_try": features}}
+
+    result = await validate_reuse_suggestions(narrative, CatalogOffer(offered_ids={skill.id}), db, RegistryScope())
+
+    kept = [f for f in result["suggestions"]["features_to_try"] if f.get("component_ref")]
+    assert len(kept) == 1
+    assert kept[0]["component_ref"]["name"] == "real"
+
+
+@pytest.mark.asyncio
+async def test_resolve_components_ignores_non_uuid_entries(db: AsyncSession):
+    assert await resolve_components(db, [("skill", "not-a-uuid")]) == {}  # type: ignore[list-item]
+
+
+# ── signal builders under junk ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "agg",
+    [
+        {"top_tools": None},
+        {"top_tools": "a string"},
+        {"top_tools": [None, [], {}, 42]},
+        {"top_languages": {"Python": 3}},
+        {"tool_error_categories": None},
+        {"top_tools": [["mcp__", 1]]},
+    ],
+)
+def test_build_signals_never_raises(agg):
+    assert isinstance(build_signals(agg=agg), str)
+
+
+@pytest.mark.parametrize(
+    "facets",
+    [
+        {"goal_categories": None},
+        {"repeated_instructions": [{"nope": 1}]},
+        {"repeated_instructions": "string"},
+        {"friction_types": [[None, 2]]},
+    ],
+)
+def test_build_signals_never_raises_on_facets(facets):
+    assert isinstance(build_signals(facets_summary=facets), str)
+
+
+def test_build_signal_query_ignores_none_and_blank():
+    assert build_signal_query(None, "", [None, "", "ok"]) == "ok"
+
+
+def test_catalog_block_escapes_nothing_but_stays_json():
+    import json
+
+    offer = CatalogOffer(
+        entries_by_type={"skills": [{"id": "x", "name": "</script>", "description": 'a"b'}]},
+        offered_ids={uuid.uuid4()},
+    )
+    block = catalog_block(offer)
+    # The payload must remain valid JSON so the prompt cannot be broken apart.
+    start = block.index("{")
+    json.loads(block[start:])
+
+
+@pytest.mark.parametrize("value", ["", None, "x", 0, [], {}, "0" * 40])
+def test_coerce_uuid_is_total(value):
+    assert coerce_uuid(value) is None or isinstance(coerce_uuid(value), uuid.UUID)

--- a/tests/test_user_profile_hardening.py
+++ b/tests/test_user_profile_hardening.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import pytest
 
-from services.user_profile import _id_array, _mcp_server_name, _topics_for
+from services.user_profile import _id_array, _mcp_server_name, _topics_for, users_with_recent_activity
 
 # Each of these, if admitted, would change how ClickHouse parses the literal.
 HOSTILE_IDS = [
@@ -120,3 +120,66 @@ def test_mcp_server_name_never_raises(tool):
 def test_topics_tolerate_junk():
     topics = _topics_for(["", "\x00", "a" * 5000, "postgres"])
     assert "databases" in topics
+
+
+# ── Active-user lookup (drives the nightly sweep's scope) ──────────────────
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_active_users_returns_project_user_pairs(monkeypatch):
+    rows = {
+        "data": [
+            {"project_id": "org-a", "user_id": "u1"},
+            {"project_id": "org-a", "user_id": "u2"},
+            {"project_id": "default", "user_id": "u3"},
+        ]
+    }
+
+    async def fake_query(sql: str, params: dict):
+        assert "session_stats_agg" in sql
+        assert "param_since" in params
+        return _FakeResponse(rows)
+
+    monkeypatch.setattr("services.user_profile._query", fake_query)
+
+    active = await users_with_recent_activity()
+
+    assert active == {("org-a", "u1"), ("org-a", "u2"), ("default", "u3")}
+
+
+@pytest.mark.asyncio
+async def test_active_users_returns_none_when_lookup_fails(monkeypatch):
+    """None, not an empty set.
+
+    An empty set means "nobody is active" and would skip every user; None
+    tells the sweep to fall back to trying everyone. A telemetry outage must
+    degrade the job, not silently switch it off.
+    """
+
+    async def boom(sql: str, params: dict):
+        raise RuntimeError("clickhouse unreachable")
+
+    monkeypatch.setattr("services.user_profile._query", boom)
+
+    assert await users_with_recent_activity() is None
+
+
+@pytest.mark.asyncio
+async def test_active_users_empty_result_is_an_empty_set(monkeypatch):
+    async def fake_query(sql: str, params: dict):
+        return _FakeResponse({"data": []})
+
+    monkeypatch.setattr("services.user_profile._query", fake_query)
+
+    assert await users_with_recent_activity() == set()

--- a/tests/test_user_profile_hardening.py
+++ b/tests/test_user_profile_hardening.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adversarial tests for the ClickHouse array literal built from session ids.
+
+Session ids arrive from client-supplied ingest payloads, so they are
+untrusted input that ends up inside a hand-built ClickHouse array literal.
+These tests pin the allowlist behaviour: anything that could alter the shape
+of that literal must be dropped, never escaped-and-kept.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.user_profile import _id_array, _mcp_server_name, _topics_for
+
+# Each of these, if admitted, would change how ClickHouse parses the literal.
+HOSTILE_IDS = [
+    "a'",  # bare quote
+    "a\\",  # trailing backslash escapes the closing quote
+    "a\\'",  # escaped quote
+    "a','b",  # element separator
+    "') OR 1=1 --",  # classic break-out
+    "a]",  # closes the array
+    "a[",  # opens an array
+    "a,b",  # separator without quotes
+    "a b",  # whitespace
+    "a\nb",  # newline
+    "a\tb",
+    "a\x00b",  # null byte
+    "/*c*/",  # slashes are not in the charset
+    "a`b",
+    'a"b',
+    "ünïcodé",  # non-ascii
+    "a" * 500,  # over length
+    "",  # empty
+]
+
+
+@pytest.mark.parametrize("hostile", HOSTILE_IDS)
+def test_hostile_session_ids_are_dropped(hostile):
+    literal = _id_array([hostile])
+
+    assert literal == "[]", f"{hostile!r} survived into the literal"
+
+
+def test_legitimate_ids_survive():
+    ids = [
+        "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+        "session_123",
+        "abc.def",
+        "a:b",
+        "ABC-123",
+    ]
+
+    literal = _id_array(ids)
+
+    for sid in ids:
+        assert f"'{sid}'" in literal
+    assert literal.startswith("[") and literal.endswith("]")
+
+
+def test_hostile_ids_do_not_contaminate_good_ones():
+    """One bad id must not break the literal for the rest."""
+    literal = _id_array(["good-1", "a\\", "good-2", "') OR 1=1 --"])
+
+    assert literal == "['good-1','good-2']"
+
+
+def test_literal_never_contains_escape_characters():
+    literal = _id_array(["a\\", "b'", "c" * 10])
+
+    assert "\\" not in literal
+    # Quotes appear only as the delimiters we emitted.
+    assert literal.count("'") % 2 == 0
+
+
+def test_sql_metacharacters_inside_the_charset_are_inert():
+    """`--` is admitted but harmless: it cannot escape the surrounding quotes.
+
+    Hyphens must stay legal (uuids contain them). Because the allowlist bars
+    quotes and backslashes, the value can never terminate its literal, so a
+    comment marker inside it is just two characters of a string.
+    """
+    literal = _id_array(["--comment"])
+
+    assert literal == "['--comment']"
+    assert "\\" not in literal
+
+
+def test_empty_input_yields_empty_array():
+    assert _id_array([]) == "[]"
+
+
+def test_none_entries_are_tolerated():
+    assert _id_array([None, "ok-1"]) == "['ok-1']"  # type: ignore[list-item]
+
+
+def test_array_is_capped():
+    from services.user_profile import MAX_ID_ARRAY
+
+    literal = _id_array([f"id-{i}" for i in range(MAX_ID_ARRAY + 50)])
+
+    assert literal.count("','") == MAX_ID_ARRAY - 1
+
+
+# ── profile helpers under hostile input ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "tool",
+    ["mcp__", "mcp____x", "mcp", "", "mcp__x", "MCP__Postgres__query", "mcp__a__b__c"],
+)
+def test_mcp_server_name_never_raises(tool):
+    result = _mcp_server_name(tool)
+    assert result is None or isinstance(result, str)
+
+
+def test_topics_tolerate_junk():
+    topics = _topics_for(["", "\x00", "a" * 5000, "postgres"])
+    assert "databases" in topics

--- a/tests/test_user_recommendations.py
+++ b/tests/test_user_recommendations.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for per-user registry recommendations.
+
+Covers the deterministic half: profile shaping, exclusion of things the user
+already has or dismissed, org-scoped visibility, and honest cold-start
+behaviour.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from models.agent import Agent, AgentStatus, AgentVersion
+from models.agent_component import AgentComponent
+from models.base import Base
+from models.download import AgentDownloadRecord
+from models.mcp import ListingStatus, McpListing, McpVersion
+from models.organization import Organization
+from models.skill import SkillListing, SkillVersion
+from models.user import User
+from services.user_profile import WorkProfile, _mcp_server_name, _topics_for
+from services.user_recommendations import recommend_for_user, record_feedback
+
+if TYPE_CHECKING:
+    import uuid
+
+
+@pytest.fixture()
+async def db():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+        await session.rollback()
+    await engine.dispose()
+
+
+async def _user(db: AsyncSession, email: str = "dev@example.com", org_id=None) -> User:
+    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _skill(
+    db: AsyncSession,
+    *,
+    name: str,
+    submitter: User,
+    description: str,
+    downloads: int = 0,
+    is_private: bool = False,
+    org_id=None,
+) -> SkillListing:
+    listing = SkillListing(
+        name=name,
+        namespace="test",
+        slug=name,
+        owner="t",
+        submitted_by=submitter.id,
+        is_private=is_private,
+        owner_org_id=org_id,
+    )
+    db.add(listing)
+    await db.flush()
+    version = SkillVersion(
+        listing_id=listing.id,
+        version="1.0.0",
+        description=description,
+        status=ListingStatus.approved,
+        task_type="general",
+        delivery_mode="registry_direct",
+        download_count=downloads,
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+async def _mcp(db: AsyncSession, *, name: str, submitter: User, description: str) -> McpListing:
+    listing = McpListing(
+        name=name, namespace="test", slug=name, owner="t", category="databases", submitted_by=submitter.id
+    )
+    db.add(listing)
+    await db.flush()
+    version = McpVersion(
+        listing_id=listing.id,
+        version="1.0.0",
+        description=description,
+        status=ListingStatus.approved,
+        released_by=submitter.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    listing.latest_version_id = version.id
+    await db.flush()
+    return listing
+
+
+async def _installed_agent_with(db: AsyncSession, user: User, component_id: uuid.UUID) -> None:
+    """Give `user` an installed agent that bundles `component_id`."""
+    agent = Agent(name="a", namespace="test", slug="a", owner="t", created_by=user.id)
+    db.add(agent)
+    await db.flush()
+    version = AgentVersion(
+        agent_id=agent.id,
+        version="1.0.0",
+        description="d",
+        prompt="p",
+        model_name="claude-sonnet-4",
+        status=AgentStatus.approved,
+        released_by=user.id,
+        released_at=datetime.now(UTC),
+    )
+    db.add(version)
+    await db.flush()
+    agent.latest_version_id = version.id
+    db.add(
+        AgentComponent(
+            agent_version_id=version.id,
+            component_type="skill",
+            component_id=component_id,
+            component_name="x",
+            resolved_version="1.0.0",
+            order_index=0,
+        )
+    )
+    db.add(AgentDownloadRecord(agent_id=agent.id, user_id=user.id, source="cli"))
+    await db.flush()
+
+
+DB_PROFILE = WorkProfile(
+    languages=["Python"],
+    tools=["Bash"],
+    mcp_servers=["postgres"],
+    topics=["databases"],
+    session_count=12,
+)
+
+
+# ── profile helpers ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "expected"),
+    [
+        ("mcp__postgres__query", "postgres"),
+        ("mcp__github__create_pr", "github"),
+        ("Bash", None),
+        ("mcp__", None),
+        ("", None),
+    ],
+)
+def test_mcp_server_name_extraction(tool_name, expected):
+    assert _mcp_server_name(tool_name) == expected
+
+
+def test_topics_bucket_known_terms():
+    topics = _topics_for(["postgres", "Docker", "pytest", "totally-unknown-thing"])
+    assert "databases" in topics
+    assert "infrastructure" in topics
+    assert "testing" in topics
+
+
+def test_empty_profile_reports_itself_empty():
+    assert WorkProfile().is_empty()
+    assert not DB_PROFILE.is_empty()
+
+
+def test_profile_search_signals_include_topics_and_servers():
+    signals = DB_PROFILE.search_signals()
+    assert "databases" in signals
+    assert "postgres" in signals
+
+
+def test_profile_roundtrips_through_dict():
+    restored = WorkProfile.from_dict(DB_PROFILE.to_dict(), session_count=12)
+    assert restored.topics == DB_PROFILE.topics
+    assert restored.mcp_servers == DB_PROFILE.mcp_servers
+    assert restored.session_count == 12
+
+
+def test_profile_from_dict_tolerates_missing_keys():
+    profile = WorkProfile.from_dict({})
+    assert profile.is_empty()
+    assert profile.languages == []
+
+
+# ── ranking ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recommendations_match_profile_topics(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="db-migrator", submitter=user, description="Postgres database migrations")
+    await _skill(db, name="css-helper", submitter=user, description="Tailwind styling helper")
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+
+    assert results
+    assert results[0].candidate.name == "db-migrator"
+    assert "database" in results[0].reason.lower() or "postgres" in results[0].reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_recommendations_span_component_types(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="db-skill", submitter=user, description="database work")
+    await _mcp(db, name="db-mcp", submitter=user, description="postgres database server")
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+
+    assert {r.candidate.component_type for r in results} == {"skill", "mcp"}
+
+
+@pytest.mark.asyncio
+async def test_already_installed_components_are_excluded(db: AsyncSession):
+    user = await _user(db)
+    installed = await _skill(db, name="db-installed", submitter=user, description="database migrations")
+    await _skill(db, name="db-fresh", submitter=user, description="database migrations")
+    await _installed_agent_with(db, user, installed.id)
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+
+    names = [r.candidate.name for r in results]
+    assert "db-installed" not in names
+    assert "db-fresh" in names
+
+
+@pytest.mark.asyncio
+async def test_dismissed_components_stay_dismissed(db: AsyncSession):
+    user = await _user(db)
+    unwanted = await _skill(db, name="db-unwanted", submitter=user, description="database migrations")
+
+    before = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    assert "db-unwanted" in [r.candidate.name for r in before]
+
+    await record_feedback(db, user.id, "skill", unwanted.id, "dismissed")
+    after = await recommend_for_user(db, user.id, None, DB_PROFILE)
+
+    assert "db-unwanted" not in [r.candidate.name for r in after]
+
+
+@pytest.mark.asyncio
+async def test_feedback_is_idempotent(db: AsyncSession):
+    user = await _user(db)
+    skill = await _skill(db, name="db-x", submitter=user, description="database")
+
+    await record_feedback(db, user.id, "skill", skill.id, "dismissed")
+    await record_feedback(db, user.id, "skill", skill.id, "not_relevant")
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    assert "db-x" not in [r.candidate.name for r in results]
+
+
+@pytest.mark.asyncio
+async def test_other_orgs_private_components_are_never_recommended(db: AsyncSession):
+    org_a = Organization(name="A", slug="org-a")
+    org_b = Organization(name="B", slug="org-b")
+    db.add_all([org_a, org_b])
+    await db.flush()
+    me = await _user(db, "me@a.com", org_id=org_a.id)
+    them = await _user(db, "them@b.com", org_id=org_b.id)
+    await _skill(
+        db,
+        name="their-db-tool",
+        submitter=them,
+        description="database migrations",
+        is_private=True,
+        org_id=org_b.id,
+    )
+
+    results = await recommend_for_user(db, me.id, org_a.id, DB_PROFILE)
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_own_org_private_components_are_recommended(db: AsyncSession):
+    org = Organization(name="A", slug="org-a")
+    db.add(org)
+    await db.flush()
+    me = await _user(db, "me@a.com", org_id=org.id)
+    await _skill(
+        db,
+        name="our-db-tool",
+        submitter=me,
+        description="database migrations",
+        is_private=True,
+        org_id=org.id,
+    )
+
+    results = await recommend_for_user(db, me.id, org.id, DB_PROFILE)
+
+    assert [r.candidate.name for r in results] == ["our-db-tool"]
+
+
+@pytest.mark.asyncio
+async def test_cold_start_falls_back_to_popularity(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="quiet-thing", submitter=user, description="Something", downloads=1)
+    await _skill(db, name="popular-thing", submitter=user, description="Something", downloads=900)
+
+    results = await recommend_for_user(db, user.id, None, WorkProfile())
+
+    assert results
+    assert results[0].candidate.name == "popular-thing"
+    # Copy must not claim personalisation that did not happen.
+    assert "your work" not in results[0].reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_weak_profile_is_topped_up_with_popular_components(db: AsyncSession):
+    """A thin profile must not leave a near-empty rail on a full registry."""
+    user = await _user(db)
+    await _skill(db, name="db-match", submitter=user, description="postgres database migrations")
+    for i in range(5):
+        await _skill(db, name=f"unrelated-{i}", submitter=user, description="Styling helpers", downloads=i * 10)
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=4)
+
+    assert len(results) == 4
+    assert results[0].candidate.name == "db-match"
+    # The filler must be honest about why it is there.
+    assert results[-1].reason == "Popular in your registry"
+
+
+@pytest.mark.asyncio
+async def test_top_up_never_duplicates_a_match(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="db-match", submitter=user, description="postgres database migrations")
+    await _skill(db, name="other", submitter=user, description="Styling helpers")
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=5)
+
+    ids = [r.candidate.id for r in results]
+    assert len(ids) == len(set(ids))
+
+
+@pytest.mark.asyncio
+async def test_top_up_respects_dismissals(db: AsyncSession):
+    user = await _user(db)
+    unwanted = await _skill(db, name="nope", submitter=user, description="Styling helpers")
+    await _skill(db, name="fine", submitter=user, description="Styling helpers")
+    await record_feedback(db, user.id, "skill", unwanted.id, "dismissed")
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=5)
+
+    assert "nope" not in [r.candidate.name for r in results]
+
+
+@pytest.mark.asyncio
+async def test_limit_is_respected(db: AsyncSession):
+    user = await _user(db)
+    for i in range(10):
+        await _skill(db, name=f"db-{i}", submitter=user, description="database migrations")
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=3)
+
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_empty_registry_returns_nothing(db: AsyncSession):
+    user = await _user(db)
+    assert await recommend_for_user(db, user.id, None, DB_PROFILE) == []
+
+
+@pytest.mark.asyncio
+async def test_recommendation_dict_shape_is_complete(db: AsyncSession):
+    user = await _user(db)
+    await _skill(db, name="db-migrator", submitter=user, description="database migrations")
+
+    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    data = results[0].to_dict()
+
+    for key in ("type", "id", "qualified_name", "description", "latest_version", "reason", "score"):
+        assert key in data

--- a/tests/test_user_recommendations.py
+++ b/tests/test_user_recommendations.py
@@ -4,7 +4,7 @@
 """Tests for per-user registry recommendations.
 
 Covers the deterministic half: profile shaping, exclusion of things the user
-already has or dismissed, org-scoped visibility, and honest cold-start
+already has or dismissed, private-listing visibility, and honest cold-start
 behaviour.
 """
 
@@ -22,7 +22,6 @@ from models.agent_component import AgentComponent
 from models.base import Base
 from models.download import AgentDownloadRecord
 from models.mcp import ListingStatus, McpListing, McpVersion
-from models.organization import Organization
 from models.skill import SkillListing, SkillVersion
 from models.user import User
 from services.user_profile import WorkProfile, _mcp_server_name, _topics_for
@@ -44,8 +43,8 @@ async def db():
     await engine.dispose()
 
 
-async def _user(db: AsyncSession, email: str = "dev@example.com", org_id=None) -> User:
-    user = User(email=email, username=email.split("@")[0], name=email, org_id=org_id)
+async def _user(db: AsyncSession, email: str = "dev@example.com") -> User:
+    user = User(email=email, username=email.split("@")[0], name=email)
     db.add(user)
     await db.flush()
     return user
@@ -59,7 +58,6 @@ async def _skill(
     description: str,
     downloads: int = 0,
     is_private: bool = False,
-    org_id=None,
 ) -> SkillListing:
     listing = SkillListing(
         name=name,
@@ -68,7 +66,6 @@ async def _skill(
         owner="t",
         submitted_by=submitter.id,
         is_private=is_private,
-        owner_org_id=org_id,
     )
     db.add(listing)
     await db.flush()
@@ -209,7 +206,7 @@ async def test_recommendations_match_profile_topics(db: AsyncSession):
     await _skill(db, name="db-migrator", submitter=user, description="Postgres database migrations")
     await _skill(db, name="css-helper", submitter=user, description="Tailwind styling helper")
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    results = await recommend_for_user(db, user.id, DB_PROFILE)
 
     assert results
     assert results[0].candidate.name == "db-migrator"
@@ -222,7 +219,7 @@ async def test_recommendations_span_component_types(db: AsyncSession):
     await _skill(db, name="db-skill", submitter=user, description="database work")
     await _mcp(db, name="db-mcp", submitter=user, description="postgres database server")
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    results = await recommend_for_user(db, user.id, DB_PROFILE)
 
     assert {r.candidate.component_type for r in results} == {"skill", "mcp"}
 
@@ -234,7 +231,7 @@ async def test_already_installed_components_are_excluded(db: AsyncSession):
     await _skill(db, name="db-fresh", submitter=user, description="database migrations")
     await _installed_agent_with(db, user, installed.id)
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    results = await recommend_for_user(db, user.id, DB_PROFILE)
 
     names = [r.candidate.name for r in results]
     assert "db-installed" not in names
@@ -246,11 +243,11 @@ async def test_dismissed_components_stay_dismissed(db: AsyncSession):
     user = await _user(db)
     unwanted = await _skill(db, name="db-unwanted", submitter=user, description="database migrations")
 
-    before = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    before = await recommend_for_user(db, user.id, DB_PROFILE)
     assert "db-unwanted" in [r.candidate.name for r in before]
 
     await record_feedback(db, user.id, "skill", unwanted.id, "dismissed")
-    after = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    after = await recommend_for_user(db, user.id, DB_PROFILE)
 
     assert "db-unwanted" not in [r.candidate.name for r in after]
 
@@ -266,11 +263,11 @@ async def test_installed_components_stop_being_recommended(db: AsyncSession):
     user = await _user(db)
     taken = await _skill(db, name="db-taken", submitter=user, description="database migrations")
 
-    before = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    before = await recommend_for_user(db, user.id, DB_PROFILE)
     assert "db-taken" in [r.candidate.name for r in before]
 
     await record_feedback(db, user.id, "skill", taken.id, "installed")
-    after = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    after = await recommend_for_user(db, user.id, DB_PROFILE)
 
     assert "db-taken" not in [r.candidate.name for r in after]
 
@@ -283,50 +280,41 @@ async def test_feedback_is_idempotent(db: AsyncSession):
     await record_feedback(db, user.id, "skill", skill.id, "dismissed")
     await record_feedback(db, user.id, "skill", skill.id, "not_relevant")
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    results = await recommend_for_user(db, user.id, DB_PROFILE)
     assert "db-x" not in [r.candidate.name for r in results]
 
 
 @pytest.mark.asyncio
-async def test_other_orgs_private_components_are_never_recommended(db: AsyncSession):
-    org_a = Organization(name="A", slug="org-a")
-    org_b = Organization(name="B", slug="org-b")
-    db.add_all([org_a, org_b])
-    await db.flush()
-    me = await _user(db, "me@a.com", org_id=org_a.id)
-    them = await _user(db, "them@b.com", org_id=org_b.id)
+async def test_other_users_private_components_are_never_recommended(db: AsyncSession):
+    me = await _user(db, "me@example.com")
+    them = await _user(db, "them@example.com")
     await _skill(
         db,
         name="their-db-tool",
         submitter=them,
         description="database migrations",
         is_private=True,
-        org_id=org_b.id,
     )
 
-    results = await recommend_for_user(db, me.id, org_a.id, DB_PROFILE)
+    results = await recommend_for_user(db, me.id, DB_PROFILE)
 
     assert results == []
 
 
 @pytest.mark.asyncio
-async def test_own_org_private_components_are_recommended(db: AsyncSession):
-    org = Organization(name="A", slug="org-a")
-    db.add(org)
-    await db.flush()
-    me = await _user(db, "me@a.com", org_id=org.id)
+async def test_personal_private_components_are_recommended(db: AsyncSession):
+    me = await _user(db, "me@example.com")
     await _skill(
         db,
-        name="our-db-tool",
+        name="my-db-tool",
         submitter=me,
         description="database migrations",
         is_private=True,
-        org_id=org.id,
     )
 
-    results = await recommend_for_user(db, me.id, org.id, DB_PROFILE)
+    results = await recommend_for_user(db, me.id, DB_PROFILE)
 
-    assert [r.candidate.name for r in results] == ["our-db-tool"]
+    assert [r.candidate.name for r in results] == ["my-db-tool"]
 
 
 @pytest.mark.asyncio
@@ -335,7 +323,7 @@ async def test_cold_start_falls_back_to_popularity(db: AsyncSession):
     await _skill(db, name="quiet-thing", submitter=user, description="Something", downloads=1)
     await _skill(db, name="popular-thing", submitter=user, description="Something", downloads=900)
 
-    results = await recommend_for_user(db, user.id, None, WorkProfile())
+    results = await recommend_for_user(db, user.id, WorkProfile())
 
     assert results
     assert results[0].candidate.name == "popular-thing"
@@ -351,7 +339,7 @@ async def test_weak_profile_is_topped_up_with_popular_components(db: AsyncSessio
     for i in range(5):
         await _skill(db, name=f"unrelated-{i}", submitter=user, description="Styling helpers", downloads=i * 10)
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=4)
+    results = await recommend_for_user(db, user.id, DB_PROFILE, limit=4)
 
     assert len(results) == 4
     assert results[0].candidate.name == "db-match"
@@ -365,7 +353,7 @@ async def test_top_up_never_duplicates_a_match(db: AsyncSession):
     await _skill(db, name="db-match", submitter=user, description="postgres database migrations")
     await _skill(db, name="other", submitter=user, description="Styling helpers")
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=5)
+    results = await recommend_for_user(db, user.id, DB_PROFILE, limit=5)
 
     ids = [r.candidate.id for r in results]
     assert len(ids) == len(set(ids))
@@ -378,7 +366,7 @@ async def test_top_up_respects_dismissals(db: AsyncSession):
     await _skill(db, name="fine", submitter=user, description="Styling helpers")
     await record_feedback(db, user.id, "skill", unwanted.id, "dismissed")
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=5)
+    results = await recommend_for_user(db, user.id, DB_PROFILE, limit=5)
 
     assert "nope" not in [r.candidate.name for r in results]
 
@@ -389,7 +377,7 @@ async def test_limit_is_respected(db: AsyncSession):
     for i in range(10):
         await _skill(db, name=f"db-{i}", submitter=user, description="database migrations")
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE, limit=3)
+    results = await recommend_for_user(db, user.id, DB_PROFILE, limit=3)
 
     assert len(results) == 3
 
@@ -397,7 +385,7 @@ async def test_limit_is_respected(db: AsyncSession):
 @pytest.mark.asyncio
 async def test_empty_registry_returns_nothing(db: AsyncSession):
     user = await _user(db)
-    assert await recommend_for_user(db, user.id, None, DB_PROFILE) == []
+    assert await recommend_for_user(db, user.id, DB_PROFILE) == []
 
 
 @pytest.mark.asyncio
@@ -405,7 +393,7 @@ async def test_recommendation_dict_shape_is_complete(db: AsyncSession):
     user = await _user(db)
     await _skill(db, name="db-migrator", submitter=user, description="database migrations")
 
-    results = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    results = await recommend_for_user(db, user.id, DB_PROFILE)
     data = results[0].to_dict()
 
     for key in ("type", "id", "qualified_name", "description", "latest_version", "reason", "score"):

--- a/tests/test_user_recommendations.py
+++ b/tests/test_user_recommendations.py
@@ -256,6 +256,26 @@ async def test_dismissed_components_stay_dismissed(db: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_installed_components_stop_being_recommended(db: AsyncSession):
+    """ "installed" is terminal feedback, not a no-op.
+
+    Adoption is normally inferred from agent installs, but the API accepts an
+    explicit "installed" action and the CLI exposes it. Accepting it and then
+    ignoring it would make the flag a lie.
+    """
+    user = await _user(db)
+    taken = await _skill(db, name="db-taken", submitter=user, description="database migrations")
+
+    before = await recommend_for_user(db, user.id, None, DB_PROFILE)
+    assert "db-taken" in [r.candidate.name for r in before]
+
+    await record_feedback(db, user.id, "skill", taken.id, "installed")
+    after = await recommend_for_user(db, user.id, None, DB_PROFILE)
+
+    assert "db-taken" not in [r.candidate.name for r in after]
+
+
+@pytest.mark.asyncio
 async def test_feedback_is_idempotent(db: AsyncSession):
     user = await _user(db)
     skill = await _skill(db, name="db-x", submitter=user, description="database")

--- a/web/src/components/registry/agent-card.tsx
+++ b/web/src/components/registry/agent-card.tsx
@@ -52,7 +52,7 @@ export function AgentCard({
     <Link
       to="/agents/$agentId" params={{ agentId: id }}
       className={[
-        "group block border border-border bg-card p-4 rounded-md",
+        "group flex h-full min-h-60 flex-col rounded-md border border-border bg-card p-4",
         "transition-all duration-200 ease-out",
         "hover:-translate-y-0.5 hover:border-foreground/20 hover:bg-accent/40",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -85,7 +85,7 @@ export function AgentCard({
         </p>
       )}
 
-      <div className="mt-3 flex items-center gap-4 text-xs text-muted-foreground">
+      <div className="mt-auto flex items-center gap-4 pt-3 text-xs text-muted-foreground">
         {downloads != null && (
           <span className="inline-flex items-center gap-1">
             <ArrowDownToLine className="h-3 w-3" />

--- a/web/src/components/registry/recommended-for-you.tsx
+++ b/web/src/components/registry/recommended-for-you.tsx
@@ -6,6 +6,8 @@ import { Sparkles, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CardSkeleton } from "@/components/shared/skeleton-layouts";
 import { RegistryMark } from "@/components/registry/registry-mark";
+// "sandbox" does not pluralise by appending "s"; the route expects "sandboxes".
+import { REVERSE_TYPE_MAP } from "@/components/registry/agent-component-constants";
 import {
 	useDismissRecommendation,
 	useMyRecommendations,
@@ -121,7 +123,7 @@ export function RecommendedForYou({ limit = 6 }: { limit?: number }) {
 						<Link
 							to="/components/$componentId"
 							params={{ componentId: item.id }}
-							search={{ type: `${item.type}s` }}
+							search={{ type: REVERSE_TYPE_MAP[item.type] ?? `${item.type}s` }}
 							className="mt-2 block font-medium text-sm hover:text-primary-accent break-all pr-6"
 						>
 							{item.name}

--- a/web/src/components/registry/recommended-for-you.tsx
+++ b/web/src/components/registry/recommended-for-you.tsx
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { Link } from "@tanstack/react-router";
+import { Sparkles, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CardSkeleton } from "@/components/shared/skeleton-layouts";
+import { RegistryMark } from "@/components/registry/registry-mark";
+import {
+	useDismissRecommendation,
+	useMyRecommendations,
+} from "@/hooks/use-recommendations-api";
+import { compactNumber } from "@/lib/utils";
+
+const TYPE_LABELS: Record<string, string> = {
+	skill: "Skill",
+	hook: "Hook",
+	prompt: "Prompt",
+	mcp: "MCP",
+	sandbox: "Sandbox",
+};
+
+/**
+ * Personalised component rail on the registry home page.
+ *
+ * Renders nothing at all when there is nothing worth showing — an empty rail
+ * is worse than no rail. When the user has no session history the copy says
+ * "popular" rather than implying personalisation that did not happen.
+ */
+export function RecommendedForYou({ limit = 6 }: { limit?: number }) {
+	const { data, isLoading, isError } = useMyRecommendations(limit);
+	const dismiss = useDismissRecommendation();
+
+	if (isError) return null;
+
+	if (isLoading) {
+		return (
+			<section className="space-y-3">
+				<h2 className="font-[family-name:var(--font-display)] text-sm font-semibold">
+					Recommended for you
+				</h2>
+				<CardSkeleton />
+			</section>
+		);
+	}
+
+	const items = data?.items ?? [];
+	const personalized = data?.personalized ?? false;
+	const sessions = data?.profile_sessions ?? 0;
+
+	// An empty rail used to render nothing at all, which is indistinguishable
+	// from the feature being broken or absent. Say why instead.
+	if (items.length === 0) {
+		return (
+			<section className="space-y-3">
+				<div className="flex items-center gap-2">
+					<Sparkles className="h-4 w-4 text-muted-foreground" />
+					<h2 className="font-[family-name:var(--font-display)] text-sm font-semibold">
+						Recommended for you
+					</h2>
+				</div>
+				<div className="rounded-lg border border-border bg-card px-4 py-3">
+					<p className="text-sm text-muted-foreground">
+						Nothing to recommend right now. Either the registry has no components
+						visible to you, or you have already installed or dismissed them all.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	// Sub-heading is the honest part: it must never imply personalisation
+	// that did not happen, and it should say what would improve it.
+	const subtitle = personalized
+		? data?.topics && data.topics.length > 0
+			? `Based on ${sessions} session${sessions === 1 ? "" : "s"} — mostly ${data.topics.slice(0, 3).join(", ")}`
+			: `Based on ${sessions} session${sessions === 1 ? "" : "s"} of your activity`
+		: "No session history yet, so these are simply the most-used components. Run a few sessions and this becomes personal.";
+
+	return (
+		<section className="space-y-3">
+			<div className="flex items-start justify-between gap-3 flex-wrap">
+				<div className="flex items-center gap-2">
+					<Sparkles className={`h-4 w-4 ${personalized ? "text-primary-accent" : "text-muted-foreground"}`} />
+					<h2 className="font-[family-name:var(--font-display)] text-sm font-semibold">
+						{personalized ? "Recommended for you" : "Popular in your registry"}
+					</h2>
+				</div>
+				<p className="text-xs text-muted-foreground max-w-prose">{subtitle}</p>
+			</div>
+
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+				{items.map((item) => (
+					<div
+						key={`${item.type}:${item.id}`}
+						className="group relative rounded-lg border border-border bg-card p-3 hover:border-primary/40 transition-colors"
+					>
+						<Button
+							variant="ghost"
+							size="sm"
+							aria-label={`Dismiss ${item.name}`}
+							className="absolute top-1.5 right-1.5 h-6 w-6 p-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+							disabled={dismiss.isPending}
+							onClick={() => dismiss.mutate({ type: item.type, id: item.id })}
+						>
+							<X className="h-3.5 w-3.5" />
+						</Button>
+
+						<div className="flex items-center gap-2">
+							<RegistryMark size={13} />
+							<span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+								{TYPE_LABELS[item.type] ?? item.type}
+							</span>
+							{item.download_count > 0 && (
+								<span className="text-xs text-muted-foreground">
+									{compactNumber(item.download_count)} installs
+								</span>
+							)}
+						</div>
+
+						<Link
+							to="/components/$componentId"
+							params={{ componentId: item.id }}
+							search={{ type: `${item.type}s` }}
+							className="mt-2 block font-medium text-sm hover:text-primary-accent break-all pr-6"
+						>
+							{item.name}
+						</Link>
+
+						<p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+							{item.description}
+						</p>
+						<p className="mt-2 text-xs text-primary-accent/80">{item.reason}</p>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/web/src/components/registry/registry-mark.tsx
+++ b/web/src/components/registry/registry-mark.tsx
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { useDeploymentConfig } from "@/hooks/use-deployment-config";
+
+/**
+ * The instance's brand mark.
+ *
+ * Honours white-label branding: a deployment that replaced the logo sees its
+ * own mark, not Observal's. Decorative by default — the surrounding text
+ * carries the meaning, so the image stays out of the accessibility tree.
+ */
+export function RegistryMark({ size = 16, className = "" }: { size?: number; className?: string }) {
+	const { brandingLogo } = useDeploymentConfig();
+	return (
+		<img
+			src={brandingLogo || "/observal-logo.svg"}
+			alt=""
+			aria-hidden="true"
+			width={size}
+			height={size}
+			className={`shrink-0 object-contain ${className}`}
+		/>
+	);
+}
+
+/** The instance's display name, for use in sentences like "Already in X". */
+export function useRegistryName(): string {
+	const { brandingAppName } = useDeploymentConfig();
+	return brandingAppName || "Observal";
+}

--- a/web/src/hooks/use-recommendations-api.ts
+++ b/web/src/hooks/use-recommendations-api.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { recommendations } from "@/lib/api";
+
+export function useMyRecommendations(limit = 8, type?: string) {
+	return useQuery({
+		queryKey: ["recommendations", "me", limit, type ?? "all"],
+		queryFn: () => recommendations.me(limit, type),
+		// The profile is cached server-side; refetching on every focus would
+		// just add load without changing the answer.
+		staleTime: 5 * 60 * 1000,
+		retry: false,
+	});
+}
+
+export function useDismissRecommendation() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: ({ type, id }: { type: string; id: string }) =>
+			recommendations.feedback(type, id, "dismissed"),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ["recommendations"] });
+		},
+	});
+}

--- a/web/src/hooks/use-recommendations-api.ts
+++ b/web/src/hooks/use-recommendations-api.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { recommendations } from "@/lib/api";
 
 export function useMyRecommendations(limit = 8, type?: string) {
@@ -22,6 +23,11 @@ export function useDismissRecommendation() {
 			recommendations.feedback(type, id, "dismissed"),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["recommendations"] });
+		},
+		// Without this the card simply stays put and the click reads as a
+		// no-op, which is indistinguishable from a broken button.
+		onError: () => {
+			toast.error("Could not dismiss that recommendation. Please try again.");
 		},
 	});
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1010,6 +1010,43 @@ export const bulk = {
 };
 
 // ── Insights ───────────────────────────────────────────────────────
+export interface RecommendationItem {
+	type: string;
+	id: string;
+	name: string;
+	namespace: string;
+	slug: string;
+	qualified_name: string;
+	description: string;
+	category: string | null;
+	latest_version: string;
+	download_count: number;
+	matched_on: string[];
+	score: number;
+	reason: string;
+}
+
+export interface RecommendationsResponse {
+	items: RecommendationItem[];
+	/** False when the user has no session history, so the UI can say so. */
+	personalized: boolean;
+	profile_sessions: number;
+	topics: string[];
+}
+
+export const recommendations = {
+	me: (limit = 8, type?: string) =>
+		get<RecommendationsResponse>(
+			`/recommendations/me?limit=${limit}${type ? `&type=${encodeURIComponent(type)}` : ""}`,
+		),
+	feedback: (componentType: string, componentId: string, action: string) =>
+		post<void>("/recommendations/feedback", {
+			component_type: componentType,
+			component_id: componentId,
+			action,
+		}),
+};
+
 export const insights = {
 	status: () => get<{ available: boolean; reason: string | null }>("/insights/status"),
 	sessionCount: (agentId: string, agentVersion?: string) =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,7 @@ import type {
 	TeamMemberUpsertBody,
 	TeamRole,
 	TeamUpdateBody,
+	RecommendationsResponse,
 } from "./types";
 
 const API = "/api/v1";
@@ -1010,30 +1011,6 @@ export const bulk = {
 };
 
 // ── Insights ───────────────────────────────────────────────────────
-export interface RecommendationItem {
-	type: string;
-	id: string;
-	name: string;
-	namespace: string;
-	slug: string;
-	qualified_name: string;
-	description: string;
-	category: string | null;
-	latest_version: string;
-	download_count: number;
-	matched_on: string[];
-	score: number;
-	reason: string;
-}
-
-export interface RecommendationsResponse {
-	items: RecommendationItem[];
-	/** False when the user has no session history, so the UI can say so. */
-	personalized: boolean;
-	profile_sessions: number;
-	topics: string[];
-}
-
 export const recommendations = {
 	me: (limit = 8, type?: string) =>
 		get<RecommendationsResponse>(

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -231,7 +231,43 @@ export interface InsightNarrative {
 	 * to the model and how many survived validation. Absent on reports
 	 * generated before reuse suggestions existed.
 	 */
-	registry_match?: unknown;
+	registry_match?: RegistryMatchSummary;
+}
+
+/** A registry component a suggestion may safely point the reader at.
+ *
+ * The server attaches this only after re-validating the reference, so its
+ * presence — not the suggestion's `action_type` — is what makes a component
+ * link safe to render.
+ */
+export interface ComponentRef {
+	type: string;
+	id: string;
+	name: string;
+	qualified_name: string;
+	latest_version: string;
+}
+
+export interface FeatureSuggestion {
+	feature: string;
+	action_type?: string;
+	name?: string;
+	one_liner: string;
+	why_for_you: string;
+	example: string;
+	match_reason?: string;
+	/** Present only on validated reuse suggestions. Older reports omit it. */
+	component_ref?: ComponentRef | null;
+	confidence?: string;
+	risk?: string;
+}
+
+/** Why a report suggested nothing to reuse. */
+export interface RegistryMatchSummary {
+	enabled?: boolean;
+	offered?: number;
+	reused?: number;
+	registry_has_components?: boolean | null;
 }
 
 export interface InsightRegression {

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -226,6 +226,12 @@ export interface InsightNarrative {
 	on_the_horizon?: unknown;
 	fun_ending?: unknown;
 	regressions?: InsightRegression[];
+	/**
+	 * Outcome of the reuse search: how many registry components were offered
+	 * to the model and how many survived validation. Absent on reports
+	 * generated before reuse suggestions existed.
+	 */
+	registry_match?: unknown;
 }
 
 export interface InsightRegression {

--- a/web/src/lib/types/registry.ts
+++ b/web/src/lib/types/registry.ts
@@ -380,3 +380,29 @@ export interface FeedbackItem {
 	created_at?: string;
 	updated_at?: string | null;
 }
+
+// ── Personalised recommendations ──────────────────────────────────────────
+
+export interface RecommendationItem {
+	type: string;
+	id: string;
+	name: string;
+	namespace: string;
+	slug: string;
+	qualified_name: string;
+	description: string;
+	category: string | null;
+	latest_version: string;
+	download_count: number;
+	matched_on: string[];
+	score: number;
+	reason: string;
+}
+
+export interface RecommendationsResponse {
+	items: RecommendationItem[];
+	/** False when the user has no session history, so the UI can say so. */
+	personalized: boolean;
+	profile_sessions: number;
+	topics: string[];
+}

--- a/web/src/pages/admin/insights/detail.tsx
+++ b/web/src/pages/admin/insights/detail.tsx
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import { useParams, useRouter } from "@tanstack/react-router";
+import { Link, useParams, useRouter } from "@tanstack/react-router";
+import { RegistryMark, useRegistryName } from "@/components/registry/registry-mark";
 import React from "react";
 import {
 	ArrowLeft,
@@ -27,6 +28,8 @@ import {
 	Sparkles,
 	ArrowUpRight,
 	ArrowDownRight,
+	ArrowRight,
+	Info,
 	Target,
 	Shield,
 	Download,
@@ -592,7 +595,131 @@ function ProjectAreas({ data }: { data: unknown }) {
 
 // ── Suggestions Section (V4: config_additions + features + patterns) ──
 
-function SuggestionsSection({ data, report }: { data: unknown; report?: InsightReport }) {
+/** A resolved registry reference, attached server-side after validation. */
+interface ComponentRef {
+	type: string;
+	id: string;
+	name: string;
+	qualified_name: string;
+	latest_version: string;
+}
+
+interface FeatureSuggestion {
+	feature: string;
+	action_type?: string;
+	name?: string;
+	one_liner: string;
+	why_for_you: string;
+	example: string;
+	match_reason?: string;
+	/** Present only on validated reuse suggestions. Older reports omit it. */
+	component_ref?: ComponentRef | null;
+	confidence?: string;
+	risk?: string;
+}
+
+const COMPONENT_TYPE_LABELS: Record<string, string> = {
+	skill: "Skill",
+	hook: "Hook",
+	prompt: "Prompt",
+	mcp: "MCP server",
+	sandbox: "Sandbox",
+};
+
+/**
+ * The identity of a component the registry already holds.
+ *
+ * This is the whole point of the feature — "you already own this, don't build
+ * it again" — so it leads with the instance's own mark and reads as a
+ * destination, not a footnote. The link stops propagation because the
+ * surrounding card owns selection for the Apply flow; navigating and
+ * selecting are different intents and must not fight.
+ */
+function ReuseBadge({ componentRef }: { componentRef: ComponentRef }) {
+	const label = COMPONENT_TYPE_LABELS[componentRef.type] ?? componentRef.type;
+	const registryName = useRegistryName();
+	return (
+		<div className="mt-3 rounded-lg border border-primary-accent/35 bg-primary-accent/[0.07] overflow-hidden">
+			<div className="flex items-center gap-2 px-3 py-2 border-b border-primary-accent/20 bg-primary-accent/[0.06]">
+				<RegistryMark size={15} />
+				<span className="text-xs font-semibold tracking-tight text-primary-accent">
+					Already in {registryName}
+				</span>
+				<span className="ml-auto text-[11px] uppercase tracking-wide text-muted-foreground">
+					{label}
+				</span>
+			</div>
+
+			<Link
+				to="/components/$componentId"
+				params={{ componentId: componentRef.id }}
+				search={{ type: `${componentRef.type}s` }}
+				onClick={(event) => event.stopPropagation()}
+				className="group/ref flex items-center gap-2 px-3 py-2.5 transition-colors duration-150 hover:bg-primary-accent/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accent/60 focus-visible:ring-inset"
+			>
+				<span className="min-w-0 flex-1">
+					<span className="block font-[family-name:var(--font-mono)] text-sm font-medium text-foreground break-all group-hover/ref:text-primary-accent transition-colors duration-150">
+						{componentRef.qualified_name || componentRef.name}
+					</span>
+					<span className="mt-0.5 block text-xs text-muted-foreground">
+						v{componentRef.latest_version} · Open in registry
+					</span>
+				</span>
+				<ArrowRight className="h-4 w-4 shrink-0 text-primary-accent transition-transform duration-150 group-hover/ref:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover/ref:translate-x-0" />
+			</Link>
+		</div>
+	);
+}
+
+/** What the reuse search did. Absent on reports generated before this existed. */
+interface RegistryMatchSummary {
+	enabled?: boolean;
+	offered?: number;
+	reused?: number;
+	registry_has_components?: boolean | null;
+}
+
+/**
+ * Explains the outcome of the reuse search when it produced nothing.
+ *
+ * Silence is ambiguous: a reader cannot tell "we searched and nothing fit"
+ * from "we never searched". Both are legitimate outcomes, and each suggests a
+ * different action, so each gets said out loud. Renders nothing when reuse
+ * suggestions were actually made — the cards speak for themselves.
+ */
+function RegistryMatchNote({ summary }: { summary?: RegistryMatchSummary }) {
+	const registryName = useRegistryName();
+	if (!summary) return null;
+	if ((summary.reused ?? 0) > 0) return null;
+
+	let message: string;
+	if (summary.enabled === false) {
+		message = `Reuse suggestions are turned off, so this report only proposes new components.`;
+	} else if (summary.registry_has_components === false) {
+		message = `No components have been published to ${registryName} yet, so there was nothing to reuse. Publish skills, hooks or prompts and future reports will point at them.`;
+	} else if ((summary.offered ?? 0) === 0) {
+		message = `Nothing in ${registryName} looked close enough to this agent's work to recommend. More sessions give the match more to go on.`;
+	} else {
+		message = `Checked ${summary.offered} component${summary.offered === 1 ? "" : "s"} already in ${registryName}; none fit this agent's problems closely enough to recommend.`;
+	}
+
+	return (
+		<div className="flex items-start gap-2 rounded-md border border-border bg-muted/20 px-3 py-2.5">
+			<Info className="h-4 w-4 shrink-0 mt-0.5 text-muted-foreground" />
+			<p className="text-xs text-muted-foreground">{message}</p>
+		</div>
+	);
+}
+
+function SuggestionsSection({
+	data,
+	report,
+	registryMatch,
+}: {
+	data: unknown;
+	report?: InsightReport;
+	registryMatch?: RegistryMatchSummary;
+}) {
 	const applySuggestions = useApplyInsightSuggestions();
 	const [showConfirm, setShowConfirm] = React.useState(false);
 	const [selectedConfigs, setSelectedConfigs] = React.useState<Set<number>>(new Set());
@@ -617,7 +744,7 @@ function SuggestionsSection({ data, report }: { data: unknown; report?: InsightR
 
 	// V4 format
 	const configAdditions = obj.config_additions as { addition: string; why: string; where: string; confidence?: string; risk?: string }[] | undefined;
-	const featuresToTry = obj.features_to_try as { feature: string; action_type?: string; one_liner: string; why_for_you: string; example: string; confidence?: string; risk?: string }[] | undefined;
+	const featuresToTry = obj.features_to_try as FeatureSuggestion[] | undefined;
 	const usagePatterns = obj.usage_patterns as { title: string; suggestion: string; detail: string; copyable_prompt: string }[] | undefined;
 
 	// V3 fallback
@@ -790,8 +917,16 @@ function SuggestionsSection({ data, report }: { data: unknown; report?: InsightR
 				{featuresToTry && featuresToTry.length > 0 && (
 					<div>
 						<h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Features to Try</h4>
+						<div className="mb-3">
+							<RegistryMatchNote summary={registryMatch} />
+						</div>
 						<div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-							{featuresToTry.map((f, i) => (
+							{/* Reuse suggestions lead: "you already own this" is a better
+							    answer than "build this", so it should be read first. */}
+							{featuresToTry
+								.map((f, i) => ({ f, i }))
+								.sort((a, b) => Number(Boolean(b.f.component_ref)) - Number(Boolean(a.f.component_ref)))
+								.map(({ f, i }) => (
 								<div
 									key={i}
 									className={`rounded-md border p-3 transition-colors ${!report?.applied_at ? "cursor-pointer" : ""} ${selectedFeatures.has(i) ? "border-primary/40 bg-primary/5" : "border-border bg-muted/10 opacity-60"}`}
@@ -802,12 +937,25 @@ function SuggestionsSection({ data, report }: { data: unknown; report?: InsightR
 											<input type="checkbox" checked={selectedFeatures.has(i)} onClick={(event) => event.stopPropagation()} onChange={() => toggleFeature(i)} className="mt-1 h-4 w-4 rounded border-border" />
 										)}
 										<div className="flex-1">
-											<span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{f.action_type ?? f.feature}</span>
+											<span
+												className={`text-xs px-2 py-0.5 rounded-full ${
+													f.component_ref
+														? "bg-primary-accent/15 text-primary-accent font-medium"
+														: "bg-muted text-muted-foreground"
+												}`}
+											>
+												{f.component_ref ? "Reuse — don't rebuild" : (f.action_type ?? f.feature)}
+											</span>
 											{f.confidence && <span className="ml-1 text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{f.confidence} confidence</span>}
 											{f.risk && <span className="ml-1 text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">{f.risk} risk</span>}
 											<div className="font-medium text-sm mt-2">{f.one_liner}</div>
 											<p className="text-xs text-foreground/60 mt-1">{f.why_for_you}</p>
-											{f.example && (
+											{f.component_ref && <ReuseBadge componentRef={f.component_ref} />}
+											{f.match_reason && (
+												<p className="text-xs text-muted-foreground mt-2 italic">Why this fits: {f.match_reason}</p>
+											)}
+											{/* A reuse suggestion has no generated body to copy. */}
+											{f.example && !f.component_ref && (
 												<>
 													<pre className="mt-2 p-2 rounded bg-muted/30 text-xs font-[family-name:var(--font-mono)] text-foreground/70 whitespace-pre-wrap break-all">
 														{f.example}
@@ -1811,7 +1959,11 @@ function ReportContent({ report }: { report: InsightReport }) {
 			<FrictionSection data={narrative?.friction_analysis} />
 
 			{/* Suggestions */}
-			<SuggestionsSection data={narrative?.suggestions} report={report} />
+			<SuggestionsSection
+				data={narrative?.suggestions}
+				report={report}
+				registryMatch={narrative?.registry_match as RegistryMatchSummary | undefined}
+			/>
 
 			{/* On the Horizon */}
 			<OnTheHorizon data={narrative?.on_the_horizon} />

--- a/web/src/pages/admin/insights/detail.tsx
+++ b/web/src/pages/admin/insights/detail.tsx
@@ -44,7 +44,12 @@ import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/layouts/page-header";
 import { ErrorState } from "@/components/shared/error-state";
 import { insights } from "@/lib/api";
-import type { InsightReport } from "@/lib/types";
+import type {
+	ComponentRef,
+	FeatureSuggestion,
+	InsightReport,
+	RegistryMatchSummary,
+} from "@/lib/types";
 
 // ── Status Indicator ──────────────────────────────────────────────────────
 
@@ -596,28 +601,6 @@ function ProjectAreas({ data }: { data: unknown }) {
 // ── Suggestions Section (V4: config_additions + features + patterns) ──
 
 /** A resolved registry reference, attached server-side after validation. */
-interface ComponentRef {
-	type: string;
-	id: string;
-	name: string;
-	qualified_name: string;
-	latest_version: string;
-}
-
-interface FeatureSuggestion {
-	feature: string;
-	action_type?: string;
-	name?: string;
-	one_liner: string;
-	why_for_you: string;
-	example: string;
-	match_reason?: string;
-	/** Present only on validated reuse suggestions. Older reports omit it. */
-	component_ref?: ComponentRef | null;
-	confidence?: string;
-	risk?: string;
-}
-
 const COMPONENT_TYPE_LABELS: Record<string, string> = {
 	skill: "Skill",
 	hook: "Hook",
@@ -672,13 +655,6 @@ function ReuseBadge({ componentRef }: { componentRef: ComponentRef }) {
 }
 
 /** What the reuse search did. Absent on reports generated before this existed. */
-interface RegistryMatchSummary {
-	enabled?: boolean;
-	offered?: number;
-	reused?: number;
-	registry_has_components?: boolean | null;
-}
-
 /**
  * Explains the outcome of the reuse search when it produced nothing.
  *

--- a/web/src/pages/registry/home.tsx
+++ b/web/src/pages/registry/home.tsx
@@ -15,8 +15,8 @@ import {
   Gauge,
   Medal,
   Search,
-  Sparkles,
   Star,
+  TrendingUp,
   Terminal,
   Trophy,
   WandSparkles,
@@ -652,7 +652,7 @@ export default function RegistryHome() {
           <div className="space-y-4">
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
-                <Sparkles className="h-4 w-4 text-muted-foreground" />
+                <TrendingUp className="h-4 w-4 text-muted-foreground" />
                 <h2 className="text-sm font-semibold text-foreground">Trending agents</h2>
               </div>
               <Link to="/leaderboard" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">

--- a/web/src/pages/registry/home.tsx
+++ b/web/src/pages/registry/home.tsx
@@ -24,6 +24,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { AgentCard } from "@/components/registry/agent-card";
+import { RecommendedForYou } from "@/components/registry/recommended-for-you";
 import { RegistryName } from "@/components/registry/registry-name";
 import { registryIdentity, registryNameWithHandle } from "@/lib/registry-name";
 import { PageHeader } from "@/components/layouts/page-header";
@@ -534,6 +535,8 @@ export default function RegistryHome() {
             </div>
           </div>
         </section>
+
+        <RecommendedForYou />
 
         <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(360px,420px)]">
           <div className="rounded-md border border-border bg-card">


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description
Two gaps in how Observal helps users find what the registry already has:

1. **Agent insight reports only ever proposed building new components** (skills, hooks,
   prompts) - even when an approved component solving the observed problem was already
   sitting in the registry. Rebuilding what an org already owns is wasted, duplicated work.
2. **A growing registry stops being browsable.** Search assumes you know what to search
   for; users miss components that would help them.

This PR makes insight suggestions point at existing registry components when one genuinely
fits, and adds personalized component recommendations derived from each user's own session
telemetry. A CLI rendering fix rides along: report narratives containing brackets
(`[/tmp]`, `array[0]`) crashed or corrupted `observal ops insights show` via Rich markup
parsing.

## Approach
One shared, deterministic recommender (`services/registry_recommender.py`) serves both
features - lexical matching via the platform's existing `keyword_search`, popularity as a
capped tie-break only, and a worker-safe `visibility_clause` (public / same-org / own
submission, deliberately **no admin bypass**).

* **Insights reuse** (`services/insights/registry_match.py`): report signals → org-visible
  shortlist → offered to the suggestions prompt → every LLM-returned reference re-validated
  (must be an id we offered *and* still resolve approved + visible). Anything else is
  rewritten to a plain suggestion with the reference stripped - a hallucinated ID can never
  render as a real component. Renderers (web / HTML export / CLI) key exclusively on the
  validated `component_ref`. When nothing is reused, `narrative.registry_match` records why,
  so reports say "checked N, none fit" instead of going silent.
* **Recommendations**: per-user `WorkProfile` built from ClickHouse session metadata only
  (no prompt/transcript text), cached 24h + nightly cron refresh. Excludes installed and
  dismissed components; cold start falls back to popularity and is labeled as such - the UI
  and CLI never claim personalization that didn't happen. Self-only API
  (`/api/v1/recommendations/me`); no route reads another user's profile.
* **Self-learn fixes** found while wiring reuse: reused components were pinned to a
  hardcoded `1.0.0` with empty names; capability inference wasn't recomputed after applying
  suggestions; existing-skill matching wasn't org-scoped; generated hooks used an invalid
  `handler_type` and had never once produced a working hook.
* Migration `017` is additive and idempotent, with a working downgrade.

## How Has This Been Tested?
* **331 tests across 14 suites** at the merged tip: unit, authz, stress
  (ClickHouse-literal injection, ILIKE/wildcard abuse, malformed LLM output, cold-start
  paths, Rich markup safety). Each commit also verified independently in an isolated
  worktree to keep the branch bisectable.
* **Live E2E** on the Docker stack: seeded agents + components, real sessions, real LLM
  insight runs - 3/3 agents produced reuse suggestions pointing at the correct seeded
  components, zero off-target. Recommendations endpoint hammered 100×: all 200s, flat
  worker memory. Dismissal round-trip verified against Postgres.
* Authorization: 401 unauthenticated, no cross-user access path, invalid type → 400,
  limit bounds → 422.
* `ruff check` / `ruff format`, `tsc --noEmit`, `eslint` all clean.

Reproduce: `docker compose up`, seed via `scripts/seed_insight_report.py`, run
`observal ops insights generate <agent> --wait`, then `observal registry recommend` and
`GET /api/v1/recommendations/me`.

## Learning (optional, can help others)
* `session_stats_agg` has a bloom-filter index on `user_id`; `session_events` does not -
  profile building resolves user → session ids first, then queries events by session id to
  avoid partition scans.
* Reasoning models (Gemini 3, o-series) spend `max_tokens` on thinking before emitting
  text; the insights connection test's budget of 10 returned zero choices and a misleading
  error. Raised to 2048.
  
<img width="2506" height="1288" alt="1" src="https://github.com/user-attachments/assets/21cfe8d3-0f9b-4614-a0cd-4c96de297cec" />


<img width="2496" height="1298" alt="2" src="https://github.com/user-attachments/assets/6c831e75-484b-45ee-b41b-78fde3c6fe1e" />

  

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## Licenses
| Library | Description | License |
| --- | --- | --- |
| google-cloud-aiplatform | Vertex AI SDK, required by LiteLLM's `vertex_ai/` provider path for insights | [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) |

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Claude Code (Claude Opus)
- [x] Was the generated code manually reviewed and tested? Yes — full line-by-line review plus live end-to-end testing against a running stack, driven and verified by the maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added personalized registry recommendations in the web app and CLI, with filtering, refresh, dismissal, and JSON output.
  * Added recommendation displays with reasons, popularity fallback, and empty-state messaging.
  * Insight reports can now suggest reusing approved registry components and explain matching results.
* **Bug Fixes**
  * Improved report and CLI rendering so user-provided text displays safely without unintended formatting.
  * Increased the token allowance for insight connection checks to support reasoning models.
* **Documentation**
  * Added guidance for recommendations and registry component reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->