### PR TITLE
feat(registry): add team publishing and team-private visibility

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -41,6 +41,7 @@ observal agent create
 observal agent create --from-file agent.json
 observal agent create --name my-agent --prompt "You are..." --model claude-sonnet-4
 observal agent create --name my-agent --prompt-file ./PROMPT.md --harness kiro --harness claude-code
+observal agent create --name team-agent --prompt 'Team workflow' --team platform-tools --visibility team
 ```
 
 | Option | Description |
@@ -53,6 +54,8 @@ observal agent create --name my-agent --prompt-file ./PROMPT.md --harness kiro -
 | `--prompt-file` | Read system prompt from a file |
 | `--model`, `-m` | Model name (e.g. claude-sonnet-4) |
 | `--harness` | Supported harnesses (repeat for multiple) |
+| `--team` | Teamspace UUID or handle |
+| `--visibility` | `public` or `team`, team visibility requires `--team` |
 
 ---
 
@@ -81,6 +84,7 @@ List active agents in the registry with pagination support. Use `--interactive` 
 ```bash
 observal agent list
 observal agent list --search my-agent
+observal agent list --team platform-tools --output json
 observal agent list --page 2 --limit 20
 observal agent list --interactive
 observal agent list --output json
@@ -90,6 +94,8 @@ observal agent list --full-id
 | Option | Description |
 | --- | --- |
 | `--search`, `-s` | Filter by search term |
+| `--namespace` | Restrict to one publisher or team namespace |
+| `--team` | Include public items plus private items from this teamspace |
 | `--interactive`, `-i` | Interactive search mode |
 | `--limit`, `-n` | Page size (1-200, default 50) |
 | `--page`, `-p` | Page number (1-indexed) |
@@ -234,6 +240,7 @@ observal agent publish
 observal agent publish --update
 observal agent publish --draft
 observal agent publish --dir /tmp/my-agent
+observal agent publish --dir /tmp/my-agent --team platform-tools --visibility team
 ```
 
 | Option | Description |
@@ -242,6 +249,8 @@ observal agent publish --dir /tmp/my-agent
 | `--update`, `-u` | Update existing agent instead of creating |
 | `--draft` | Save as draft instead of submitting for review |
 | `--submit` | Submit an existing draft agent for review (agent ID) |
+| `--team` | Publish into a teamspace by UUID or handle |
+| `--visibility` | Set `public` or `team` visibility, team visibility requires `--team` |
 
 ---
 

--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -32,7 +32,21 @@ Notes:
 
 All registry references accept a UUID, canonical `namespace/slug`, a unique legacy bare name, a row number from the last `list` output, or an `@alias`. If the same bare slug exists in multiple namespaces, qualify it (for example, `alice/search` instead of `search`).
 
-The namespace is the publisher's username. Usernames cannot change after the account owns a registry listing. Transferring ownership moves the item to the recipient's namespace and fails if that `namespace/slug` already exists.
+The namespace is the publisher's username or a teamspace handle. Usernames cannot change after the account owns a registry listing. Team members can browse approved private teamspace items in normal list results. Use `--team TEAM_HANDLE` to include public items plus that team's private items, or `--namespace TEAM_HANDLE` to restrict results to that namespace. Direct references use `team-handle/item-slug`. Nonmembers receive the same not-found response for private items as for unknown items.
+
+### Teamspace visibility
+
+Use the teamspace target and visibility options on submit commands:
+
+```bash
+observal registry skill submit --skill-md ./SKILL.md --team platform-tools --visibility public
+observal registry skill submit --skill-md ./SKILL.md --team platform-tools --visibility team
+observal registry skill list --team platform-tools --search 'frontend design' --harness claude-code --output json
+observal registry skill list --namespace platform-tools --output json
+observal registry skill show platform-tools/internal-skill --output json
+```
+
+`public` teamspace items are visible to all registry users. `team` items are visible only to team members and privileged reviewers. Team owners and reviewers can change visibility after publication. A team member's new submission still follows the normal review workflow.
 
 ---
 

--- a/observal-server/alembic/versions/018_team_publishing.py
+++ b/observal-server/alembic/versions/018_team_publishing.py
@@ -94,6 +94,14 @@ def _assert_no_team_owned_rows() -> None:
         count = conn.execute(sa.text(f"SELECT count(*) FROM {table} WHERE team_id IS NOT NULL")).scalar_one()
         if count:
             owned[table] = count
+    # agents.is_private is dropped by this downgrade and recreated with a false
+    # default on re-upgrade, so a personal-private agent (is_private with no
+    # teamspace) comes back public. team_id alone does not detect those.
+    private_agents = conn.execute(
+        sa.text("SELECT count(*) FROM agents WHERE is_private IS TRUE AND team_id IS NULL")
+    ).scalar_one()
+    if private_agents:
+        owned["agents (private, no teamspace)"] = private_agents
     if owned:
         detail = ", ".join(f"{table}={count}" for table, count in sorted(owned.items()))
         raise RuntimeError(

--- a/observal-server/alembic/versions/018_team_publishing.py
+++ b/observal-server/alembic/versions/018_team_publishing.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""team publishing visibility
+
+Adds the teamspace ownership and privacy axis for the registry: agents gain a
+private concept for the first time, and agents, all five component listings, and
+component sources gain a team_id.
+
+Revision ID: 018_team_publishing
+Revises: 017_teams
+Create Date: 2026-08-01 20:20:56.795715
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "018_team_publishing"
+down_revision: Union[str, Sequence[str], None] = "017_teams"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Every table that gains a nullable team_id pointing at teams.id.
+_TEAM_TABLES = (
+    "agents",
+    "mcp_listings",
+    "skill_listings",
+    "hook_listings",
+    "prompt_listings",
+    "sandbox_listings",
+    "component_sources",
+)
+
+# The subset whose team ownership the downgrade guard protects. component_sources
+# is excluded: it carries no is_private of its own and follows its listing.
+_GUARDED_TABLES = _TEAM_TABLES[:-1]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Agents had no privacy concept before teamspaces. The five component
+    # listings already carry is_private.
+    op.add_column("agents", sa.Column("is_private", sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.alter_column("agents", "is_private", server_default=None)
+
+    for table in _TEAM_TABLES:
+        op.add_column(table, sa.Column("team_id", sa.UUID(), nullable=True))
+        op.create_index(f"ix_{table}_team_id", table, ["team_id"], unique=False)
+        op.create_foreign_key(
+            f"fk_{table}_team_id_teams",
+            table,
+            "teams",
+            ["team_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    # This migration deliberately backfills no visibility data.
+    #
+    # A legacy row with is_private=True and a null team_id predates teamspaces,
+    # and the shared helpers in api/deps.py already resolve it without a
+    # teamspace: apply_visibility_filter matches such a row only for its creator
+    # (submitted_by or created_by), and check_listing_visibility_async returns
+    # True only for that creator or for a reviewer, admin, or super_admin.
+    # A legacy component_sources row with is_public=False and a null team_id is
+    # likewise restricted to reviewers and admins by _source_visible in
+    # api/routes/component_source.py.
+    #
+    # Flipping those rows to public in bulk would therefore fix nothing and
+    # would disclose data on every upgrade, and downgrade() cannot undo it
+    # because it has no record of which rows it flipped.
+
+
+def _assert_no_team_owned_rows() -> None:
+    """Refuse to downgrade while any listing still belongs to a teamspace.
+
+    Dropping team_id destroys the only record of which teamspace owns a private
+    listing, and this downgrade also drops agents.is_private. Re-upgrading
+    afterwards recreates is_private with a false server default, so every agent a
+    teamspace kept private comes back public, and every surviving private listing
+    comes back with a null team_id that its team can no longer reach. Rather than
+    let a rollback silently disclose or orphan private rows, stop and make the
+    operator move or delete team-owned rows first.
+    """
+    conn = op.get_bind()
+    owned = {}
+    for table in _GUARDED_TABLES:
+        count = conn.execute(sa.text(f"SELECT count(*) FROM {table} WHERE team_id IS NOT NULL")).scalar_one()
+        if count:
+            owned[table] = count
+    if owned:
+        detail = ", ".join(f"{table}={count}" for table, count in sorted(owned.items()))
+        raise RuntimeError(
+            "Cannot downgrade 018_team_publishing: team-owned listings still exist "
+            f"({detail}). Reassign or delete them before rolling back, otherwise "
+            "their teamspace ownership is lost and a later re-upgrade cannot restore it."
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    _assert_no_team_owned_rows()
+    for table in reversed(_TEAM_TABLES):
+        op.drop_constraint(f"fk_{table}_team_id_teams", table, type_="foreignkey")
+        op.drop_index(f"ix_{table}_team_id", table_name=table)
+        op.drop_column(table, "team_id")
+    op.drop_column("agents", "is_private")

--- a/observal-server/alembic/versions/018_team_publishing.py
+++ b/observal-server/alembic/versions/018_team_publishing.py
@@ -37,9 +37,11 @@ _TEAM_TABLES = (
     "component_sources",
 )
 
-# The subset whose team ownership the downgrade guard protects. component_sources
-# is excluded: it carries no is_private of its own and follows its listing.
-_GUARDED_TABLES = _TEAM_TABLES[:-1]
+# Every table the downgrade guard protects. component_sources is included: it has
+# no listing relationship to inherit visibility from, it carries its own team_id
+# and is_public, so dropping its team_id strands a non-public source exactly the
+# way it strands a listing.
+_GUARDED_TABLES = _TEAM_TABLES
 
 
 def upgrade() -> None:

--- a/observal-server/alembic/versions/019_team_listing_restrict.py
+++ b/observal-server/alembic/versions/019_team_listing_restrict.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""restrict teamspace deletion while listings reference it
+
+018 created the team_id foreign keys with ON DELETE SET NULL, which made deleting
+a teamspace silently strip its listings: is_private stayed true, team_id went
+null, and every member except the original submitter lost access. The application
+guard added afterwards counts rows and then deletes, which is racy, because a
+publish landing between the count and the delete is orphaned anyway.
+
+RESTRICT moves the rule into the database, where the check and the delete are the
+same statement. The guard stays as a pre-check so the API can answer with a
+useful message instead of an integrity error.
+
+Revision ID: 019_team_listing_restrict
+Revises: 018_team_publishing
+Create Date: 2026-08-02 11:40:00.000000
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+from alembic import op
+
+revision: str = "019_team_listing_restrict"
+down_revision: Union[str, Sequence[str], None] = "018_team_publishing"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TEAM_TABLES = (
+    "agents",
+    "mcp_listings",
+    "skill_listings",
+    "hook_listings",
+    "prompt_listings",
+    "sandbox_listings",
+    "component_sources",
+)
+
+
+def _recreate(ondelete: str) -> None:
+    for table in _TEAM_TABLES:
+        op.drop_constraint(f"fk_{table}_team_id_teams", table, type_="foreignkey")
+        op.create_foreign_key(
+            f"fk_{table}_team_id_teams",
+            table,
+            "teams",
+            ["team_id"],
+            ["id"],
+            ondelete=ondelete,
+        )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _recreate("RESTRICT")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    _recreate("SET NULL")

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -493,24 +493,31 @@ def apply_publish_scope(stmt, model, target_team_id):
     return stmt.where(or_(public, (model.is_private == True) & (model.team_id == target_team_id)))  # noqa: E712
 
 
-def apply_registry_scope(stmt, model, current_user, *, team_id=None, public_only=False):
-    """Apply caller visibility and the optional teamspace list filter.
+def apply_registry_scope(stmt, model, current_user, *, team_id=None, composable_for_team_id=None, public_only=False):
+    """Apply caller visibility plus one optional teamspace filter.
 
-    ``team_id`` here is deliberately the same predicate as ``apply_publish_scope``
-    even though the two answer different questions. ``apply_publish_scope`` answers
-    "what may an agent published for this target contain", while the registry list
-    filter behind ``?team_id=`` (the CLI ``--team TEAM_HANDLE`` flag) means
-    "public items plus this teamspace's private items". Both are public plus that
-    one team's private rows, so they share an implementation. Narrowing a list to a
-    single teamspace is what ``?namespace=`` is for, so do not "fix" this to drop
-    public rows. Caller visibility is applied first, so a non-member passing a
-    teamspace id still gets public rows only.
+    Two different questions used to share ``team_id``, which made every teamspace
+    view show the whole public registry:
+
+    ``team_id`` means OWNERSHIP: show what this teamspace published, and nothing
+    else. That is what a teamspace page, the ``?team_id=`` list filter, and the CLI
+    ``--team TEAM_HANDLE`` flag all want. A listing owned by another namespace has
+    no business appearing under a team's own tab just because it is public.
+
+    ``composable_for_team_id`` means PUBLISH SCOPE: public items plus this
+    teamspace's private items, which is the set an agent published for that target
+    may contain. Only the agent builder's component picker wants this.
+
+    Caller visibility is applied first either way, so a non-member passing a
+    teamspace id still sees only that team's public rows.
     """
     stmt = apply_visibility_filter(stmt, model, current_user)
     if public_only:
         return stmt.where(model.is_private == False)  # noqa: E712
-    if team_id is not None:
-        return apply_publish_scope(stmt, model, team_id)
+    if composable_for_team_id is not None:
+        return apply_publish_scope(stmt, model, composable_for_team_id)
+    if team_id is not None and hasattr(model, "team_id"):
+        return stmt.where(model.team_id == team_id)
     return stmt
 
 

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -266,6 +266,22 @@ def may_view_unapproved(permission: str, user: User | None) -> bool:
     return permission == "owner" or (user is not None and user.role == UserRole.reviewer)
 
 
+def can_see_private_listings(user: User | None) -> bool:
+    """Whether a global role by itself may read team-private listings.
+
+    Only admins and super_admins qualify. Global reviewers are deliberately
+    excluded: their mandate is the PUBLIC catalog, and team-private content is
+    reviewed inside its own teamspace by a team owner or team reviewer, so a
+    global reviewer has no reason to read another team's private listings.
+
+    This answers a PRIVACY question and is not the same gate as
+    ``may_view_unapproved``, which answers a STATUS question. A reviewer must
+    still open a pending public listing to review it, so that helper keeps its
+    reviewer arm while this one does not grow one.
+    """
+    return user is not None and ROLE_HIERARCHY.get(user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
+
+
 # Convenience shorthand for super_admin-only endpoints
 require_super_admin = require_role(UserRole.super_admin)
 
@@ -504,19 +520,18 @@ def apply_visibility_filter(stmt, model, current_user):
     Public listings are visible to everyone. Team-private listings require a
     membership row for the requesting user, while legacy private user listings
     remain visible only to their creator.
+
+    Admins and super_admins skip the filter entirely. Global reviewers do not:
+    see ``can_see_private_listings``.
     """
     from sqlalchemy import or_
 
     from models.team import TeamMembership
-    from models.user import UserRole
 
     if not hasattr(model, "is_private"):
         return stmt
 
-    privileged = (
-        current_user is not None and ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    )
-    if privileged:
+    if can_see_private_listings(current_user):
         return stmt
 
     public = model.is_private == False  # noqa: E712
@@ -559,10 +574,8 @@ async def check_listing_visibility_async(listing, current_user, db: AsyncSession
         return False
 
     from models.team import TeamMembership
-    from models.user import UserRole
 
-    privileged = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    if privileged:
+    if can_see_private_listings(current_user):
         return True
     team_id = getattr(listing, "team_id", None)
     if team_id is None:

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -364,18 +364,22 @@ MAX_BARE_NAME_MATCHES = 6
 async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_status=None, current_user=None):
     """Resolve a listing by UUID, canonical name, or unambiguous legacy bare name.
 
-    ``current_user`` scopes the legacy bare-name collision report. The 409 names
-    only listings the caller is allowed to see, and a bare name that collides
-    solely with hidden listings resolves to the single visible one instead of
-    disclosing canonical names through the error message.
+    ``current_user`` decides what the caller may see, and a listing they may not
+    see resolves to None exactly as a nonexistent one does. This is the single
+    gate every read AND write path inherits: archive, unarchive, draft edit and
+    the editing lock all resolve through here, and they authorize with
+    ``get_effective_component_permission``, which answers "owner" for the original
+    submitter forever. Without the check below, a user removed from a teamspace
+    could still mutate a listing they can no longer read.
 
-    ``current_user=None`` means an anonymous caller and narrows the collision set
-    to public listings, so leaving it off at a call site that does have a caller
-    is a real behaviour change: a name that must raise 409 for a team member
-    resolves to the single public row instead. Every call site under
-    ``observal-server/api`` therefore passes it explicitly, and
-    ``TestEveryCallSitePassesTheCaller`` in ``tests/test_sec009_org_scoping.py``
-    fails the build when a new one does not.
+    ``current_user=None`` means an anonymous caller, so omitting it fails closed
+    rather than open. Every call site under ``observal-server/api`` passes it
+    explicitly, and ``TestEveryCallSitePassesTheCaller`` in
+    ``tests/test_sec009_org_scoping.py`` fails the build when a new one does not.
+
+    The legacy bare-name collision report is scoped the same way: the 409 names
+    only listings the caller may see, and a name colliding solely with hidden
+    listings resolves to the single visible one rather than disclosing the others.
     """
 
     value = str(identifier).strip()
@@ -406,16 +410,14 @@ async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_s
     if not isinstance(matches, (list, tuple)):
         first = scalars.first()
         matches = [first] if first is not None else []
-    if ambiguous_label is not None and len(matches) > 1:
-        visible = [item for item in matches if await check_listing_visibility_async(item, current_user, db)]
-        if len(visible) > 1:
-            choices = ", ".join(item.qualified_name for item in visible)
-            raise HTTPException(
-                status_code=409,
-                detail=f"'{ambiguous_label}' is ambiguous; use one of: {choices}",
-            )
-        return visible[0] if visible else None
-    return matches[0] if matches else None
+    visible = [item for item in matches if await check_listing_visibility_async(item, current_user, db)]
+    if ambiguous_label is not None and len(visible) > 1:
+        choices = ", ".join(item.qualified_name for item in visible)
+        raise HTTPException(
+            status_code=409,
+            detail=f"'{ambiguous_label}' is ambiguous; use one of: {choices}",
+        )
+    return visible[0] if visible else None
 
 
 MIN_ID_PREFIX_LENGTH = 4

--- a/observal-server/api/deps.py
+++ b/observal-server/api/deps.py
@@ -249,6 +249,23 @@ def get_effective_component_permission(listing, user: User | None) -> str:
     return "view"
 
 
+def may_view_unapproved(permission: str, user: User | None) -> bool:
+    """Non-approved listings are visible only to owners, co-authors, admins, and reviewers.
+
+    ``permission`` is the return of ``get_effective_component_permission`` or
+    ``get_effective_agent_permission``. Both already answer "owner" for the
+    submitter, for co-authors, and for admins and super_admins, so those three
+    arrive through ``permission``.
+
+    Reviewers are deliberately absent from those two functions: "owner" there
+    also means "may edit", and a reviewer must be able to open a pending item
+    without gaining edit rights over it. The reviewer arm below is therefore the
+    only thing that lets the review queue read what it has to review. Removing it
+    as redundant would close the queue.
+    """
+    return permission == "owner" or (user is not None and user.role == UserRole.reviewer)
+
+
 # Convenience shorthand for super_admin-only endpoints
 require_super_admin = require_role(UserRole.super_admin)
 
@@ -322,8 +339,28 @@ async def require_password_auth() -> None:
         raise HTTPException(status_code=403, detail="Password authentication is disabled (SSO-only mode)")
 
 
-async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_status=None):
-    """Resolve a listing by UUID, canonical name, or unambiguous legacy bare name."""
+# Legacy bare names can collide across namespaces. Fetch a small window instead
+# of two rows so the ambiguity report still sees alternatives after the listings
+# the caller may not see are dropped.
+MAX_BARE_NAME_MATCHES = 6
+
+
+async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_status=None, current_user=None):
+    """Resolve a listing by UUID, canonical name, or unambiguous legacy bare name.
+
+    ``current_user`` scopes the legacy bare-name collision report. The 409 names
+    only listings the caller is allowed to see, and a bare name that collides
+    solely with hidden listings resolves to the single visible one instead of
+    disclosing canonical names through the error message.
+
+    ``current_user=None`` means an anonymous caller and narrows the collision set
+    to public listings, so leaving it off at a call site that does have a caller
+    is a real behaviour change: a name that must raise 409 for a team member
+    resolves to the single public row instead. Every call site under
+    ``observal-server/api`` therefore passes it explicitly, and
+    ``TestEveryCallSitePassesTheCaller`` in ``tests/test_sec009_org_scoping.py``
+    fails the build when a new one does not.
+    """
 
     value = str(identifier).strip()
     try:
@@ -347,18 +384,21 @@ async def resolve_listing(model, identifier: str, db: AsyncSession, *, require_s
         stmt = stmt.join(version_model, model.latest_version_id == version_model.id).where(
             version_model.status == require_status
         )
-    result = await db.execute(stmt.limit(2))
+    result = await db.execute(stmt.limit(MAX_BARE_NAME_MATCHES if ambiguous_label is not None else 2))
     scalars = result.scalars()
     matches = scalars.all()
     if not isinstance(matches, (list, tuple)):
         first = scalars.first()
         matches = [first] if first is not None else []
     if ambiguous_label is not None and len(matches) > 1:
-        choices = ", ".join(item.qualified_name for item in matches)
-        raise HTTPException(
-            status_code=409,
-            detail=f"'{ambiguous_label}' is ambiguous; use one of: {choices}",
-        )
+        visible = [item for item in matches if await check_listing_visibility_async(item, current_user, db)]
+        if len(visible) > 1:
+            choices = ", ".join(item.qualified_name for item in visible)
+            raise HTTPException(
+                status_code=409,
+                detail=f"'{ambiguous_label}' is ambiguous; use one of: {choices}",
+            )
+        return visible[0] if visible else None
     return matches[0] if matches else None
 
 
@@ -425,55 +465,124 @@ async def resolve_prefix_id(
     raise HTTPException(status_code=400, detail=detail)
 
 
-def apply_visibility_filter(stmt, model, current_user):
-    """Exclude private listings from orgs other than the requesting user's.
+def apply_publish_scope(stmt, model, target_team_id):
+    """Limit components to what an agent published for one target can contain."""
+    from sqlalchemy import or_
 
-    Rules:
-    - Public items (is_private=False) are always visible.
-    - Private items are only visible to users in the same org, or to the
-      submitter directly, or to admins/reviewers.
+    if not hasattr(model, "is_private") or not hasattr(model, "team_id"):
+        return stmt
+    public = model.is_private == False  # noqa: E712
+    if target_team_id is None:
+        return stmt.where(public)
+    return stmt.where(or_(public, (model.is_private == True) & (model.team_id == target_team_id)))  # noqa: E712
+
+
+def apply_registry_scope(stmt, model, current_user, *, team_id=None, public_only=False):
+    """Apply caller visibility and the optional teamspace list filter.
+
+    ``team_id`` here is deliberately the same predicate as ``apply_publish_scope``
+    even though the two answer different questions. ``apply_publish_scope`` answers
+    "what may an agent published for this target contain", while the registry list
+    filter behind ``?team_id=`` (the CLI ``--team TEAM_HANDLE`` flag) means
+    "public items plus this teamspace's private items". Both are public plus that
+    one team's private rows, so they share an implementation. Narrowing a list to a
+    single teamspace is what ``?namespace=`` is for, so do not "fix" this to drop
+    public rows. Caller visibility is applied first, so a non-member passing a
+    teamspace id still gets public rows only.
+    """
+    stmt = apply_visibility_filter(stmt, model, current_user)
+    if public_only:
+        return stmt.where(model.is_private == False)  # noqa: E712
+    if team_id is not None:
+        return apply_publish_scope(stmt, model, team_id)
+    return stmt
+
+
+def apply_visibility_filter(stmt, model, current_user):
+    """Restrict team-private listings without using organization state.
+
+    Public listings are visible to everyone. Team-private listings require a
+    membership row for the requesting user, while legacy private user listings
+    remain visible only to their creator.
     """
     from sqlalchemy import or_
 
+    from models.team import TeamMembership
     from models.user import UserRole
 
     if not hasattr(model, "is_private"):
         return stmt
 
-    is_admin = (
+    privileged = (
         current_user is not None and ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
     )
-    if is_admin:
-        return stmt  # admins see everything
+    if privileged:
+        return stmt
 
     public = model.is_private == False  # noqa: E712
     if current_user is None:
         return stmt.where(public)
 
-    # Guard: only match same-org if user actually has an org (not NULL)
-    if current_user.org_id is not None:
-        same_org = (model.is_private == True) & (model.owner_org_id == current_user.org_id)  # noqa: E712
-        own = (model.is_private == True) & (model.submitted_by == current_user.id)  # noqa: E712
-        return stmt.where(or_(public, same_org, own))
-    # User has no org - can only see their own private items
-    own = (model.is_private == True) & (model.submitted_by == current_user.id)  # noqa: E712
+    creator_column = getattr(model, "submitted_by", None) or getattr(model, "created_by", None)
+    if hasattr(model, "team_id"):
+        own = (model.is_private == True) & model.team_id.is_(None)  # noqa: E712
+    else:
+        own = model.is_private == True  # noqa: E712
+    own = own & (creator_column == current_user.id) if creator_column is not None else False
+
+    if hasattr(model, "team_id"):
+        member = (
+            select(TeamMembership.id)
+            .where(TeamMembership.team_id == model.team_id, TeamMembership.user_id == current_user.id)
+            .correlate(model)
+            .exists()
+        )
+        team_private = (model.is_private == True) & model.team_id.is_not(None) & member  # noqa: E712
+        return stmt.where(or_(public, own, team_private))
+
+    # Models without team_id are outside the registry visibility contract.
     return stmt.where(or_(public, own))
 
 
-def check_listing_visibility(listing, current_user) -> bool:
-    """Return True if current_user may see this listing.
+async def check_listing_visibility_async(listing, current_user, db: AsyncSession) -> bool:
+    """Check visibility with a membership query for detail and install routes.
 
-    Used on detail routes to gate access to private items.
+    This is the row-level twin of ``apply_visibility_filter`` and must stay
+    identical to it: a team-private listing is reachable through team membership
+    only. Being the original submitter is not a standing grant, otherwise someone
+    removed from a teamspace would keep reading by id an item that has already
+    vanished from every list.
     """
-    from models.user import UserRole
-
     if not getattr(listing, "is_private", False):
         return True
     if current_user is None:
         return False
-    is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
-    if is_admin:
+
+    from models.team import TeamMembership
+    from models.user import UserRole
+
+    privileged = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.reviewer]
+    if privileged:
         return True
-    if listing.submitted_by == current_user.id:
-        return True
-    return current_user.org_id is not None and listing.owner_org_id == current_user.org_id
+    team_id = getattr(listing, "team_id", None)
+    if team_id is None:
+        # Private with no teamspace is a personal listing: only its creator sees it.
+        creator_id = getattr(listing, "submitted_by", None) or getattr(listing, "created_by", None)
+        return creator_id == current_user.id
+    return (
+        await db.scalar(
+            select(TeamMembership.id).where(
+                TeamMembership.team_id == team_id,
+                TeamMembership.user_id == current_user.id,
+            )
+        )
+        is not None
+    )
+
+
+async def resolve_visible_listing(model, identifier: str, db: AsyncSession, current_user, *, require_status=None):
+    """Resolve a listing and hide it when the caller cannot see it."""
+    listing = await resolve_listing(model, identifier, db, require_status=require_status, current_user=current_user)
+    if listing is None or not await check_listing_visibility_async(listing, current_user, db):
+        return None
+    return listing

--- a/observal-server/api/routes/_component_archive.py
+++ b/observal-server/api/routes/_component_archive.py
@@ -10,7 +10,7 @@ from models.user import User
 
 
 async def archive_listing(model, listing_id: str, db: AsyncSession, current_user: User, item_type: str) -> dict:
-    listing = await resolve_listing(model, listing_id, db)
+    listing = await resolve_listing(model, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -24,7 +24,7 @@ async def archive_listing(model, listing_id: str, db: AsyncSession, current_user
 
 
 async def unarchive_listing(model, listing_id: str, db: AsyncSession, current_user: User, item_type: str) -> dict:
-    listing = await resolve_listing(model, listing_id, db)
+    listing = await resolve_listing(model, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":

--- a/observal-server/api/routes/admin/org.py
+++ b/observal-server/api/routes/admin/org.py
@@ -205,24 +205,3 @@ async def clear_cache(current_user: User = Depends(require_role(UserRole.admin))
 
     deleted = await invalidate_all()
     return {"cleared": deleted}
-
-
-@router.post("/fix-agent-org")
-async def fix_agent_org(
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.admin)),
-):
-    """Fix agents missing owner_org_id by setting it from the creator's org."""
-    optic.debug("org.fix_agent_org called")
-    from models.agent import Agent
-
-    result = await db.execute(select(Agent).where(Agent.owner_org_id.is_(None)))
-    agents = result.scalars().all()
-    fixed = 0
-    for agent in agents:
-        creator = (await db.execute(select(User).where(User.id == agent.created_by))).scalar_one_or_none()
-        if creator and creator.org_id:
-            agent.owner_org_id = creator.org_id
-            fixed += 1
-    await db.commit()
-    return {"fixed": fixed, "total_checked": len(agents)}

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -229,7 +229,7 @@ async def create_agent(
             )
         raise
 
-    agent = await _load_agent(db, str(agent.id))
+    agent = await _load_agent(db, str(agent.id), prefer_user_id=current_user.id, current_user=current_user)
     name_map = await _resolve_component_names(agent.components, db)
 
     emit_registry_event(
@@ -383,6 +383,7 @@ async def my_agents(
         .where(Agent.created_by == current_user.id, Agent.deleted_at.is_(None))
         .order_by(Agent.created_at.desc())
     )
+    stmt = apply_registry_scope(stmt, Agent, current_user)
     agents = (await db.execute(stmt)).scalars().all()
 
     agent_ids = [a.id for a in agents]
@@ -806,7 +807,7 @@ async def update_agent(
         agent.inferred_supported_harnesses = compute_supported_harnesses(agent.required_capabilities)
 
     await db.commit()
-    agent = await _load_agent(db, str(agent.id))
+    agent = await _load_agent(db, str(agent.id), prefer_user_id=current_user.id, current_user=current_user)
     name_map = await _resolve_component_names(agent.components, db)
 
     emit_registry_event(

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -253,7 +253,10 @@ async def list_agents(
     search: str | None = Query(None),
     namespace: str | None = Query(None),
     category: str | None = Query(None),
-    team_id: uuid.UUID | None = Query(None),
+    team_id: uuid.UUID | None = Query(None, description="Only agents owned by this teamspace"),
+    composable_for_team_id: uuid.UUID | None = Query(
+        None, description="Public agents plus this teamspace's private ones"
+    ),
     public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200, description="Page size (1-200)"),
     offset: int = Query(0, ge=0, description="Items to skip"),
@@ -291,13 +294,25 @@ async def list_agents(
     if category:
         filters.append(Agent.category == category)
     count_stmt = apply_registry_scope(
-        count_stmt.where(*filters), Agent, current_user, team_id=team_id, public_only=public_only
+        count_stmt.where(*filters),
+        Agent,
+        current_user,
+        team_id=team_id,
+        composable_for_team_id=composable_for_team_id,
+        public_only=public_only,
     )
     total = (await db.execute(count_stmt)).scalar_one()
     response.headers["X-Total-Count"] = str(total)
 
     stmt = select(Agent).join(AgentVersion, Agent.latest_version_id == AgentVersion.id).where(base_filter, *filters)
-    stmt = apply_registry_scope(stmt, Agent, current_user, team_id=team_id, public_only=public_only)
+    stmt = apply_registry_scope(
+        stmt,
+        Agent,
+        current_user,
+        team_id=team_id,
+        composable_for_team_id=composable_for_team_id,
+        public_only=public_only,
+    )
     order_by = [Agent.created_at.desc()]
     if search_rank is not None:
         order_by.insert(0, search_rank.desc())

--- a/observal-server/api/routes/agent/crud.py
+++ b/observal-server/api/routes/agent/crud.py
@@ -3,7 +3,7 @@
 
 """Agent CRUD routes: create, list, get, update, delete, archive, unarchive."""
 
-import uuid  # noqa: TC003
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import Depends, HTTPException, Query, Response
@@ -14,9 +14,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     ROLE_HIERARCHY,
+    apply_registry_scope,
     get_db,
     get_effective_agent_permission,
-    registry_identity,
     require_role,
 )
 from api.search import keyword_search
@@ -40,6 +40,7 @@ from services.config_generator import validate_mcp_command
 from services.harness_capability_inference import compute_supported_harnesses, infer_required_features
 from services.registry_namespace import identity_exists, slugify
 from services.registry_telemetry import emit_registry_event
+from services.teamspace import resolve_publish_target
 
 from ._router import router
 from .helpers import (
@@ -61,12 +62,26 @@ async def create_agent(
     if not req.description:
         raise HTTPException(status_code=422, detail="Description must not be empty")
 
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+
     # If `components` is provided, it supersedes legacy `mcp_server_ids`
     if req.components:
         req.mcp_server_ids = []
 
     # Validate legacy mcp_server_ids
-    mcp_listings = await _validate_mcp_ids(req.mcp_server_ids, db)
+    mcp_listings = await _validate_mcp_ids(
+        req.mcp_server_ids,
+        db,
+        current_user=current_user,
+        target_team_id=target.team_id if target.visibility == "team" else None,
+        enforce_target=True,
+    )
 
     # Validate new components field (component_type already validated by Pydantic Literal)
     if req.components:
@@ -76,6 +91,9 @@ async def create_agent(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
             require_approved=False,
+            current_user=current_user,
+            target_team_id=target.team_id if target.visibility == "team" else None,
+            enforce_target=True,
         )
         if errors:
             raise HTTPException(
@@ -97,25 +115,25 @@ async def create_agent(
             raise HTTPException(status_code=422, detail=f"Invalid MCP command: {e}")
 
     # The database remains the source of truth; this pre-check gives a clean 409.
-    namespace, slug = registry_identity(current_user, req.name)
     existing = await db.execute(
         select(Agent.id).where(
-            Agent.namespace == namespace,
-            Agent.slug == slug,
+            Agent.namespace == target.namespace,
+            Agent.slug == target.slug,
             Agent.deleted_at.is_(None),
         )
     )
     if existing.scalar_one_or_none() is not None:
-        raise HTTPException(status_code=409, detail=f"Agent '{namespace}/{slug}' already exists")
+        raise HTTPException(status_code=409, detail=f"Agent '{target.namespace}/{target.slug}' already exists")
 
     agent = Agent(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner or current_user.username or current_user.email,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else (req.owner or current_user.username or current_user.email),
         category=req.category,
         created_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(agent)
     await db.flush()
@@ -130,8 +148,10 @@ async def create_agent(
         models_by_harness=req.models_by_harness,
         external_mcps=[m.model_dump() for m in req.external_mcps],
         supported_harnesses=req.supported_harnesses,
-        status=AgentStatus.pending,
+        status=AgentStatus.approved if target.auto_approve else AgentStatus.pending,
         released_by=current_user.id,
+        reviewed_by=current_user.id if target.auto_approve else None,
+        reviewed_at=datetime.now(UTC) if target.auto_approve else None,
     )
     db.add(version)
     await db.flush()
@@ -203,7 +223,10 @@ async def create_agent(
     except IntegrityError as exc:
         await db.rollback()
         if "uq_agents_active_namespace_slug" in str(exc.orig):
-            raise HTTPException(status_code=409, detail=f"Agent '{namespace}/{slug}' already exists")
+            raise HTTPException(
+                status_code=409,
+                detail=f"Agent '{target.namespace}/{target.slug}' already exists",
+            )
         raise
 
     agent = await _load_agent(db, str(agent.id))
@@ -230,6 +253,8 @@ async def list_agents(
     search: str | None = Query(None),
     namespace: str | None = Query(None),
     category: str | None = Query(None),
+    team_id: uuid.UUID | None = Query(None),
+    public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200, description="Page size (1-200)"),
     offset: int = Query(0, ge=0, description="Items to skip"),
     db: AsyncSession = Depends(get_db),
@@ -256,26 +281,23 @@ async def list_agents(
             name_field=Agent.name,
         )
 
-    # Org-scoping: when the caller belongs to an org, show agents owned by that org
-    # or agents with no org set (legacy/bulk-created agents)
-    org_filter = None
-    if current_user.org_id is not None:
-        org_filter = (Agent.owner_org_id == current_user.org_id) | (Agent.owner_org_id.is_(None))
-
     # Total count for pagination header
     count_stmt = (
         select(func.count(Agent.id)).join(AgentVersion, Agent.latest_version_id == AgentVersion.id).where(base_filter)
     )
-    filters = [condition for condition in (search_filter, org_filter) if condition is not None]
+    filters = [condition for condition in (search_filter,) if condition is not None]
     if namespace:
         filters.append(Agent.namespace == namespace.strip().lower())
     if category:
         filters.append(Agent.category == category)
-    count_stmt = count_stmt.where(*filters)
+    count_stmt = apply_registry_scope(
+        count_stmt.where(*filters), Agent, current_user, team_id=team_id, public_only=public_only
+    )
     total = (await db.execute(count_stmt)).scalar_one()
     response.headers["X-Total-Count"] = str(total)
 
     stmt = select(Agent).join(AgentVersion, Agent.latest_version_id == AgentVersion.id).where(base_filter, *filters)
+    stmt = apply_registry_scope(stmt, Agent, current_user, team_id=team_id, public_only=public_only)
     order_by = [Agent.created_at.desc()]
     if search_rank is not None:
         order_by.insert(0, search_rank.desc())
@@ -313,6 +335,9 @@ async def list_agents(
             version=a.version,
             description=a.description,
             owner=a.owner,
+            team_id=a.team_id,
+            visibility=a.visibility,
+            is_private=a.is_private,
             model_name=a.model_name,
             supported_harnesses=a.supported_harnesses,
             status=a.status,
@@ -365,6 +390,9 @@ async def my_agents(
             version=a.version,
             description=a.description,
             owner=a.owner,
+            team_id=a.team_id,
+            visibility=a.visibility,
+            is_private=a.is_private,
             model_name=a.model_name,
             supported_harnesses=a.supported_harnesses,
             status=a.status,
@@ -396,9 +424,6 @@ async def archived_agents(
         .where(AgentVersion.status == AgentStatus.archived, Agent.deleted_at.is_(None))
         .order_by(Agent.created_at.desc())
     )
-    if current_user.org_id is not None:
-        stmt = stmt.where(Agent.owner_org_id == current_user.org_id)
-
     agents = (await db.execute(stmt)).scalars().all()
 
     agent_ids = [a.id for a in agents]
@@ -430,6 +455,9 @@ async def archived_agents(
             version=a.version,
             description=a.description,
             owner=a.owner,
+            team_id=a.team_id,
+            visibility=a.visibility,
+            is_private=a.is_private,
             model_name=a.model_name,
             supported_harnesses=a.supported_harnesses,
             status=a.status,
@@ -457,10 +485,7 @@ async def deleted_agents(
 
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     stmt = select(Agent).where(Agent.deleted_at.is_not(None)).order_by(Agent.deleted_at.desc())
-    if is_admin:
-        if current_user.org_id is not None:
-            stmt = stmt.where(Agent.owner_org_id == current_user.org_id)
-    else:
+    if not is_admin:
         stmt = stmt.where(Agent.created_by == current_user.id)
 
     agents = (await db.execute(stmt)).scalars().all()
@@ -494,6 +519,9 @@ async def deleted_agents(
             version=a.version,
             description=a.description,
             owner=a.owner,
+            team_id=a.team_id,
+            visibility=a.visibility,
+            is_private=a.is_private,
             model_name=a.model_name,
             supported_harnesses=a.supported_harnesses,
             status=a.status,
@@ -523,11 +551,9 @@ async def get_agent(
         db,
         agent_id,
         prefer_user_id=current_user.id,
-        org_id=current_user.org_id,
+        current_user=current_user,
     )
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     perm = get_effective_agent_permission(agent, current_user)
     if perm == "none":
@@ -556,11 +582,9 @@ async def version_suggestions(
         db,
         agent_id,
         prefer_user_id=current_user.id,
-        org_id=current_user.org_id,
+        current_user=current_user,
     )
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent")
@@ -594,16 +618,30 @@ async def update_agent(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
-    if not is_admin and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=404, detail="Agent not found")
 
     perm = get_effective_agent_permission(agent, current_user)
     if perm not in ("owner", "edit") and not is_admin:
         raise HTTPException(status_code=403, detail="Not the agent owner or editor")
+
+    # Visibility and teamspace are not editable here. Echoing back the current
+    # value is a no-op; asking for a different one is refused rather than
+    # silently dropped, because both have their own authorized flows.
+    if req.visibility is not None and (req.visibility == "team") != bool(agent.is_private):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Visibility cannot be changed here. Use PATCH /api/v1/registry/agent/{agent.id}/visibility instead."
+            ),
+        )
+    if req.team_id is not None and req.team_id != agent.team_id:
+        raise HTTPException(
+            status_code=422,
+            detail="Teamspace cannot be changed here. Recreate the agent under the target teamspace.",
+        )
 
     if req.version_bump_type and req.version is None:
         from services.versioning import bump_version
@@ -654,6 +692,9 @@ async def update_agent(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
             require_approved=False,
+            current_user=current_user,
+            target_team_id=agent.team_id if agent.is_private else None,
+            enforce_target=True,
         )
         if errors:
             raise HTTPException(
@@ -693,7 +734,13 @@ async def update_agent(
         if not agent.latest_version:
             raise HTTPException(status_code=400, detail="Agent has no version to update components on")
 
-        mcp_listings = await _validate_mcp_ids(req.mcp_server_ids, db)
+        mcp_listings = await _validate_mcp_ids(
+            req.mcp_server_ids,
+            db,
+            current_user=current_user,
+            target_team_id=agent.team_id if agent.is_private else None,
+            enforce_target=True,
+        )
         version_id = agent.latest_version.id
         old_comps = (
             (
@@ -770,13 +817,11 @@ async def delete_agent(
     optic.debug("soft deleting agent")
 
     agent = await _load_agent(
-        db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id, include_all_statuses=True
+        db, agent_id, prefer_user_id=current_user.id, current_user=current_user, include_all_statuses=True
     )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
-    if not is_admin and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=404, detail="Agent not found")
     perm = get_effective_agent_permission(agent, current_user)
     if perm != "owner" and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
@@ -809,15 +854,13 @@ async def restore_deleted_agent(
         db,
         agent_id,
         prefer_user_id=current_user.id,
-        org_id=current_user.org_id,
+        current_user=current_user,
         include_all_statuses=True,
         include_deleted=True,
     )
     if not agent or agent.deleted_at is None:
         raise HTTPException(status_code=404, detail="Deleted agent not found")
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
-    if not is_admin and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=404, detail="Deleted agent not found")
     perm = get_effective_agent_permission(agent, current_user)
     if perm != "owner" and not is_admin:
         raise HTTPException(status_code=403, detail="Not authorized")
@@ -855,10 +898,8 @@ async def archive_agent(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if agent.created_by != current_user.id and not is_admin:
@@ -892,11 +933,9 @@ async def unarchive_agent(
 ):
     optic.trace("agent_id={}", agent_id)
     agent = await _load_agent(
-        db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id, include_all_statuses=True
+        db, agent_id, prefer_user_id=current_user.id, current_user=current_user, include_all_statuses=True
     )
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     is_admin = ROLE_HIERARCHY.get(current_user.role, 999) <= ROLE_HIERARCHY[UserRole.admin]
     if agent.created_by != current_user.id and not is_admin:

--- a/observal-server/api/routes/agent/draft.py
+++ b/observal-server/api/routes/agent/draft.py
@@ -281,7 +281,7 @@ async def update_draft(
     # approved yet and the call cannot currently fire. It stays as an invariant guard:
     # every site that writes is_private must route a private-to-public transition back
     # through review, so loosening the status gate above can never open that bypass.
-    review_publication_to_public(agent, current_user, was_private=was_private)
+    await review_publication_to_public(agent, current_user, db, was_private=was_private)
 
     if req.version_bump_type and req.version is None:
         from services.versioning import bump_version

--- a/observal-server/api/routes/agent/draft.py
+++ b/observal-server/api/routes/agent/draft.py
@@ -3,21 +3,31 @@
 
 """Agent draft workflow routes: save, update, start/cancel edit, submit."""
 
+from datetime import UTC, datetime
+
 from fastapi import Depends, HTTPException
 from loguru import logger as optic
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import commit_or_name_conflict, get_db, get_effective_agent_permission, registry_identity, require_role
+from api.deps import commit_or_name_conflict, get_db, get_effective_agent_permission, require_role
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.agent_component import AgentComponent
 from models.skill import SkillListing
+from models.team import TeamRole
 from models.user import User, UserRole
 from schemas.agent import AgentCreateRequest, AgentResponse, AgentUpdateRequest
 from services.config_generator import validate_mcp_command
 from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.harness_capability_inference import compute_supported_harnesses, infer_required_features
 from services.registry_telemetry import emit_registry_event
+from services.teamspace import (
+    is_global_reviewer,
+    publish_auto_approves_for_entity,
+    resolve_publish_target,
+    review_publication_to_public,
+    team_membership,
+)
 
 from ._router import router
 from .helpers import _agent_to_response, _load_agent, _resolve_component_names
@@ -25,6 +35,63 @@ from .helpers import _agent_to_response, _load_agent, _resolve_component_names
 # ---------------------------------------------------------------------------
 # Draft workflow
 # ---------------------------------------------------------------------------
+
+
+async def _authorize_visibility_change(agent: Agent, current_user: User, db: AsyncSession) -> None:
+    """Gate a visibility flip behind the roles the registry visibility route requires.
+
+    Personal agents are already covered by the owner or editor check on the
+    route. Team agents additionally require a team owner or team reviewer,
+    matching PATCH /api/v1/registry/agent/{id}/visibility.
+    """
+    if is_global_reviewer(current_user):
+        return
+    if agent.team_id is None:
+        return
+    membership = await team_membership(db, agent.team_id, current_user.id)
+    if not membership or membership.role not in (TeamRole.owner, TeamRole.reviewer):
+        raise HTTPException(status_code=403, detail="Only team owners and reviewers can change visibility")
+
+
+async def _reject_components_outside_target(
+    components: list,
+    db: AsyncSession,
+    current_user: User,
+    *,
+    target_team_id,
+    target_visibility: str,
+) -> None:
+    """Re-run the shared composition validation against a new publish target.
+
+    Used when visibility changes without the caller resending components: the
+    components already attached must still be legal under the new target.
+    """
+    refs = [{"component_type": c.component_type, "component_id": c.component_id} for c in components]
+    if not refs:
+        return
+
+    from services.agent_resolver import validate_component_ids
+
+    errors = await validate_component_ids(
+        refs,
+        db,
+        require_approved=False,
+        current_user=current_user,
+        target_team_id=target_team_id,
+        enforce_target=True,
+    )
+    if not errors:
+        return
+
+    name_map = await _resolve_component_names(components, db)
+    offenders = ", ".join(
+        f"{error.component_type} '{name_map.get(str(error.component_id)) or error.component_id}'" for error in errors
+    )
+    raise HTTPException(
+        status_code=409,
+        detail=f"Cannot change visibility to '{target_visibility}': {offenders} cannot be used by a "
+        f"{target_visibility} agent",
+    )
 
 
 @router.post("/draft", response_model=AgentResponse)
@@ -35,14 +102,43 @@ async def save_draft(
 ):
     """Create an agent as a draft (relaxed validation, not submitted for review)."""
     optic.trace("req={}", req)
-    namespace, slug = registry_identity(current_user, req.name)
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    from services.agent_resolver import validate_component_ids
+
+    component_refs = [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components] + [
+        {"component_type": "mcp", "component_id": mid} for mid in req.mcp_server_ids
+    ]
+    errors = await validate_component_ids(
+        component_refs,
+        db,
+        require_approved=False,
+        current_user=current_user,
+        target_team_id=target.team_id if target.visibility == "team" else None,
+        enforce_target=True,
+    )
+    if errors:
+        raise HTTPException(
+            status_code=400,
+            detail=[
+                {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                for e in errors
+            ],
+        )
+
     agent = Agent(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner or current_user.username or current_user.email,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else (req.owner or current_user.username or current_user.email),
         created_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(agent)
     await db.flush()
@@ -94,7 +190,7 @@ async def save_draft(
                 component_type=cref.component_type,
                 component_id=cref.component_id,
                 component_name="",
-                resolved_version=component_versions.get(("mcp", mid), "latest"),
+                resolved_version=component_versions.get((cref.component_type, cref.component_id), "latest"),
                 order_index=order,
                 config_override=cref.config_override,
             )
@@ -136,10 +232,8 @@ async def update_draft(
 ):
     """Update a draft agent."""
     optic.trace("agent_id={}, req={}", agent_id, req)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     perm = get_effective_agent_permission(agent, current_user)
     if perm not in ("owner", "edit"):
@@ -150,6 +244,49 @@ async def update_draft(
     version = agent.latest_version
     if not version:
         raise HTTPException(status_code=400, detail="Agent has no version to update")
+
+    # Moving an item between teamspaces is a separate operation and must never
+    # ride along on a draft save.
+    if req.team_id is not None and req.team_id != agent.team_id:
+        raise HTTPException(
+            status_code=422,
+            detail="Teamspace cannot be changed here. Recreate the agent under the target teamspace.",
+        )
+    if req.mcp_server_ids is not None:
+        raise HTTPException(
+            status_code=422,
+            detail="mcp_server_ids is not accepted here. Send MCP servers in 'components' instead.",
+        )
+
+    if req.visibility == "team" and agent.team_id is None:
+        raise HTTPException(status_code=422, detail="Team visibility requires a teamspace")
+    target_is_private = bool(agent.is_private) if req.visibility is None else req.visibility == "team"
+    visibility_changed = target_is_private != bool(agent.is_private)
+    target_team_id = agent.team_id if target_is_private else None
+    if visibility_changed:
+        await _authorize_visibility_change(agent, current_user, db)
+        # A caller who resends components gets them validated below; otherwise
+        # the currently attached set has to survive the new target.
+        if req.components is None:
+            await _reject_components_outside_target(
+                list(agent.components),
+                db,
+                current_user,
+                target_team_id=target_team_id,
+                target_visibility="team" if target_is_private else "public",
+            )
+    was_private = bool(agent.is_private)
+    agent.is_private = target_is_private
+    # This route only accepts draft, rejected, and pending agents, so nothing here is
+    # approved yet and the call cannot currently fire. It stays as an invariant guard:
+    # every site that writes is_private must route a private-to-public transition back
+    # through review, so loosening the status gate above can never open that bypass.
+    review_publication_to_public(agent, current_user, was_private=was_private)
+
+    if req.version_bump_type and req.version is None:
+        from services.versioning import bump_version
+
+        req.version = bump_version(agent.version, req.version_bump_type)
 
     for field in (
         "version",
@@ -175,7 +312,24 @@ async def update_draft(
         version.external_mcps = [m.model_dump() for m in req.external_mcps]
 
     if req.components is not None:
-        from services.agent_resolver import resolve_component_versions
+        from services.agent_resolver import resolve_component_versions, validate_component_ids
+
+        errors = await validate_component_ids(
+            [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
+            db,
+            require_approved=False,
+            current_user=current_user,
+            target_team_id=target_team_id,
+            enforce_target=True,
+        )
+        if errors:
+            raise HTTPException(
+                status_code=400,
+                detail=[
+                    {"component_type": e.component_type, "component_id": str(e.component_id), "reason": e.reason}
+                    for e in errors
+                ],
+            )
 
         component_versions = await resolve_component_versions(req.components, db)
         version_id = version.id
@@ -232,7 +386,7 @@ async def update_draft(
     release_edit_lock(version, current_user.id, force=True)
     await db.flush()
 
-    for field in ("name", "owner"):
+    for field in ("name", "owner", "category"):
         val = getattr(req, field)
         if val is not None:
             setattr(agent, field, val)
@@ -255,7 +409,7 @@ async def start_edit_agent(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     perm = get_effective_agent_permission(agent, current_user)
@@ -282,7 +436,7 @@ async def cancel_edit_agent(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     perm = get_effective_agent_permission(agent, current_user)
@@ -304,10 +458,8 @@ async def submit_draft(
 ):
     """Submit a draft agent for review (transitions draft -> pending)."""
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     perm = get_effective_agent_permission(agent, current_user)
     if perm not in ("owner", "edit"):
@@ -325,6 +477,9 @@ async def submit_draft(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in agent.components],
             db,
             require_approved=False,
+            current_user=current_user,
+            target_team_id=agent.team_id if agent.is_private else None,
+            enforce_target=True,
         )
         if errors:
             raise HTTPException(
@@ -347,7 +502,12 @@ async def submit_draft(
 
         agent.latest_version.yaml_snapshot = await build_yaml_snapshot(agent.latest_version, db)
 
-    agent.status = AgentStatus.pending
+    if await publish_auto_approves_for_entity(agent, current_user, db):
+        agent.status = AgentStatus.approved
+        agent.latest_version.reviewed_by = current_user.id
+        agent.latest_version.reviewed_at = datetime.now(UTC)
+    else:
+        agent.status = AgentStatus.pending
     await db.commit()
     agent = await _load_agent(db, str(agent.id))
     name_map = await _resolve_component_names(agent.components, db)

--- a/observal-server/api/routes/agent/draft.py
+++ b/observal-server/api/routes/agent/draft.py
@@ -219,7 +219,7 @@ async def save_draft(
     version.yaml_snapshot = await build_yaml_snapshot(version, db)
 
     await commit_or_name_conflict(db, "agent")
-    agent = await _load_agent(db, str(agent.id))
+    agent = await _load_agent(db, str(agent.id), prefer_user_id=current_user.id, current_user=current_user)
     return _agent_to_response(agent, created_by_email=current_user.email, created_by_username=current_user.username)
 
 
@@ -398,7 +398,7 @@ async def update_draft(
     version.yaml_snapshot = await build_yaml_snapshot(version, db)
 
     await db.commit()
-    agent = await _load_agent(db, str(agent.id))
+    agent = await _load_agent(db, str(agent.id), prefer_user_id=current_user.id, current_user=current_user)
     return _agent_to_response(agent, created_by_email=current_user.email, created_by_username=current_user.username)
 
 
@@ -509,7 +509,7 @@ async def submit_draft(
     else:
         agent.status = AgentStatus.pending
     await db.commit()
-    agent = await _load_agent(db, str(agent.id))
+    agent = await _load_agent(db, str(agent.id), prefer_user_id=current_user.id, current_user=current_user)
     name_map = await _resolve_component_names(agent.components, db)
 
     emit_registry_event(

--- a/observal-server/api/routes/agent/helpers.py
+++ b/observal-server/api/routes/agent/helpers.py
@@ -9,7 +9,14 @@ from fastapi import HTTPException
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import apply_publish_scope, apply_visibility_filter, check_listing_visibility_async, resolve_prefix_id
+from api.deps import (
+    apply_publish_scope,
+    apply_visibility_filter,
+    check_listing_visibility_async,
+    get_effective_agent_permission,
+    may_view_unapproved,
+    resolve_prefix_id,
+)
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.mcp import ListingStatus, McpListing, McpVersion
 from schemas.agent import (
@@ -51,6 +58,16 @@ async def _load_agent(
         agent = await resolve_prefix_id(Agent, agent_id, db, extra_conditions=conditions)
         if current_user is not _VISIBILITY_UNSET and not await check_listing_visibility_async(agent, current_user, db):
             return None
+        # The name branch below gates on approved status; this one has to as well.
+        # Otherwise a UUID or prefix reads an agent whose version is pending, which
+        # is exactly the state a team-private agent lands in the moment it is made
+        # public, and its prompt would be readable before any reviewer saw it.
+        if not include_all_statuses and agent.status != AgentStatus.approved:
+            owner_id = getattr(agent, "created_by", None)
+            caller = None if current_user is _VISIBILITY_UNSET else current_user
+            permission = get_effective_agent_permission(agent, caller)
+            if not may_view_unapproved(permission, caller) and owner_id != prefer_user_id:
+                return None
         return agent
     except HTTPException:
         pass

--- a/observal-server/api/routes/agent/helpers.py
+++ b/observal-server/api/routes/agent/helpers.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import resolve_prefix_id
+from api.deps import apply_publish_scope, apply_visibility_filter, check_listing_visibility_async, resolve_prefix_id
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.mcp import ListingStatus, McpListing, McpVersion
 from schemas.agent import (
@@ -20,6 +20,8 @@ from schemas.agent import (
 from services.registry_namespace import _namespace_slug_parts
 from services.shared.utils import registry_item_slug
 
+_VISIBILITY_UNSET = object()
+
 
 async def _load_agent(
     db: AsyncSession,
@@ -27,7 +29,7 @@ async def _load_agent(
     extra_conditions=None,
     *,
     prefer_user_id: uuid.UUID | None = None,
-    org_id: uuid.UUID | None = None,
+    current_user=_VISIBILITY_UNSET,
     include_all_statuses: bool = False,
     include_deleted: bool = False,
 ) -> Agent | None:
@@ -35,8 +37,8 @@ async def _load_agent(
 
     When *prefer_user_id* is provided and resolution is by name, prefer the
     caller's own agent over agents created by other users with the same name.
-    The global name fallback is restricted to active agents and, when *org_id*
-    is set, to agents within the same organisation.
+    The global name fallback is restricted to active agents and the caller's
+    visibility scope when *current_user* is supplied.
 
     Set *include_all_statuses* to find agents regardless of version status
     (needed for unarchive, delete, etc.).
@@ -46,7 +48,10 @@ async def _load_agent(
         conditions.append(Agent.deleted_at.is_(None))
 
     try:
-        return await resolve_prefix_id(Agent, agent_id, db, extra_conditions=conditions)
+        agent = await resolve_prefix_id(Agent, agent_id, db, extra_conditions=conditions)
+        if current_user is not _VISIBILITY_UNSET and not await check_listing_visibility_async(agent, current_user, db):
+            return None
+        return agent
     except HTTPException:
         pass
 
@@ -64,8 +69,8 @@ async def _load_agent(
         stmt = stmt.where(visible_status)
     if conditions:
         stmt = stmt.where(*conditions)
-    if org_id is not None:
-        stmt = stmt.where(Agent.owner_org_id == org_id)
+    if current_user is not _VISIBILITY_UNSET:
+        stmt = apply_visibility_filter(stmt, Agent, current_user)
     results = (await db.execute(stmt.limit(2))).scalars().all()
     if not parts and len(results) > 1:
         choices = ", ".join(item.qualified_name for item in results)
@@ -122,10 +127,17 @@ def _agent_to_response(
         "inferred_supported_harnesses",
         "status",
         "rejection_reason",
+        "visibility",
     ):
         agent_dict[field] = getattr(agent, field)
     if not isinstance(agent_dict.get("models_by_harness"), dict):
         agent_dict["models_by_harness"] = {}
+    if not isinstance(agent_dict.get("team_id"), uuid.UUID):
+        agent_dict["team_id"] = None
+    if agent_dict.get("visibility") not in ("public", "team"):
+        agent_dict["visibility"] = "team" if agent_dict.get("is_private") is True else "public"
+    if not isinstance(agent_dict.get("is_private"), bool):
+        agent_dict["is_private"] = False
     namespace = agent_dict.get("namespace")
     if not isinstance(namespace, str):
         namespace = created_by_username or str(agent.owner)
@@ -210,14 +222,26 @@ async def _resolve_component_statuses(components: list, db: AsyncSession) -> dic
     return status_map
 
 
-async def _validate_mcp_ids(mcp_ids: list[uuid.UUID], db: AsyncSession) -> list[McpListing]:
+async def _validate_mcp_ids(
+    mcp_ids: list[uuid.UUID],
+    db: AsyncSession,
+    *,
+    current_user=None,
+    target_team_id: uuid.UUID | None = None,
+    enforce_target: bool = False,
+) -> list[McpListing]:
     listings = []
     for mid in mcp_ids:
-        result = await db.execute(
+        stmt = (
             select(McpListing)
             .join(McpVersion, McpListing.latest_version_id == McpVersion.id)
             .where(McpListing.id == mid, McpVersion.status == ListingStatus.approved)
         )
+        if current_user is not None:
+            stmt = apply_visibility_filter(stmt, McpListing, current_user)
+        if enforce_target:
+            stmt = apply_publish_scope(stmt, McpListing, target_team_id)
+        result = await db.execute(stmt)
         listing = result.scalar_one_or_none()
         if not listing:
             raise HTTPException(status_code=400, detail=f"MCP server {mid} not found or not approved")

--- a/observal-server/api/routes/agent/install.py
+++ b/observal-server/api/routes/agent/install.py
@@ -11,6 +11,8 @@ from sqlalchemy.orm import selectinload
 
 import services.dynamic_settings as _ds
 from api.deps import (
+    apply_publish_scope,
+    apply_visibility_filter,
     get_db,
     get_effective_agent_permission,
     optional_current_user,
@@ -51,7 +53,7 @@ async def install_agent(
         db,
         agent_id,
         prefer_user_id=current_user.id,
-        org_id=current_user.org_id,
+        current_user=current_user,
     )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
@@ -59,8 +61,6 @@ async def install_agent(
         _ds.get_sync_bool("security.allow_draft_install") and agent.created_by == current_user.id
     ):
         raise HTTPException(status_code=404, detail="Agent not found or not approved for installation")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to install this agent")
 
@@ -87,6 +87,7 @@ async def install_agent(
         install_version = agent.latest_version
 
     install_components = list(install_version.components or [])
+    component_target_team_id = agent.team_id if agent.is_private else None
 
     class _InstallAgentProxy:
         _version_fields = {
@@ -116,14 +117,28 @@ async def install_agent(
     mcp_comp_ids = [c.component_id for c in install_components if c.component_type == "mcp"]
     mcp_listings_map = {}
     if mcp_comp_ids:
-        mcp_rows = (await db.execute(select(McpListing).where(McpListing.id.in_(mcp_comp_ids)))).scalars().all()
+        mcp_stmt = apply_publish_scope(
+            apply_visibility_filter(
+                select(McpListing).where(McpListing.id.in_(mcp_comp_ids)), McpListing, current_user
+            ),
+            McpListing,
+            component_target_team_id,
+        )
+        mcp_rows = (await db.execute(mcp_stmt)).scalars().all()
         mcp_listings_map = {row.id: row for row in mcp_rows}
 
     # Pre-load skill listings for skill file generation
     skill_comp_ids = [c.component_id for c in install_components if c.component_type == "skill"]
     skill_listings_map = {}
     if skill_comp_ids:
-        skill_rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)))).scalars().all()
+        skill_stmt = apply_publish_scope(
+            apply_visibility_filter(
+                select(SkillListing).where(SkillListing.id.in_(skill_comp_ids)), SkillListing, current_user
+            ),
+            SkillListing,
+            component_target_team_id,
+        )
+        skill_rows = (await db.execute(skill_stmt)).scalars().all()
         skill_listings_map = {row.id: row for row in skill_rows}
 
     # Pre-load hook listings for hook config generation
@@ -133,9 +148,17 @@ async def install_agent(
         hook_rows = (
             (
                 await db.execute(
-                    select(HookListing)
-                    .options(selectinload(HookListing.latest_version))
-                    .where(HookListing.id.in_(hook_comp_ids))
+                    apply_publish_scope(
+                        apply_visibility_filter(
+                            select(HookListing)
+                            .options(selectinload(HookListing.latest_version))
+                            .where(HookListing.id.in_(hook_comp_ids)),
+                            HookListing,
+                            current_user,
+                        ),
+                        HookListing,
+                        component_target_team_id,
+                    )
                 )
             )
             .scalars()
@@ -150,9 +173,17 @@ async def install_agent(
         prompt_rows = (
             (
                 await db.execute(
-                    select(PromptListing)
-                    .options(selectinload(PromptListing.latest_version))
-                    .where(PromptListing.id.in_(prompt_comp_ids))
+                    apply_publish_scope(
+                        apply_visibility_filter(
+                            select(PromptListing)
+                            .options(selectinload(PromptListing.latest_version))
+                            .where(PromptListing.id.in_(prompt_comp_ids)),
+                            PromptListing,
+                            current_user,
+                        ),
+                        PromptListing,
+                        component_target_team_id,
+                    )
                 )
             )
             .scalars()
@@ -167,9 +198,17 @@ async def install_agent(
         sandbox_rows = (
             (
                 await db.execute(
-                    select(SandboxListing)
-                    .options(selectinload(SandboxListing.latest_version))
-                    .where(SandboxListing.id.in_(sandbox_comp_ids))
+                    apply_publish_scope(
+                        apply_visibility_filter(
+                            select(SandboxListing)
+                            .options(selectinload(SandboxListing.latest_version))
+                            .where(SandboxListing.id.in_(sandbox_comp_ids)),
+                            SandboxListing,
+                            current_user,
+                        ),
+                        SandboxListing,
+                        component_target_team_id,
+                    )
                 )
             )
             .scalars()
@@ -206,6 +245,16 @@ async def install_agent(
                         status_code=404, detail=f"Sandbox {listing.name} version {resolved_version!r} not found"
                     )
                 sandbox_listings_map[sid] = _VersionedSandboxListing(listing, pinned)
+
+    component_maps = (
+        (mcp_comp_ids, mcp_listings_map),
+        (skill_comp_ids, skill_listings_map),
+        (hook_comp_ids, hook_listings_map),
+        (prompt_comp_ids, prompt_listings_map),
+        (sandbox_comp_ids, sandbox_listings_map),
+    )
+    if any(set(ids) - set(listings) for ids, listings in component_maps):
+        raise HTTPException(status_code=404, detail="Agent contains a component unavailable to this agent target")
 
     archived_warnings = []
     setup_warnings = []
@@ -302,11 +351,9 @@ async def agent_download_stats(
         db,
         agent_id,
         prefer_user_id=current_user.id if current_user else None,
-        org_id=current_user.org_id if current_user else None,
+        current_user=current_user,
     )
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user is not None and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view stats for this agent")
@@ -330,11 +377,9 @@ async def get_agent_traces(
         db,
         agent_id,
         prefer_user_id=current_user.id if current_user else None,
-        org_id=current_user.org_id if current_user else None,
+        current_user=current_user,
     )
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user is not None and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent")
@@ -349,16 +394,14 @@ async def resolve_agent_components(
 ):
     """Resolve all components for an agent - validates they exist and are approved."""
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to resolve this agent")
     from services.agent_resolver import resolve_agent
 
-    resolved = await resolve_agent(agent, db)
+    resolved = await resolve_agent(agent, db, current_user=current_user)
     from services.agent_builder import build_composition_summary
 
     return build_composition_summary(resolved)
@@ -372,16 +415,14 @@ async def get_agent_manifest(
 ):
     """Generate a portable agent manifest with all resolved components."""
     optic.trace("agent_id={}", agent_id)
-    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, org_id=current_user.org_id)
+    agent = await _load_agent(db, agent_id, prefer_user_id=current_user.id, current_user=current_user)
     if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
         raise HTTPException(status_code=404, detail="Agent not found")
     if get_effective_agent_permission(agent, current_user) == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent's manifest")
     from services.agent_resolver import resolve_agent
 
-    resolved = await resolve_agent(agent, db)
+    resolved = await resolve_agent(agent, db, current_user=current_user)
     if not resolved.ok:
         raise HTTPException(
             status_code=422,
@@ -415,6 +456,9 @@ async def validate_agent_composition(
         [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
         db,
         require_approved=False,
+        current_user=current_user,
+        target_team_id=req.team_id if req.visibility == "team" else None,
+        enforce_target=True,
     )
     issues = [
         ValidationIssue(

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -22,7 +22,12 @@ from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 
-from api.deps import get_db, get_effective_agent_permission, require_role
+from api.deps import (
+    get_db,
+    get_effective_agent_permission,
+    may_view_unapproved,
+    require_role,
+)
 from models.agent import (
     Agent,
     AgentStatus,
@@ -130,10 +135,18 @@ async def _list_agent_versions(
     if perm == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent")
 
+    # A version carries the agent's prompt and generated harness config. Seeing the
+    # agent is not enough to read a version nobody has approved: making a
+    # team-private agent public returns its versions to the queue, and without this
+    # an ordinary caller reads them before a reviewer does.
+    version_filters = [AgentVersion.agent_id == agent.id]
+    if not may_view_unapproved(perm, current_user):
+        version_filters.append(AgentVersion.status == AgentStatus.approved)
+
     offset = (page - 1) * page_size
     stmt = (
         select(AgentVersion)
-        .where(AgentVersion.agent_id == agent.id)
+        .where(*version_filters)
         .order_by(AgentVersion.created_at.desc())
         .offset(offset)
         .limit(page_size)
@@ -167,10 +180,15 @@ async def _get_agent_version(
     if perm == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent")
 
-    stmt = select(AgentVersion).where(
-        AgentVersion.agent_id == agent.id,
-        AgentVersion.version == version,
-    )
+    # A version carries the agent's prompt and generated harness config. Seeing the
+    # agent is not enough to read a version nobody has approved: making a
+    # team-private agent public returns its versions to the queue, and without this
+    # an ordinary caller reads them before a reviewer does.
+    version_filters = [AgentVersion.agent_id == agent.id]
+    if not may_view_unapproved(perm, current_user):
+        version_filters.append(AgentVersion.status == AgentStatus.approved)
+
+    stmt = select(AgentVersion).where(*version_filters, AgentVersion.version == version)
     ver = (await db.execute(stmt)).scalar_one_or_none()
     if not ver:
         raise HTTPException(status_code=404, detail="Version not found")
@@ -378,10 +396,17 @@ async def _review_agent_version(
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    stmt = select(AgentVersion).where(
-        AgentVersion.agent_id == agent.id,
-        AgentVersion.version == version,
-    )
+    perm = get_effective_agent_permission(agent, current_user)
+
+    # A version carries the agent's prompt and generated harness config. Seeing the
+    # agent is not enough to read a version nobody has approved: making a
+    # team-private agent public returns its versions to the queue, and without this
+    # an ordinary caller reads them before a reviewer does.
+    version_filters = [AgentVersion.agent_id == agent.id]
+    if not may_view_unapproved(perm, current_user):
+        version_filters.append(AgentVersion.status == AgentStatus.approved)
+
+    stmt = select(AgentVersion).where(*version_filters, AgentVersion.version == version)
     ver = (await db.execute(stmt)).scalar_one_or_none()
     if not ver:
         raise HTTPException(status_code=404, detail="Version not found")
@@ -438,10 +463,15 @@ async def _get_agent_harness_config(
     if perm == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent")
 
-    stmt = select(AgentVersion).where(
-        AgentVersion.agent_id == agent.id,
-        AgentVersion.version == version,
-    )
+    # A version carries the agent's prompt and generated harness config. Seeing the
+    # agent is not enough to read a version nobody has approved: making a
+    # team-private agent public returns its versions to the queue, and without this
+    # an ordinary caller reads them before a reviewer does.
+    version_filters = [AgentVersion.agent_id == agent.id]
+    if not may_view_unapproved(perm, current_user):
+        version_filters.append(AgentVersion.status == AgentStatus.approved)
+
+    stmt = select(AgentVersion).where(*version_filters, AgentVersion.version == version)
     ver = (await db.execute(stmt)).scalar_one_or_none()
     if not ver:
         raise HTTPException(status_code=404, detail="Version not found")

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -502,12 +502,16 @@ async def _get_version_diff(
     if perm == "none":
         raise HTTPException(status_code=403, detail="Insufficient permissions to view this agent")
 
-    stmt1 = select(AgentVersion).where(AgentVersion.agent_id == agent.id, AgentVersion.version == v1)
+    version_filters = [AgentVersion.agent_id == agent.id]
+    if not may_view_unapproved(perm, current_user):
+        version_filters.append(AgentVersion.status == AgentStatus.approved)
+
+    stmt1 = select(AgentVersion).where(*version_filters, AgentVersion.version == v1)
     ver1 = (await db.execute(stmt1)).scalar_one_or_none()
     if not ver1:
         raise HTTPException(status_code=404, detail=f"Version {v1!r} not found")
 
-    stmt2 = select(AgentVersion).where(AgentVersion.agent_id == agent.id, AgentVersion.version == v2)
+    stmt2 = select(AgentVersion).where(*version_filters, AgentVersion.version == v2)
     ver2 = (await db.execute(stmt2)).scalar_one_or_none()
     if not ver2:
         raise HTTPException(status_code=404, detail=f"Version {v2!r} not found")

--- a/observal-server/api/routes/agent_versions.py
+++ b/observal-server/api/routes/agent_versions.py
@@ -42,6 +42,11 @@ from services.versioning import parse_semver, validate_semver
 
 agent_version_router = APIRouter()
 
+
+async def audit(*_args, **_kwargs):
+    return None
+
+
 # Import _load_agent from agent.py to avoid duplication.
 # This is a late import done inside each function to avoid circular imports
 # at module load time (agent.py imports from schemas.agent which we also import here).
@@ -101,12 +106,12 @@ def _version_to_detail(ver: AgentVersion) -> dict:
 # ---------------------------------------------------------------------------
 
 
-async def _load_agent(db: AsyncSession, agent_id: str) -> Agent | None:
+async def _load_agent(db: AsyncSession, agent_id: str, current_user: User | None = None) -> Agent | None:
     """Thin wrapper that delegates to the route-level _load_agent."""
     optic.trace("agent_id={}", agent_id)
     from api.routes.agent import _load_agent as _base_load
 
-    return await _base_load(db, agent_id)
+    return await _base_load(db, agent_id, current_user=current_user)
 
 
 async def _list_agent_versions(
@@ -117,7 +122,7 @@ async def _list_agent_versions(
     current_user: User,
 ) -> dict:
     optic.trace("agent_id={}, page={}", agent_id, page)
-    agent = await _load_agent(db, agent_id)
+    agent = await _load_agent(db, agent_id, current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -154,7 +159,7 @@ async def _get_agent_version(
     current_user: User,
 ) -> dict:
     optic.trace("agent_id={}, version={}", agent_id, version)
-    agent = await _load_agent(db, agent_id)
+    agent = await _load_agent(db, agent_id, current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -194,7 +199,7 @@ async def _create_agent_version(
     if not validate_semver(req.version):
         raise HTTPException(status_code=422, detail=f"Invalid semver string: {req.version!r}")
 
-    agent = await _load_agent(db, agent_id)
+    agent = await _load_agent(db, agent_id, current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -215,6 +220,9 @@ async def _create_agent_version(
         errors = await validate_component_ids(
             [{"component_type": c.component_type, "component_id": c.component_id} for c in req.components],
             db,
+            current_user=current_user,
+            target_team_id=agent.team_id if agent.is_private else None,
+            enforce_target=True,
         )
         if errors:
             raise HTTPException(
@@ -366,7 +374,7 @@ async def _review_agent_version(
     current_user: User,
 ) -> dict:
     optic.trace("agent_id={}, version={}", agent_id, version)
-    agent = await _load_agent(db, agent_id)
+    agent = await _load_agent(db, agent_id, current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -422,7 +430,7 @@ async def _get_agent_harness_config(
     current_user: User,
 ) -> dict:
     optic.trace("agent_id={}, version={}", agent_id, version)
-    agent = await _load_agent(db, agent_id)
+    agent = await _load_agent(db, agent_id, current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 
@@ -456,7 +464,7 @@ async def _get_version_diff(
     current_user: User,
 ) -> dict:
     optic.trace("agent_id={}, v1={}", agent_id, v1)
-    agent = await _load_agent(db, agent_id)
+    agent = await _load_agent(db, agent_id, current_user)
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
 

--- a/observal-server/api/routes/bulk.py
+++ b/observal-server/api/routes/bulk.py
@@ -45,7 +45,6 @@ async def _create_single_agent(
         slug=slug,
         owner=item.owner or user.email,
         created_by=user.id,
-        owner_org_id=user.org_id,
     )
     db.add(agent)
     await db.flush()

--- a/observal-server/api/routes/co_authors.py
+++ b/observal-server/api/routes/co_authors.py
@@ -30,9 +30,11 @@ from models.mcp import McpListing, McpVersion
 from models.prompt import PromptListing, PromptVersion
 from models.sandbox import SandboxListing, SandboxVersion
 from models.skill import SkillListing, SkillVersion
+from models.team import TeamRole
 from models.user import User
 from services.ownership import transfer_entity_owner
 from services.registry_namespace import identity_exists
+from services.teamspace import is_admin, review_publication_to_public, team_membership
 
 router = APIRouter(prefix="/api/v1", tags=["co-authors"])
 
@@ -165,14 +167,24 @@ async def transfer_ownership(
     current_user: User = Depends(get_current_user),
 ):
     entity = await _get_entity_for_transfer(entity_type, entity_id, current_user, db)
-    # Transfer rewrites the namespace to the target user's handle. A teamspace
-    # listing would end up in a user namespace while still carrying the team's
-    # id and visibility, so refuse instead of silently rehoming or publishing it.
-    if getattr(entity, "team_id", None) is not None:
-        raise HTTPException(
-            status_code=409,
-            detail="This listing belongs to a teamspace; move it out of the teamspace before transferring ownership",
-        )
+
+    # Transfer rewrites the namespace to the target user's handle, so a teamspace
+    # listing has to leave its teamspace on the way out. Refusing outright used to
+    # be a dead end: deleting a teamspace requires emptying it, emptying it
+    # requires transferring, and transferring refused every team-owned listing.
+    #
+    # Leaving a teamspace also means losing team visibility, because team-private
+    # requires a teamspace. That makes the listing public, which is a publication,
+    # so it returns to the review queue on the way just like any other
+    # private-to-public transition.
+    team_id = getattr(entity, "team_id", None)
+    if team_id is not None:
+        membership = await team_membership(db, team_id, current_user.id)
+        if not is_admin(current_user) and (not membership or membership.role != TeamRole.owner):
+            raise HTTPException(
+                status_code=403,
+                detail="Only a teamspace owner or an admin can transfer a listing out of a teamspace",
+            )
     target_user = await _resolve_target_user(db, user_id=req.user_id, email=req.email, username=req.username)
     if not target_user:
         raise HTTPException(status_code=404, detail="User not found")
@@ -180,6 +192,12 @@ async def transfer_ownership(
         raise HTTPException(status_code=422, detail="Cannot transfer ownership to a deactivated user")
     if target_user.id == current_user.id:
         raise HTTPException(status_code=422, detail="You already own this item")
+
+    was_private = bool(getattr(entity, "is_private", False))
+    if team_id is not None:
+        entity.team_id = None
+        entity.is_private = False
+        await review_publication_to_public(entity, current_user, db, was_private=was_private)
 
     model = ENTITY_MODELS[entity_type]
     if await identity_exists(db, model, target_user.username, entity.slug, exclude_id=entity.id):

--- a/observal-server/api/routes/co_authors.py
+++ b/observal-server/api/routes/co_authors.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
+    check_listing_visibility_async,
     commit_or_name_conflict,
     get_current_user,
     get_db,
@@ -118,7 +119,7 @@ async def _get_entity_for_transfer(entity_type: str, entity_id: str, current_use
     if not model:
         raise HTTPException(status_code=400, detail=f"Invalid entity type: {entity_type}")
 
-    entity = await resolve_listing(model, entity_id, db)
+    entity = await resolve_listing(model, entity_id, db, current_user=current_user)
 
     if not entity:
         raise HTTPException(status_code=404, detail=f"{entity_type[:-1].title()} not found")
@@ -164,6 +165,14 @@ async def transfer_ownership(
     current_user: User = Depends(get_current_user),
 ):
     entity = await _get_entity_for_transfer(entity_type, entity_id, current_user, db)
+    # Transfer rewrites the namespace to the target user's handle. A teamspace
+    # listing would end up in a user namespace while still carrying the team's
+    # id and visibility, so refuse instead of silently rehoming or publishing it.
+    if getattr(entity, "team_id", None) is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="This listing belongs to a teamspace; move it out of the teamspace before transferring ownership",
+        )
     target_user = await _resolve_target_user(db, user_id=req.user_id, email=req.email, username=req.username)
     if not target_user:
         raise HTTPException(status_code=404, detail="User not found")
@@ -207,7 +216,7 @@ async def list_co_authors(
         raise HTTPException(status_code=400, detail=f"Invalid entity type: {entity_type}")
 
     entity = await db.get(model, entity_id)
-    if not entity:
+    if not entity or not await check_listing_visibility_async(entity, current_user, db):
         raise HTTPException(status_code=404, detail=f"{entity_type[:-1].title()} not found")
 
     co_author_ids = entity.co_authors or []

--- a/observal-server/api/routes/co_authors.py
+++ b/observal-server/api/routes/co_authors.py
@@ -100,7 +100,9 @@ async def _get_entity_and_check_permission(
     if not model:
         raise HTTPException(status_code=400, detail=f"Invalid entity type: {entity_type}")
 
-    entity = await db.get(model, entity_id)
+    # resolve_listing, not db.get: it applies the caller's visibility, so a listing
+    # they cannot read is not one they can edit the co-authors of either.
+    entity = await resolve_listing(model, str(entity_id), db, current_user=current_user)
     if not entity:
         raise HTTPException(status_code=404, detail=f"{entity_type[:-1].title()} not found")
 
@@ -126,8 +128,23 @@ async def _get_entity_for_transfer(entity_type: str, entity_id: str, current_use
     if not entity:
         raise HTTPException(status_code=404, detail=f"{entity_type[:-1].title()} not found")
 
+    # Authority depends on where the listing lives. A team-owned listing belongs to
+    # its teamspace, so a team owner or admin may move it even though they did not
+    # submit it. Checking the submitter first, as this used to, meant a team owner
+    # was refused before the teamspace rule was ever consulted, which left a
+    # teamspace impossible to empty and therefore impossible to delete.
     owner_id = entity.created_by if entity_type == "agents" else entity.submitted_by
-    if owner_id != current_user.id:
+    if getattr(entity, "team_id", None) is not None:
+        if is_admin(current_user):
+            return entity
+        membership = await team_membership(db, entity.team_id, current_user.id)
+        if membership and membership.role == TeamRole.owner:
+            return entity
+        raise HTTPException(
+            status_code=403,
+            detail="Only a teamspace owner or an admin can transfer a listing out of a teamspace",
+        )
+    if owner_id != current_user.id and not is_admin(current_user):
         raise HTTPException(status_code=403, detail="Only the current owner can transfer ownership")
     return entity
 
@@ -177,20 +194,15 @@ async def transfer_ownership(
     # requires a teamspace. That makes the listing public, which is a publication,
     # so it returns to the review queue on the way just like any other
     # private-to-public transition.
+    # _get_entity_for_transfer has already authorized the move; it needs the
+    # teamspace rule itself in order to decide.
     team_id = getattr(entity, "team_id", None)
-    if team_id is not None:
-        membership = await team_membership(db, team_id, current_user.id)
-        if not is_admin(current_user) and (not membership or membership.role != TeamRole.owner):
-            raise HTTPException(
-                status_code=403,
-                detail="Only a teamspace owner or an admin can transfer a listing out of a teamspace",
-            )
     target_user = await _resolve_target_user(db, user_id=req.user_id, email=req.email, username=req.username)
     if not target_user:
         raise HTTPException(status_code=404, detail="User not found")
     if target_user.auth_provider == "deactivated":
         raise HTTPException(status_code=422, detail="Cannot transfer ownership to a deactivated user")
-    if target_user.id == current_user.id:
+    if target_user.id == current_user.id and team_id is None:
         raise HTTPException(status_code=422, detail="You already own this item")
 
     was_private = bool(getattr(entity, "is_private", False))

--- a/observal-server/api/routes/component_source.py
+++ b/observal-server/api/routes/component_source.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role
 from models.component_source import ComponentSource
-from models.team import TeamMembership
+from models.team import TeamMembership, TeamRole
 from models.user import User, UserRole
 from schemas.component_source import (
     ComponentSourceCreate,
@@ -22,7 +22,7 @@ from schemas.component_source import (
     SyncResponse,
 )
 from services.git_mirror_service import sync_source
-from services.teamspace import resolve_publish_target
+from services.teamspace import is_admin, resolve_publish_target, team_membership
 
 router = APIRouter(prefix="/api/v1/component-sources", tags=["component-sources"])
 
@@ -164,12 +164,16 @@ async def trigger_sync(
 async def delete_source(
     source_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.admin)),
+    current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("component_source delete")
     source = await db.get(ComponentSource, source_id)
-    if not source:
+    if not source or not await _source_visible(source, current_user, db):
         raise HTTPException(status_code=404, detail="Source not found")
+    if not is_admin(current_user):
+        membership = await team_membership(db, source.team_id, current_user.id) if source.team_id else None
+        if not membership or membership.role != TeamRole.owner:
+            raise HTTPException(status_code=403, detail="Only teamspace owners and admins can delete this source")
     await db.delete(source)
     await db.commit()
     return {"deleted": str(source_id)}

--- a/observal-server/api/routes/component_source.py
+++ b/observal-server/api/routes/component_source.py
@@ -8,12 +8,13 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger as optic
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import get_db, require_role
 from models.component_source import ComponentSource
+from models.team import TeamMembership
 from models.user import User, UserRole
 from schemas.component_source import (
     ComponentSourceCreate,
@@ -21,8 +22,25 @@ from schemas.component_source import (
     SyncResponse,
 )
 from services.git_mirror_service import sync_source
+from services.teamspace import resolve_publish_target
 
 router = APIRouter(prefix="/api/v1/component-sources", tags=["component-sources"])
+
+
+async def _source_visible(source: ComponentSource, current_user: User, db: AsyncSession) -> bool:
+    if source.is_public or current_user.role in (UserRole.super_admin, UserRole.admin, UserRole.reviewer):
+        return True
+    if source.team_id is None:
+        return False
+    return (
+        await db.scalar(
+            select(TeamMembership.id).where(
+                TeamMembership.team_id == source.team_id,
+                TeamMembership.user_id == current_user.id,
+            )
+        )
+        is not None
+    )
 
 
 @router.post("", response_model=ComponentSourceResponse, status_code=201)
@@ -40,13 +58,19 @@ async def add_source(
     elif "bitbucket" in url_lower:
         provider = "bitbucket"
 
-    # Always derive owner from the authenticated user's org - never trust client-supplied org
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        "source",
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
     source = ComponentSource(
         url=req.url,
         provider=provider,
         component_type=req.component_type,
-        is_public=req.is_public,
-        owner_org_id=current_user.org_id,
+        is_public=target.visibility == "public",
+        team_id=target.team_id,
     )
     try:
         db.add(source)
@@ -68,14 +92,19 @@ async def list_sources(
     stmt = select(ComponentSource)
     if component_type:
         stmt = stmt.where(ComponentSource.component_type == component_type)
-    # Scope: public sources are visible to all; private sources only to owning org
-    if current_user.org_id is not None:
-        stmt = stmt.where(
-            (ComponentSource.is_public == True)  # noqa: E712
-            | (ComponentSource.owner_org_id == current_user.org_id)
+    if current_user.role not in (UserRole.super_admin, UserRole.admin, UserRole.reviewer):
+        member = (
+            select(TeamMembership.id)
+            .where(TeamMembership.team_id == ComponentSource.team_id, TeamMembership.user_id == current_user.id)
+            .correlate(ComponentSource)
+            .exists()
         )
-    else:
-        stmt = stmt.where(ComponentSource.is_public == True)  # noqa: E712
+        stmt = stmt.where(
+            or_(
+                ComponentSource.is_public == True,  # noqa: E712
+                and_(ComponentSource.is_public == False, member),  # noqa: E712
+            )
+        )
     result = await db.execute(stmt.order_by(ComponentSource.created_at.desc()))
     sources = result.scalars().all()
     return [ComponentSourceResponse.model_validate(s) for s in sources]
@@ -91,8 +120,7 @@ async def get_source(
     source = await db.get(ComponentSource, source_id)
     if not source:
         raise HTTPException(status_code=404, detail="Source not found")
-    # Private sources are only visible to the owning org
-    if not source.is_public and (current_user.org_id is None or source.owner_org_id != current_user.org_id):
+    if not await _source_visible(source, current_user, db):
         raise HTTPException(status_code=404, detail="Source not found")
     return ComponentSourceResponse.model_validate(source)
 

--- a/observal-server/api/routes/component_versions.py
+++ b/observal-server/api/routes/component_versions.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 from api.deps import (
     get_db,
     get_effective_component_permission,
+    may_view_unapproved,
     require_role,
     resolve_visible_listing,
 )
@@ -88,10 +89,20 @@ async def _list_versions(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
+    # A version carries the real payload: prompt templates, MCP commands and args,
+    # hook handler config, SKILL.md. Seeing the listing is not enough to read a
+    # version that has not been approved. This matters most right after a team
+    # listing goes public: the listing is public immediately while its versions
+    # return to the review queue, and without this filter an ordinary caller reads
+    # content no global reviewer has accepted yet.
+    version_filters = [version_model.listing_id == listing.id]
+    if not may_view_unapproved(get_effective_component_permission(listing, current_user), current_user):
+        version_filters.append(version_model.status == ListingStatus.approved)
+
     offset = (page - 1) * page_size
     stmt = (
         select(version_model)
-        .where(version_model.listing_id == listing.id)
+        .where(*version_filters)
         .order_by(version_model.released_at.desc())
         .offset(offset)
         .limit(page_size)
@@ -99,7 +110,7 @@ async def _list_versions(
     result = await db.execute(stmt)
     versions = result.scalars().all()
 
-    count_stmt = select(func.count(version_model.id)).where(version_model.listing_id == listing.id)
+    count_stmt = select(func.count(version_model.id)).where(*version_filters)
     total = (await db.execute(count_stmt)).scalar() or 0
 
     return {
@@ -124,10 +135,10 @@ async def _get_version(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    stmt = select(version_model).where(
-        version_model.listing_id == listing.id,
-        version_model.version == version,
-    )
+    version_filters = [version_model.listing_id == listing.id, version_model.version == version]
+    if not may_view_unapproved(get_effective_component_permission(listing, current_user), current_user):
+        version_filters.append(version_model.status == ListingStatus.approved)
+    stmt = select(version_model).where(*version_filters)
     result = await db.execute(stmt)
     ver = result.scalar_one_or_none()
     if not ver:
@@ -268,10 +279,10 @@ async def _review_version(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    stmt = select(version_model).where(
-        version_model.listing_id == listing.id,
-        version_model.version == version,
-    )
+    version_filters = [version_model.listing_id == listing.id, version_model.version == version]
+    if not may_view_unapproved(get_effective_component_permission(listing, current_user), current_user):
+        version_filters.append(version_model.status == ListingStatus.approved)
+    stmt = select(version_model).where(*version_filters)
     result = await db.execute(stmt)
     ver = result.scalar_one_or_none()
     if not ver:

--- a/observal-server/api/routes/component_versions.py
+++ b/observal-server/api/routes/component_versions.py
@@ -19,7 +19,12 @@ from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 
-from api.deps import get_db, get_effective_component_permission, require_role, resolve_listing
+from api.deps import (
+    get_db,
+    get_effective_component_permission,
+    require_role,
+    resolve_visible_listing,
+)
 from models.mcp import ListingStatus
 from models.user import User, UserRole
 from schemas.component_version import VersionPublishRequest, VersionReviewRequest  # noqa: TC001
@@ -79,7 +84,7 @@ async def _list_versions(
     current_user: User,
 ) -> dict:
     optic.trace("listing_id={}, page={}", listing_id, page)
-    listing = await resolve_listing(listing_model, listing_id, db)
+    listing = await resolve_visible_listing(listing_model, listing_id, db, current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
@@ -115,7 +120,7 @@ async def _get_version(
     current_user: User,
 ) -> dict:
     optic.trace("listing_id={}, version={}", listing_id, version)
-    listing = await resolve_listing(listing_model, listing_id, db)
+    listing = await resolve_visible_listing(listing_model, listing_id, db, current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
@@ -144,7 +149,7 @@ async def _publish_version(
     if not SEMVER_RE.match(req.version):
         raise HTTPException(status_code=422, detail=f"Invalid semver string: {req.version!r}")
 
-    listing = await resolve_listing(listing_model, listing_id, db)
+    listing = await resolve_visible_listing(listing_model, listing_id, db, current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
@@ -224,7 +229,7 @@ async def _version_suggestions(
     current_user: User,
 ) -> dict:
     optic.trace("listing_id={}, listing_model={}", listing_id, listing_model)
-    listing = await resolve_listing(listing_model, listing_id, db)
+    listing = await resolve_visible_listing(listing_model, listing_id, db, current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
@@ -259,7 +264,7 @@ async def _review_version(
     current_user: User,
 ) -> dict:
     optic.trace("listing_id={}, version={}", listing_id, version)
-    listing = await resolve_listing(listing_model, listing_id, db)
+    listing = await resolve_visible_listing(listing_model, listing_id, db, current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 

--- a/observal-server/api/routes/dashboard.py
+++ b/observal-server/api/routes/dashboard.py
@@ -14,13 +14,11 @@ from datetime import UTC, timedelta
 from datetime import datetime as dt
 
 from fastapi import APIRouter, Depends, Query
-from fastapi_cache.decorator import cache
 from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 
-import services.dynamic_settings as ds
-from api.deps import get_db, require_role
+from api.deps import apply_visibility_filter, get_db, optional_current_user, require_role
 from api.sanitize import escape_like
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.agent_component import AgentComponent
@@ -92,10 +90,10 @@ async def _ch_json_scoped(sql: str, current_user, params: dict | None = None) ->
 
 
 @router.get("/overview/stats", response_model=OverviewStats)
-@cache(expire=ds.get_sync_int("data.cache_ttl_dashboard", 60), namespace="dashboard")
 async def overview_stats(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
 
     optic.trace("range={}", range_)
@@ -103,16 +101,18 @@ async def overview_stats(
     days = _range_days(range_)
 
     # Fan out all independent queries in parallel (3 Postgres + 2 ClickHouse)
-    total_mcps_coro = db.scalar(
+    total_mcps_stmt = (
         select(func.count(McpListing.id))
         .join(McpVersion, McpListing.latest_version_id == McpVersion.id)
         .where(McpVersion.status == ListingStatus.approved)
     )
-    total_agents_coro = db.scalar(
+    total_agents_stmt = (
         select(func.count(Agent.id))
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
         .where(AgentVersion.status == AgentStatus.approved, Agent.deleted_at.is_(None))
     )
+    total_mcps_coro = db.scalar(apply_visibility_filter(total_mcps_stmt, McpListing, current_user))
+    total_agents_coro = db.scalar(apply_visibility_filter(total_agents_stmt, Agent, current_user))
     total_users_coro = db.scalar(select(func.count(User.id)))
     tool_rows_coro = _ch_json(
         "SELECT sum(tool_call_count) as cnt FROM session_stats_agg FINAL WHERE last_event_time > now() - INTERVAL {days:UInt32} DAY",
@@ -141,26 +141,27 @@ async def overview_stats(
 
 
 @router.get("/overview/top-mcps", response_model=list[TopItem])
-@cache(expire=ds.get_sync_int("data.cache_ttl_dashboard", 60), namespace="dashboard")
-async def top_mcps(db: AsyncSession = Depends(get_db)):
+async def top_mcps(
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+):
     optic.debug("top_mcps called")
-    result = await db.execute(
-        select(McpDownload.listing_id, func.count(McpDownload.id).label("cnt"), McpListing.name)
-        .join(McpListing, McpDownload.listing_id == McpListing.id)
-        .group_by(McpDownload.listing_id, McpListing.name)
-        .order_by(func.count(McpDownload.id).desc())
-        .limit(5)
+    stmt = select(McpDownload.listing_id, func.count(McpDownload.id).label("cnt"), McpListing.name).join(
+        McpListing, McpDownload.listing_id == McpListing.id
     )
+    stmt = apply_visibility_filter(stmt, McpListing, current_user)
+    stmt = stmt.group_by(McpDownload.listing_id, McpListing.name).order_by(func.count(McpDownload.id).desc()).limit(5)
+    result = await db.execute(stmt)
     return [TopItem(id=row.listing_id, name=row.name, value=row.cnt) for row in result.all()]
 
 
 @router.get("/overview/top-agents", response_model=list[TopAgentItem])
-@cache(expire=ds.get_sync_int("data.cache_ttl_dashboard", 60), namespace="dashboard")
 async def top_agents(
     limit: int = Query(6, le=50),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
-    result = await db.execute(
+    stmt = (
         select(
             AgentDownloadRecord.agent_id,
             func.count(AgentDownloadRecord.id).label("cnt"),
@@ -172,10 +173,16 @@ async def top_agents(
         .join(Agent, AgentDownloadRecord.agent_id == Agent.id)
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
         .where(AgentVersion.status == AgentStatus.approved, Agent.deleted_at.is_(None))
-        .group_by(AgentDownloadRecord.agent_id, Agent.name, AgentVersion.description, Agent.owner, AgentVersion.version)
+    )
+    stmt = apply_visibility_filter(stmt, Agent, current_user)
+    stmt = (
+        stmt.group_by(
+            AgentDownloadRecord.agent_id, Agent.name, AgentVersion.description, Agent.owner, AgentVersion.version
+        )
         .order_by(func.count(AgentDownloadRecord.id).desc())
         .limit(limit)
     )
+    result = await db.execute(stmt)
     rows = result.all()
 
     # Batch-fetch average ratings
@@ -204,12 +211,12 @@ async def top_agents(
 
 
 @router.get("/overview/leaderboard", response_model=list[LeaderboardItem])
-@cache(expire=ds.get_sync_int("data.cache_ttl_dashboard", 60), namespace="dashboard")
 async def agent_leaderboard(
     window: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
     limit: int = Query(20, le=50),
     user: str | None = Query(None, description="Filter by creator email"),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
     """Public leaderboard of agents ranked by downloads within a time window."""
     stmt = (
@@ -226,6 +233,7 @@ async def agent_leaderboard(
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
         .where(AgentVersion.status == AgentStatus.approved, Agent.deleted_at.is_(None))
     )
+    stmt = apply_visibility_filter(stmt, Agent, current_user)
     if user:
         stmt = stmt.join(User, Agent.created_by == User.id).where(User.email.ilike(f"%{escape_like(user)}%"))
     if window != "all":
@@ -274,6 +282,7 @@ async def agent_leaderboard(
                 Agent.id.notin_(existing_ids),
             )
         )
+        extra_stmt = apply_visibility_filter(extra_stmt, Agent, current_user)
         if user:
             extra_stmt = extra_stmt.join(User, Agent.created_by == User.id).where(
                 User.email.ilike(f"%{escape_like(user)}%")
@@ -322,12 +331,12 @@ async def agent_leaderboard(
 
 
 @router.get("/overview/component-leaderboard", response_model=list[ComponentLeaderboardItem])
-@cache(expire=ds.get_sync_int("data.cache_ttl_dashboard", 60), namespace="dashboard")
 async def component_leaderboard(
     window: str = Query("7d", pattern="^(24h|7d|30d|all)$"),
     limit: int = Query(20, le=50),
     user: str | None = Query(None, description="Filter by creator email"),
     db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
 ):
     """Public leaderboard of components ranked by agent downloads within a time window."""
     listing_types = [
@@ -364,6 +373,8 @@ async def component_leaderboard(
                 Agent.deleted_at.is_(None),
             )
         )
+        stmt = apply_visibility_filter(stmt, Agent, current_user)
+        stmt = apply_visibility_filter(stmt, listing_model, current_user)
         if user:
             stmt = stmt.join(User, listing_model.submitted_by == User.id).where(
                 User.email.ilike(f"%{escape_like(user)}%")
@@ -438,9 +449,9 @@ async def component_leaderboard(
                 select(listing_model.id, listing_model.name, version_model.description, listing_model.submitted_by)
                 .join(version_model, listing_model.latest_version_id == version_model.id)
                 .where(version_model.status == ListingStatus.approved, listing_model.id.notin_(existing_ids))
-                .order_by(listing_model.created_at.desc())
-                .limit(limit - len(all_items))
             )
+            extra_stmt = apply_visibility_filter(extra_stmt, listing_model, current_user)
+            extra_stmt = extra_stmt.order_by(listing_model.created_at.desc()).limit(limit - len(all_items))
             extra_rows = (await db.execute(extra_stmt)).all()
             extra_sub_ids = {r.submitted_by for r in extra_rows if r.submitted_by} - set(email_map)
             if extra_sub_ids:
@@ -472,7 +483,6 @@ async def component_leaderboard(
 
 
 @router.get("/overview/trends", response_model=list[TrendPoint])
-@cache(expire=ds.get_sync_int("data.cache_ttl_dashboard", 60), namespace="dashboard")
 async def trends(
     range_: str | None = Query(None, alias="range"),
     db: AsyncSession = Depends(get_db),
@@ -484,14 +494,10 @@ async def trends(
 
     day_col_mcp = func.date_trunc("day", McpListing.created_at).label("day")
     mcp_stmt = select(day_col_mcp, func.count(McpListing.id).label("cnt")).where(McpListing.created_at >= start)
-    if current_user.org_id is not None:
-        mcp_stmt = mcp_stmt.where(McpListing.owner_org_id == current_user.org_id)
     mcp_rows = await db.execute(mcp_stmt.group_by(day_col_mcp).order_by(day_col_mcp))
 
     day_col_user = func.date_trunc("day", User.created_at).label("day")
     user_stmt = select(day_col_user, func.count(User.id).label("cnt")).where(User.created_at >= start)
-    if current_user.org_id is not None:
-        user_stmt = user_stmt.where(User.org_id == current_user.org_id)
     user_rows = await db.execute(user_stmt.group_by(day_col_user).order_by(day_col_user))
 
     submissions = {str(r.day.date()): r.cnt for r in mcp_rows.all()}

--- a/observal-server/api/routes/exec_dashboard.py
+++ b/observal-server/api/routes/exec_dashboard.py
@@ -297,12 +297,7 @@ async def get_agent_counts(
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Agent count breakdown by status and category."""
-    org_id = current_user.org_id
-
     base = select(Agent)
-    if org_id:
-        base = base.where(Agent.owner_org_id == org_id)
-
     # Total
     total = await db.scalar(select(func.count()).select_from(base.subquery())) or 0
 
@@ -312,8 +307,6 @@ async def get_agent_counts(
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
         .where(AgentVersion.status == AgentStatus.approved)
     )
-    if org_id:
-        pub_stmt = pub_stmt.where(Agent.owner_org_id == org_id)
     published = await db.scalar(pub_stmt) or 0
 
     # In development (pending/draft)
@@ -322,8 +315,6 @@ async def get_agent_counts(
         .join(AgentVersion, Agent.latest_version_id == AgentVersion.id)
         .where(AgentVersion.status.in_([AgentStatus.pending, AgentStatus.draft]))
     )
-    if org_id:
-        dev_stmt = dev_stmt.where(Agent.owner_org_id == org_id)
     in_development = await db.scalar(dev_stmt) or 0
 
     # Active agents with sessions in the last 7 days
@@ -337,8 +328,6 @@ async def get_agent_counts(
 
     # By category
     cat_stmt = select(Agent.category, func.count(Agent.id)).group_by(Agent.category)
-    if org_id:
-        cat_stmt = cat_stmt.where(Agent.owner_org_id == org_id)
     cat_rows = (await db.execute(cat_stmt)).all()
     by_category = [{"category": row[0] or "Uncategorized", "count": row[1]} for row in cat_rows]
 
@@ -585,8 +574,6 @@ async def get_top_agents(
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Top agents by composite score (downloads + sessions + rating)."""
-    org_id = current_user.org_id
-
     # Downloads from PG
     dl_stmt = select(AgentDownloadRecord.agent_id, func.count(AgentDownloadRecord.id).label("downloads")).group_by(
         AgentDownloadRecord.agent_id
@@ -644,8 +631,6 @@ async def get_top_agents(
     agent_info: dict[str, tuple[str, str]] = {}
     if valid_ids:
         info_stmt = select(Agent.id, Agent.name, Agent.category)
-        if org_id:
-            info_stmt = info_stmt.where(Agent.owner_org_id == org_id)
         info_stmt = info_stmt.where(Agent.id.in_(valid_ids))
         info_rows = (await db.execute(info_stmt)).all()
         agent_info = {str(r.id): (r.name, r.category or "Uncategorized") for r in info_rows}
@@ -1372,8 +1357,6 @@ async def get_inactivity_alerts(
     agent_info: dict[str, tuple[str, str]] = {}
     if agent_ids_to_resolve:
         info_stmt = select(Agent.id, Agent.name, Agent.category)
-        if org_id:
-            info_stmt = info_stmt.where(Agent.owner_org_id == org_id)
         info_stmt = info_stmt.where(Agent.id.in_(agent_ids_to_resolve))
         rows = (await db.execute(info_stmt)).all()
         agent_info = {str(r.id): (r.name, r.category or "Uncategorized") for r in rows}
@@ -1479,12 +1462,8 @@ async def get_time_to_value(
     current_user: User = Depends(require_role(UserRole.admin)),
 ):
     """Days from agent deployment to reaching 100 sessions."""
-    org_id = current_user.org_id
-
     # Get all agents with their created_at
     agent_stmt = select(Agent.id, Agent.name, Agent.category, Agent.created_at)
-    if org_id:
-        agent_stmt = agent_stmt.where(Agent.owner_org_id == org_id)
     agent_rows = (await db.execute(agent_stmt)).all()
 
     if not agent_rows:

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -11,7 +11,13 @@ from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import check_listing_visibility_async, get_db, optional_current_user, require_role
+from api.deps import (
+    apply_visibility_filter,
+    check_listing_visibility_async,
+    get_db,
+    optional_current_user,
+    require_role,
+)
 from models.agent import Agent
 from models.feedback import Feedback
 from models.hook import HookListing
@@ -197,28 +203,17 @@ async def my_feedback_received(
 ):
     """Feedback received on listings submitted/created by the current user."""
     optic.debug("my_feedback_received called")
-    mcp_ids = list(
-        (await db.execute(select(McpListing.id).where(McpListing.submitted_by == current_user.id))).scalars().all()
-    )
-    agent_ids = list((await db.execute(select(Agent.id).where(Agent.created_by == current_user.id))).scalars().all())
-    skill_ids = list(
-        (await db.execute(select(SkillListing.id).where(SkillListing.submitted_by == current_user.id))).scalars().all()
-    )
-    hook_ids = list(
-        (await db.execute(select(HookListing.id).where(HookListing.submitted_by == current_user.id))).scalars().all()
-    )
-    prompt_ids = list(
-        (await db.execute(select(PromptListing.id).where(PromptListing.submitted_by == current_user.id)))
-        .scalars()
-        .all()
-    )
-    sandbox_ids = list(
-        (await db.execute(select(SandboxListing.id).where(SandboxListing.submitted_by == current_user.id)))
-        .scalars()
-        .all()
-    )
-
-    all_ids = mcp_ids + agent_ids + skill_ids + hook_ids + prompt_ids + sandbox_ids
+    all_ids = []
+    for model, owner_column in (
+        (McpListing, McpListing.submitted_by),
+        (Agent, Agent.created_by),
+        (SkillListing, SkillListing.submitted_by),
+        (HookListing, HookListing.submitted_by),
+        (PromptListing, PromptListing.submitted_by),
+        (SandboxListing, SandboxListing.submitted_by),
+    ):
+        stmt = apply_visibility_filter(select(model.id).where(owner_column == current_user.id), model, current_user)
+        all_ids.extend((await db.execute(stmt)).scalars().all())
     if not all_ids:
         return []
 

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -11,7 +11,7 @@ from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role
+from api.deps import check_listing_visibility_async, get_db, optional_current_user, require_role
 from models.agent import Agent
 from models.feedback import Feedback
 from models.hook import HookListing
@@ -32,6 +32,26 @@ LISTING_MODELS = {
     "prompt": PromptListing,
     "sandbox": SandboxListing,
 }
+
+
+async def _visible_listing(db: AsyncSession, listing_type: str, listing_id: uuid.UUID, current_user: User | None):
+    model = LISTING_MODELS.get(listing_type)
+    if not model:
+        raise HTTPException(status_code=400, detail=f"Unknown listing type: {listing_type}")
+    listing = await db.scalar(select(model).where(model.id == listing_id))
+    if not listing or not await check_listing_visibility_async(listing, current_user, db):
+        raise HTTPException(status_code=404, detail="Listing not found")
+    return listing
+
+
+async def _visible_listing_by_id(db: AsyncSession, listing_id: uuid.UUID, current_user: User | None):
+    for listing_type in LISTING_MODELS:
+        try:
+            return await _visible_listing(db, listing_type, listing_id, current_user)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
+    raise HTTPException(status_code=404, detail="Listing not found")
 
 
 def _serialize_feedback(fb: Feedback) -> FeedbackResponse:
@@ -58,13 +78,8 @@ async def create_feedback(
     """Submit a review. One review per user per listing (returns 409 if already reviewed)."""
     optic.debug("feedback create: user={}, listing={}", current_user.id, req.listing_id)
 
-    # Validate listing exists
-    model = LISTING_MODELS.get(req.listing_type)
-    if not model:
-        raise HTTPException(status_code=400, detail=f"Unknown listing type: {req.listing_type}")
-    exists = await db.scalar(select(model.id).where(model.id == req.listing_id))
-    if not exists:
-        raise HTTPException(status_code=404, detail="Listing not found")
+    # Validate listing exists and is visible to the caller.
+    await _visible_listing(db, req.listing_type, req.listing_id, current_user)
 
     # Enforce one review per user per listing
     existing = await db.scalar(
@@ -103,8 +118,7 @@ async def get_my_review(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Get the current user's review for a specific listing (if it exists)."""
-    if listing_type not in LISTING_MODELS:
-        raise HTTPException(status_code=400, detail=f"Unknown listing type: {listing_type}")
+    await _visible_listing(db, listing_type, listing_id, current_user)
     result = await db.execute(
         select(Feedback).where(
             Feedback.user_id == current_user.id,
@@ -132,6 +146,7 @@ async def update_feedback(
         raise HTTPException(status_code=404, detail="Review not found")
     if fb.user_id != current_user.id:
         raise HTTPException(status_code=403, detail="You can only update your own review")
+    await _visible_listing(db, fb.listing_type, fb.listing_id, current_user)
 
     if req.rating is not None:
         fb.rating = req.rating
@@ -160,6 +175,7 @@ async def delete_feedback(
         raise HTTPException(status_code=404, detail="Review not found")
     if fb.user_id != current_user.id:
         raise HTTPException(status_code=403, detail="You can only delete your own review")
+    await _visible_listing(db, fb.listing_type, fb.listing_id, current_user)
 
     await db.delete(fb)
     await db.commit()
@@ -206,8 +222,13 @@ async def my_feedback_received(
 
 
 @router.get("/summary/{listing_id}", response_model=FeedbackSummary)
-async def feedback_summary(listing_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+async def feedback_summary(
+    listing_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+):
     optic.trace("listing_id={}", listing_id)
+    await _visible_listing_by_id(db, listing_id, current_user)
     result = await db.execute(
         select(
             func.avg(Feedback.rating).label("avg_rating"),
@@ -223,11 +244,15 @@ async def feedback_summary(listing_id: uuid.UUID, db: AsyncSession = Depends(get
 
 
 @router.get("/{listing_type}/{listing_id}", response_model=list[FeedbackResponse])
-async def get_feedback(listing_type: str, listing_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+async def get_feedback(
+    listing_type: str,
+    listing_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+):
     """Get all reviews for a listing. Anonymous reviews have user_id redacted."""
     optic.trace("listing_type={}, listing_id={}", listing_type, listing_id)
-    if listing_type not in LISTING_MODELS:
-        raise HTTPException(status_code=400, detail=f"Unknown listing type: {listing_type}")
+    await _visible_listing(db, listing_type, listing_id, current_user)
     result = await db.execute(
         select(Feedback)
         .where(Feedback.listing_id == listing_id, Feedback.listing_type == listing_type)

--- a/observal-server/api/routes/feedback.py
+++ b/observal-server/api/routes/feedback.py
@@ -45,13 +45,21 @@ async def _visible_listing(db: AsyncSession, listing_type: str, listing_id: uuid
 
 
 async def _visible_listing_by_id(db: AsyncSession, listing_id: uuid.UUID, current_user: User | None):
-    for listing_type in LISTING_MODELS:
-        try:
-            return await _visible_listing(db, listing_type, listing_id, current_user)
-        except HTTPException as exc:
-            if exc.status_code != 404:
-                raise
-    raise HTTPException(status_code=404, detail="Listing not found")
+    """Resolve a listing when only its id is known, without probing every table.
+
+    This backs the anonymous feedback summary, which the registry detail page hits
+    on every render. Scanning all six listing models cost up to six round trips
+    before the aggregate even ran. Feedback rows already record which type the
+    listing is, so one lookup narrows it to a single model.
+    """
+    listing_type = await db.scalar(select(Feedback.listing_type).where(Feedback.listing_id == listing_id).limit(1))
+    if listing_type is not None and listing_type in LISTING_MODELS:
+        return await _visible_listing(db, listing_type, listing_id, current_user)
+
+    # No feedback yet, so the type is unknown. An empty summary is the same answer
+    # a public listing with no ratings gives, so returning it discloses nothing
+    # about whether the id exists or is hidden.
+    return None
 
 
 def _serialize_feedback(fb: Feedback) -> FeedbackResponse:

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -116,7 +116,10 @@ async def list_hooks(
     scope: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
-    team_id: uuid.UUID | None = Query(None),
+    team_id: uuid.UUID | None = Query(None, description="Only listings owned by this teamspace"),
+    composable_for_team_id: uuid.UUID | None = Query(
+        None, description="Public listings plus this teamspace's private ones, for agent composition"
+    ),
     public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -153,7 +156,14 @@ async def list_hooks(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_registry_scope(stmt, HookListing, current_user, team_id=team_id, public_only=public_only)
+    stmt = apply_registry_scope(
+        stmt,
+        HookListing,
+        current_user,
+        team_id=team_id,
+        composable_for_team_id=composable_for_team_id,
+        public_only=public_only,
+    )
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [HookListing.created_at.desc()]
     if search_rank is not None:

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -5,25 +5,24 @@
 # SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from fastapi_cache.decorator import cache
 from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import services.dynamic_settings as ds
 from api.deps import (
-    apply_visibility_filter,
-    check_listing_visibility,
+    apply_registry_scope,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    may_view_unapproved,
     optional_current_user,
-    registry_identity,
     require_role,
     resolve_listing,
+    resolve_visible_listing,
 )
 from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
@@ -43,6 +42,7 @@ from schemas.hook import (
 )
 from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.registry_namespace import identity_exists
+from services.teamspace import publish_auto_approves_for_entity, resolve_publish_target
 
 router = APIRouter(prefix="/api/v1/hooks", tags=["hooks"])
 
@@ -54,17 +54,24 @@ async def submit_hook(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("hook submit: name={}", req.name)
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, HookListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Hook '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, HookListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Hook '{target.namespace}/{target.slug}' already exists")
 
     listing = HookListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else req.owner,
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -87,9 +94,11 @@ async def submit_hook(
         source_ref=req.source_ref,
         source_path=req.source_path,
         requirements=req.requirements,
-        status=ListingStatus.pending,
+        status=ListingStatus.approved if target.auto_approve else ListingStatus.pending,
         released_by=current_user.id,
         released_at=datetime.now(UTC),
+        reviewed_by=current_user.id if target.auto_approve else None,
+        reviewed_at=datetime.now(UTC) if target.auto_approve else None,
     )
     db.add(version)
     await db.flush()
@@ -101,13 +110,14 @@ async def submit_hook(
 
 
 @router.get("", response_model=list[HookListingSummary])
-@cache(expire=ds.get_sync_int("data.cache_ttl_registry", 30), namespace="registry")
 async def list_hooks(
     response: Response,
     event: str | None = Query(None),
     scope: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
+    team_id: uuid.UUID | None = Query(None),
+    public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
@@ -143,7 +153,7 @@ async def list_hooks(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_visibility_filter(stmt, HookListing, current_user)
+    stmt = apply_registry_scope(stmt, HookListing, current_user, team_id=team_id, public_only=public_only)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [HookListing.created_at.desc()]
     if search_rank is not None:
@@ -175,22 +185,19 @@ async def get_hook(
     current_user: User | None = Depends(optional_current_user),
 ):
     optic.debug("hook get: listing_id={}", listing_id)
-    listing = await resolve_listing(HookListing, listing_id, db, require_status=ListingStatus.approved)
-    if listing:
-        resp = HookListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    listing = await resolve_listing(HookListing, listing_id, db)
-    if not listing:
-        raise HTTPException(status_code=404, detail="Listing not found")
-
-    if check_listing_visibility(listing, current_user):
-        resp = HookListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    raise HTTPException(status_code=404, detail="Listing not found")
+    listing = await resolve_visible_listing(
+        HookListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
+    if listing is None:
+        listing = await resolve_visible_listing(HookListing, listing_id, db, current_user)
+        may_view = listing is not None and may_view_unapproved(
+            get_effective_component_permission(listing, current_user), current_user
+        )
+        if not may_view:
+            raise HTTPException(status_code=404, detail="Listing not found")
+    resp = HookListingResponse.model_validate(listing)
+    resp.user_permission = get_effective_component_permission(listing, current_user)
+    return resp
 
 
 @router.post("/{listing_id}/install", response_model=HookInstallResponse)
@@ -202,10 +209,12 @@ async def install_hook(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("hook install: listing_id={}", listing_id)
-    listing = await resolve_listing(HookListing, listing_id, db, require_status=ListingStatus.approved)
+    listing = await resolve_visible_listing(
+        HookListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
     if not listing:
-        listing = await resolve_listing(HookListing, listing_id, db)
-        if not listing or not check_listing_visibility(listing, current_user):
+        listing = await resolve_visible_listing(HookListing, listing_id, db, current_user)
+        if not listing:
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
         if (
             listing.status != ListingStatus.archived
@@ -246,16 +255,23 @@ async def save_hook_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("req={}", req)
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, HookListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Hook '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, HookListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Hook '{target.namespace}/{target.slug}' already exists")
     listing = HookListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner or current_user.username or current_user.email,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else (req.owner or current_user.username or current_user.email),
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -291,6 +307,27 @@ async def save_hook_draft(
     return HookListingResponse.model_validate(listing)
 
 
+def _reject_visibility_edits(listing, req) -> None:
+    """Refuse teamspace or visibility changes sent to the draft update route.
+
+    Visibility has exactly one authoritative path, PATCH /api/v1/registry/hook/{listing_id}/visibility,
+    which authorizes team owners and reviewers, writes audit metadata, and blocks privatizing a
+    component that an approved public agent depends on. Accepting these fields here would either
+    silently discard them or fork that policy into a weaker second implementation, so a real change
+    is rejected. A request that repeats the values the listing already holds changes nothing and passes.
+    """
+    if req.team_id is not None and req.team_id != listing.team_id:
+        raise HTTPException(
+            status_code=400,
+            detail="team_id cannot be changed here. A listing stays in the teamspace it was created under.",
+        )
+    if req.visibility is not None and req.visibility != listing.visibility:
+        raise HTTPException(
+            status_code=400,
+            detail=f"visibility cannot be changed here. Use PATCH /api/v1/registry/hook/{listing.id}/visibility.",
+        )
+
+
 @router.put("/{listing_id}/draft", response_model=HookListingResponse)
 async def update_hook_draft(
     listing_id: str,
@@ -299,13 +336,14 @@ async def update_hook_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(HookListing, listing_id, db)
+    listing = await resolve_listing(HookListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
         raise HTTPException(status_code=403, detail="Not the listing owner")
     if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
         raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+    _reject_visibility_edits(listing, req)
 
     ver = listing.latest_version
     if not ver:
@@ -359,7 +397,7 @@ async def start_edit_hook(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(HookListing, listing_id, db)
+    listing = await resolve_listing(HookListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -383,7 +421,7 @@ async def cancel_edit_hook(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(HookListing, listing_id, db)
+    listing = await resolve_listing(HookListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -403,7 +441,7 @@ async def submit_hook_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(HookListing, listing_id, db)
+    listing = await resolve_listing(HookListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -414,7 +452,12 @@ async def submit_hook_draft(
     if not listing.description:
         raise HTTPException(status_code=400, detail="Description is required before submitting")
 
-    listing.status = ListingStatus.pending
+    if await publish_auto_approves_for_entity(listing, current_user, db):
+        listing.status = ListingStatus.approved
+        listing.latest_version.reviewed_by = current_user.id
+        listing.latest_version.reviewed_at = datetime.now(UTC)
+    else:
+        listing.status = ListingStatus.pending
     await commit_or_name_conflict(db, "hook")
     await db.refresh(listing)
     return HookListingResponse.model_validate(listing)

--- a/observal-server/api/routes/hook.py
+++ b/observal-server/api/routes/hook.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     apply_registry_scope,
+    apply_visibility_filter,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
@@ -180,9 +181,13 @@ async def my_hooks(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("my_hooks called")
+    # Authorship is not a standing grant: a member removed from a teamspace keeps
+    # submitted_by on its listings but must not keep reading them, so /my is
+    # scoped like every other list rather than trusting the author column.
     stmt = (
         select(HookListing).where(HookListing.submitted_by == current_user.id).order_by(HookListing.created_at.desc())
     )
+    stmt = apply_visibility_filter(stmt, HookListing, current_user)
     result = await db.execute(stmt)
     listings = [HookListingSummary.model_validate(r) for r in result.scalars().all()]
     return listings

--- a/observal-server/api/routes/insights.py
+++ b/observal-server/api/routes/insights.py
@@ -13,7 +13,7 @@ from loguru import logger as optic
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, get_effective_agent_permission, require_role
+from api.deps import check_listing_visibility_async, get_db, get_effective_agent_permission, require_role
 from api.routes.agent.helpers import _load_agent
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.insight_meta_cache import InsightMetaCache
@@ -43,7 +43,13 @@ def _require_insights():
 
 
 def _require_agent_edit_access(agent: Agent, user: User) -> None:
-    """Raise 403 unless user is admin or has owner/edit permission on the agent."""
+    """Raise 403 unless user is admin or has owner/edit permission on the agent.
+
+    Insight reports expose the agent's private session telemetry, so seeing the
+    agent is not enough. Team membership is a visibility axis in the registry, not
+    an ownership axis: a team member who is not the creator, a co-author, or an
+    admin resolves the agent and is then refused here.
+    """
     perm = get_effective_agent_permission(agent, user)
     if perm not in ("owner", "edit"):
         raise HTTPException(status_code=403, detail="Insufficient permissions for this agent")
@@ -55,14 +61,27 @@ async def _resolve_insights_agent(agent_id: str, db: AsyncSession, current_user:
         db,
         agent_id,
         prefer_user_id=current_user.id,
-        org_id=current_user.org_id,
+        current_user=current_user,
         include_all_statuses=True,
     )
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
     _require_agent_edit_access(agent, current_user)
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    return agent
+
+
+async def _authorize_report_agent(report: InsightReport, db: AsyncSession, current_user: User) -> Agent:
+    """Resolve the agent behind a report and apply visibility plus the edit gate.
+
+    Reports carry a non-null agent_id with an ON DELETE CASCADE foreign key, so a
+    missing agent row means the report is unreachable. That is reported as 404
+    rather than silently skipping the authorization checks.
+    """
+    agent_result = await db.execute(select(Agent).where(Agent.id == report.agent_id))
+    agent = agent_result.scalar_one_or_none()
+    if not agent or not await check_listing_visibility_async(agent, current_user, db):
+        raise HTTPException(status_code=404, detail="Report not found")
+    _require_agent_edit_access(agent, current_user)
     return agent
 
 
@@ -378,15 +397,7 @@ async def get_report(
     if not report:
         raise HTTPException(status_code=404, detail="Report not found")
 
-    # Org-scope check via agent
-    agent_stmt = select(Agent).where(Agent.id == report.agent_id)
-    agent_result = await db.execute(agent_stmt)
-    agent = agent_result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Report not found")
-    _require_agent_edit_access(agent, current_user)
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    await _authorize_report_agent(report, db, current_user)
 
     return InsightReportResponse.model_validate(report)
 
@@ -410,15 +421,7 @@ async def export_report_html(
     if report.status != InsightReportStatus.completed:
         raise HTTPException(status_code=400, detail="Report is not yet completed")
 
-    # Org-scope check
-    agent_stmt = select(Agent).where(Agent.id == report.agent_id)
-    agent_result = await db.execute(agent_stmt)
-    agent = agent_result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Report not found")
-    _require_agent_edit_access(agent, current_user)
-    if current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    await _authorize_report_agent(report, db, current_user)
 
     # Build report dict for the renderer
     report_data = {
@@ -488,12 +491,7 @@ async def delete_report(
     if not report:
         raise HTTPException(status_code=404, detail="Report not found")
 
-    # Org-scope check
-    agent_stmt = select(Agent).where(Agent.id == report.agent_id)
-    agent_result = await db.execute(agent_stmt)
-    agent = agent_result.scalar_one_or_none()
-    if agent and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    await _authorize_report_agent(report, db, current_user)
 
     await db.delete(report)
     await db.commit()
@@ -526,18 +524,13 @@ async def apply_report_suggestions(
             detail="Self-learning is disabled. Enable via settings: insights.self_learn_enabled",
         )
 
-    # Org-scope check
     stmt = select(InsightReport).where(InsightReport.id == report_id)
     result = await db.execute(stmt)
     report = result.scalar_one_or_none()
     if not report:
         raise HTTPException(status_code=404, detail="Report not found")
 
-    agent_stmt = select(Agent).where(Agent.id == report.agent_id)
-    agent_result = await db.execute(agent_stmt)
-    agent = agent_result.scalar_one_or_none()
-    if agent and current_user.org_id is not None and agent.owner_org_id != current_user.org_id:
-        raise HTTPException(status_code=403, detail="Agent does not belong to your organization")
+    await _authorize_report_agent(report, db, current_user)
 
     # Run the self-learn pipeline
     from services.insights.self_learn import apply_insight_suggestions

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -216,7 +216,10 @@ async def list_mcps(
     category: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
-    team_id: uuid.UUID | None = Query(None),
+    team_id: uuid.UUID | None = Query(None, description="Only listings owned by this teamspace"),
+    composable_for_team_id: uuid.UUID | None = Query(
+        None, description="Public listings plus this teamspace's private ones, for agent composition"
+    ),
     public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -251,7 +254,14 @@ async def list_mcps(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_registry_scope(stmt, McpListing, current_user, team_id=team_id, public_only=public_only)
+    stmt = apply_registry_scope(
+        stmt,
+        McpListing,
+        current_user,
+        team_id=team_id,
+        composable_for_team_id=composable_for_team_id,
+        public_only=public_only,
+    )
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [McpListing.created_at.desc()]
     if search_rank is not None:

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -5,25 +5,24 @@
 # SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
-from fastapi_cache.decorator import cache
 from loguru import logger as optic
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import services.dynamic_settings as ds
 from api.deps import (
-    apply_visibility_filter,
-    check_listing_visibility,
+    apply_registry_scope,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    may_view_unapproved,
     optional_current_user,
-    registry_identity,
     require_role,
     resolve_listing,
+    resolve_visible_listing,
 )
 from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
@@ -47,6 +46,7 @@ from services.config_generator import generate_config
 from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.mcp_validator import analyze_repo, run_validation
 from services.registry_namespace import identity_exists
+from services.teamspace import publish_auto_approves_for_entity, resolve_publish_target
 
 router = APIRouter(prefix="/api/v1/mcps", tags=["mcp"])
 
@@ -128,9 +128,22 @@ async def submit_mcp(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("mcp submit: name={}", req.name)
-    namespace, slug = registry_identity(current_user, req.name)
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
     existing = (
-        (await db.execute(select(McpListing).where(McpListing.namespace == namespace, McpListing.slug == slug)))
+        (
+            await db.execute(
+                select(McpListing).where(
+                    McpListing.namespace == target.namespace,
+                    McpListing.slug == target.slug,
+                )
+            )
+        )
         .scalars()
         .first()
     )
@@ -139,16 +152,20 @@ async def submit_mcp(
             await db.delete(existing)
             await db.flush()
         else:
-            raise HTTPException(status_code=409, detail=f"Approved MCP server '{namespace}/{slug}' already exists")
+            raise HTTPException(
+                status_code=409,
+                detail=f"Approved MCP server '{target.namespace}/{target.slug}' already exists",
+            )
 
     listing = McpListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
+        namespace=target.namespace,
+        slug=target.slug,
         category=req.category,
-        owner=req.owner,
+        owner=target.owner if target.team_id else req.owner,
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -170,9 +187,11 @@ async def submit_mcp(
         setup_instructions=req.setup_instructions,
         changelog=req.changelog,
         source_url=req.git_url,
-        status=ListingStatus.pending,
+        status=ListingStatus.approved if target.auto_approve else ListingStatus.pending,
         released_by=current_user.id,
         released_at=datetime.now(UTC),
+        reviewed_by=current_user.id if target.auto_approve else None,
+        reviewed_at=datetime.now(UTC) if target.auto_approve else None,
     )
     db.add(version)
     await db.flush()
@@ -192,12 +211,13 @@ async def submit_mcp(
 
 
 @router.get("", response_model=list[McpListingSummary])
-@cache(expire=ds.get_sync_int("data.cache_ttl_registry", 30), namespace="registry")
 async def list_mcps(
     response: Response,
     category: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
+    team_id: uuid.UUID | None = Query(None),
+    public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
@@ -231,7 +251,7 @@ async def list_mcps(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_visibility_filter(stmt, McpListing, current_user)
+    stmt = apply_registry_scope(stmt, McpListing, current_user, team_id=team_id, public_only=public_only)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [McpListing.created_at.desc()]
     if search_rank is not None:
@@ -261,22 +281,19 @@ async def get_mcp(
     current_user: User | None = Depends(optional_current_user),
 ):
     optic.debug("mcp get: listing_id={}", listing_id)
-    listing = await resolve_listing(McpListing, listing_id, db, require_status=ListingStatus.approved)
-    if listing:
-        resp = McpListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    listing = await resolve_listing(McpListing, listing_id, db)
-    if not listing:
-        raise HTTPException(status_code=404, detail="Listing not found")
-
-    if check_listing_visibility(listing, current_user):
-        resp = McpListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    raise HTTPException(status_code=404, detail="Listing not found")
+    listing = await resolve_visible_listing(
+        McpListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
+    if listing is None:
+        listing = await resolve_visible_listing(McpListing, listing_id, db, current_user)
+        may_view = listing is not None and may_view_unapproved(
+            get_effective_component_permission(listing, current_user), current_user
+        )
+        if not may_view:
+            raise HTTPException(status_code=404, detail="Listing not found")
+    resp = McpListingResponse.model_validate(listing)
+    resp.user_permission = get_effective_component_permission(listing, current_user)
+    return resp
 
 
 @router.post("/{listing_id}/install", response_model=McpInstallResponse)
@@ -288,12 +305,12 @@ async def install_mcp(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("mcp install: listing_id={}", listing_id)
-    listing = await resolve_listing(McpListing, listing_id, db, require_status=ListingStatus.approved)
+    listing = await resolve_visible_listing(
+        McpListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
     if not listing:
-        listing = await resolve_listing(McpListing, listing_id, db)
-        if not listing or not check_listing_visibility(listing, current_user):
-            raise HTTPException(status_code=404, detail="Listing not found or not approved")
-        if (
+        listing = await resolve_visible_listing(McpListing, listing_id, db, current_user)
+        if not listing or (
             listing.status != ListingStatus.archived
             and get_effective_component_permission(listing, current_user) != "owner"
         ):
@@ -332,17 +349,24 @@ async def save_mcp_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("req={}", req)
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, McpListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"MCP server '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, McpListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"MCP server '{target.namespace}/{target.slug}' already exists")
     listing = McpListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
+        namespace=target.namespace,
+        slug=target.slug,
         category=req.category,
-        owner=req.owner or current_user.username or current_user.email,
+        owner=target.owner if target.team_id else (req.owner or current_user.username or current_user.email),
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -377,6 +401,27 @@ async def save_mcp_draft(
     return McpListingResponse.model_validate(listing)
 
 
+def _reject_visibility_edits(listing, req) -> None:
+    """Refuse teamspace or visibility changes sent to the draft update route.
+
+    Visibility has exactly one authoritative path, PATCH /api/v1/registry/mcp/{listing_id}/visibility,
+    which authorizes team owners and reviewers, writes audit metadata, and blocks privatizing a
+    component that an approved public agent depends on. Accepting these fields here would either
+    silently discard them or fork that policy into a weaker second implementation, so a real change
+    is rejected. A request that repeats the values the listing already holds changes nothing and passes.
+    """
+    if req.team_id is not None and req.team_id != listing.team_id:
+        raise HTTPException(
+            status_code=400,
+            detail="team_id cannot be changed here. A listing stays in the teamspace it was created under.",
+        )
+    if req.visibility is not None and req.visibility != listing.visibility:
+        raise HTTPException(
+            status_code=400,
+            detail=f"visibility cannot be changed here. Use PATCH /api/v1/registry/mcp/{listing.id}/visibility.",
+        )
+
+
 @router.put("/{listing_id}/draft", response_model=McpListingResponse)
 async def update_mcp_draft(
     listing_id: str,
@@ -385,13 +430,14 @@ async def update_mcp_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(McpListing, listing_id, db)
+    listing = await resolve_listing(McpListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
         raise HTTPException(status_code=403, detail="Not the listing owner")
     if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
         raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+    _reject_visibility_edits(listing, req)
 
     ver = listing.latest_version
     if not ver:
@@ -448,7 +494,7 @@ async def start_edit_mcp(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(McpListing, listing_id, db)
+    listing = await resolve_listing(McpListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -472,7 +518,7 @@ async def cancel_edit_mcp(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(McpListing, listing_id, db)
+    listing = await resolve_listing(McpListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -492,7 +538,7 @@ async def submit_mcp_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(McpListing, listing_id, db)
+    listing = await resolve_listing(McpListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -505,7 +551,12 @@ async def submit_mcp_draft(
     if not listing.git_url and not listing.command and not listing.url:
         raise HTTPException(status_code=400, detail="At least one of git_url, command, or url is required")
 
-    listing.status = ListingStatus.pending
+    if await publish_auto_approves_for_entity(listing, current_user, db):
+        listing.status = ListingStatus.approved
+        listing.latest_version.reviewed_by = current_user.id
+        listing.latest_version.reviewed_at = datetime.now(UTC)
+    else:
+        listing.status = ListingStatus.pending
     await commit_or_name_conflict(db, "listing")
     await db.refresh(listing)
     return McpListingResponse.model_validate(listing)

--- a/observal-server/api/routes/mcp.py
+++ b/observal-server/api/routes/mcp.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     apply_registry_scope,
+    apply_visibility_filter,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
@@ -278,7 +279,11 @@ async def my_mcps(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("my_mcps called")
+    # Authorship is not a standing grant: a member removed from a teamspace keeps
+    # submitted_by on its listings but must not keep reading them, so /my is
+    # scoped like every other list rather than trusting the author column.
     stmt = select(McpListing).where(McpListing.submitted_by == current_user.id).order_by(McpListing.created_at.desc())
+    stmt = apply_visibility_filter(stmt, McpListing, current_user)
     result = await db.execute(stmt)
     listings = [McpListingSummary.model_validate(r) for r in result.scalars().all()]
     return listings

--- a/observal-server/api/routes/preview.py
+++ b/observal-server/api/routes/preview.py
@@ -9,13 +9,13 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger as optic
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from api.deps import get_current_user, get_db
+from api.deps import apply_visibility_filter, get_current_user, get_db
 from models.hook import HookListing
 from models.mcp import McpListing
 from models.prompt import PromptListing
@@ -115,52 +115,40 @@ async def preview_config(
         components=components,
     )
 
-    # Resolve component listings by ID (same pattern as install endpoint -
-    # the builder UI already scoped what the user can select)
+    # Resolve component listings by ID. Preview renders real component content
+    # (MCP commands, hook handlers, prompt templates, SKILL.md), so it must apply
+    # the same visibility rules as every other read path. The builder UI scoping
+    # what a user can select is not an authorization boundary.
     mcp_ids = [c.component_id for c in components if c.component_type == "mcp"]
     skill_ids = [c.component_id for c in components if c.component_type == "skill"]
     hook_ids = [c.component_id for c in components if c.component_type == "hook"]
     prompt_ids = [c.component_id for c in components if c.component_type == "prompt"]
 
-    mcp_map: dict = {}
-    if mcp_ids:
-        rows = (await db.execute(select(McpListing).where(McpListing.id.in_(mcp_ids)))).scalars().all()
-        mcp_map = {row.id: row for row in rows}
+    async def _visible_map(model, ids, *, load_latest_version=False):
+        if not ids:
+            return {}
+        stmt = select(model).where(model.id.in_(ids))
+        if load_latest_version:
+            stmt = stmt.options(selectinload(model.latest_version))
+        stmt = apply_visibility_filter(stmt, model, current_user)
+        rows = (await db.execute(stmt)).scalars().all()
+        return {row.id: row for row in rows}
 
-    skill_map: dict = {}
-    if skill_ids:
-        rows = (await db.execute(select(SkillListing).where(SkillListing.id.in_(skill_ids)))).scalars().all()
-        skill_map = {row.id: row for row in rows}
+    mcp_map = await _visible_map(McpListing, mcp_ids)
+    skill_map = await _visible_map(SkillListing, skill_ids)
+    hook_map = await _visible_map(HookListing, hook_ids, load_latest_version=True)
+    prompt_map = await _visible_map(PromptListing, prompt_ids, load_latest_version=True)
 
-    hook_map: dict = {}
-    if hook_ids:
-        rows = (
-            (
-                await db.execute(
-                    select(HookListing)
-                    .options(selectinload(HookListing.latest_version))
-                    .where(HookListing.id.in_(hook_ids))
-                )
-            )
-            .scalars()
-            .all()
+    # Refuse loudly rather than quietly previewing a partial agent. A component the
+    # caller cannot see is reported the same way as one that does not exist, so the
+    # response is not an existence oracle for team-private listings.
+    requested = set(mcp_ids) | set(skill_ids) | set(hook_ids) | set(prompt_ids)
+    resolved = set(mcp_map) | set(skill_map) | set(hook_map) | set(prompt_map)
+    if missing := requested - resolved:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Component not found: {', '.join(sorted(str(i) for i in missing))}",
         )
-        hook_map = {row.id: row for row in rows}
-
-    prompt_map: dict = {}
-    if prompt_ids:
-        rows = (
-            (
-                await db.execute(
-                    select(PromptListing)
-                    .options(selectinload(PromptListing.latest_version))
-                    .where(PromptListing.id.in_(prompt_ids))
-                )
-            )
-            .scalars()
-            .all()
-        )
-        prompt_map = {row.id: row for row in rows}
 
     # Build component name map
     name_map: dict[str, str] = {}

--- a/observal-server/api/routes/preview.py
+++ b/observal-server/api/routes/preview.py
@@ -15,9 +15,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from api.deps import apply_visibility_filter, get_current_user, get_db
+from api.deps import (
+    apply_visibility_filter,
+    get_current_user,
+    get_db,
+    get_effective_component_permission,
+    may_view_unapproved,
+)
 from models.hook import HookListing
-from models.mcp import McpListing
+from models.mcp import ListingStatus, McpListing
 from models.prompt import PromptListing
 from models.skill import SkillListing
 from observal_shared.harness_registry import HARNESS_REGISTRY
@@ -132,7 +138,15 @@ async def preview_config(
             stmt = stmt.options(selectinload(model.latest_version))
         stmt = apply_visibility_filter(stmt, model, current_user)
         rows = (await db.execute(stmt)).scalars().all()
-        return {row.id: row for row in rows}
+        # apply_visibility_filter answers privacy only. Preview renders real
+        # component content, so a public but unapproved listing must stay with its
+        # owner, co-authors, admins and reviewers, exactly as the detail routes do.
+        return {
+            row.id: row
+            for row in rows
+            if row.status == ListingStatus.approved
+            or may_view_unapproved(get_effective_component_permission(row, current_user), current_user)
+        }
 
     mcp_map = await _visible_map(McpListing, mcp_ids)
     skill_map = await _visible_map(SkillListing, skill_ids)

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     apply_registry_scope,
+    apply_visibility_filter,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
@@ -172,6 +173,10 @@ async def my_prompts(
         .where(PromptListing.submitted_by == current_user.id)
         .order_by(PromptListing.created_at.desc())
     )
+    # Authorship is not a standing grant: a member removed from a teamspace keeps
+    # the author column on its listings but must not keep reading them.
+    stmt = apply_visibility_filter(stmt, PromptListing, current_user)
+
     result = await db.execute(stmt)
     listings = [PromptListingSummary.model_validate(r) for r in result.scalars().all()]
     return listings

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -106,7 +106,10 @@ async def list_prompts(
     category: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
-    team_id: uuid.UUID | None = Query(None),
+    team_id: uuid.UUID | None = Query(None, description="Only listings owned by this teamspace"),
+    composable_for_team_id: uuid.UUID | None = Query(
+        None, description="Public listings plus this teamspace's private ones, for agent composition"
+    ),
     public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -140,7 +143,14 @@ async def list_prompts(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_registry_scope(stmt, PromptListing, current_user, team_id=team_id, public_only=public_only)
+    stmt = apply_registry_scope(
+        stmt,
+        PromptListing,
+        current_user,
+        team_id=team_id,
+        composable_for_team_id=composable_for_team_id,
+        public_only=public_only,
+    )
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [PromptListing.created_at.desc()]
     if search_rank is not None:

--- a/observal-server/api/routes/prompt.py
+++ b/observal-server/api/routes/prompt.py
@@ -5,25 +5,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from fastapi_cache.decorator import cache
 from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import services.dynamic_settings as ds
 from api.deps import (
-    apply_visibility_filter,
-    check_listing_visibility,
+    apply_registry_scope,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    may_view_unapproved,
     optional_current_user,
-    registry_identity,
     require_role,
     resolve_listing,
+    resolve_visible_listing,
 )
 from api.routes._component_archive import archive_listing, unarchive_listing
 from api.routes.component_versions import create_version_router
@@ -42,6 +41,7 @@ from schemas.prompt import (
 )
 from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.registry_namespace import identity_exists
+from services.teamspace import publish_auto_approves_for_entity, resolve_publish_target
 
 router = APIRouter(prefix="/api/v1/prompts", tags=["prompts"])
 
@@ -53,17 +53,24 @@ async def submit_prompt(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("prompt submit: name={}", req.name)
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, PromptListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Prompt '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, PromptListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Prompt '{target.namespace}/{target.slug}' already exists")
 
     listing = PromptListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else req.owner,
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -78,9 +85,11 @@ async def submit_prompt(
         model_hints=req.model_hints,
         tags=req.tags,
         supported_harnesses=req.supported_harnesses,
-        status=ListingStatus.pending,
+        status=ListingStatus.approved if target.auto_approve else ListingStatus.pending,
         released_by=current_user.id,
         released_at=datetime.now(UTC),
+        reviewed_by=current_user.id if target.auto_approve else None,
+        reviewed_at=datetime.now(UTC) if target.auto_approve else None,
     )
     db.add(version)
     await db.flush()
@@ -92,12 +101,13 @@ async def submit_prompt(
 
 
 @router.get("", response_model=list[PromptListingSummary])
-@cache(expire=ds.get_sync_int("data.cache_ttl_registry", 30), namespace="registry")
 async def list_prompts(
     response: Response,
     category: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
+    team_id: uuid.UUID | None = Query(None),
+    public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
@@ -130,7 +140,7 @@ async def list_prompts(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_visibility_filter(stmt, PromptListing, current_user)
+    stmt = apply_registry_scope(stmt, PromptListing, current_user, team_id=team_id, public_only=public_only)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [PromptListing.created_at.desc()]
     if search_rank is not None:
@@ -164,22 +174,19 @@ async def get_prompt(
     current_user: User | None = Depends(optional_current_user),
 ):
     optic.debug("prompt get: listing_id={}", listing_id)
-    listing = await resolve_listing(PromptListing, listing_id, db, require_status=ListingStatus.approved)
-    if listing:
-        resp = PromptListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    listing = await resolve_listing(PromptListing, listing_id, db)
-    if not listing:
-        raise HTTPException(status_code=404, detail="Listing not found")
-
-    if check_listing_visibility(listing, current_user):
-        resp = PromptListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    raise HTTPException(status_code=404, detail="Listing not found")
+    listing = await resolve_visible_listing(
+        PromptListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
+    if listing is None:
+        listing = await resolve_visible_listing(PromptListing, listing_id, db, current_user)
+        may_view = listing is not None and may_view_unapproved(
+            get_effective_component_permission(listing, current_user), current_user
+        )
+        if not may_view:
+            raise HTTPException(status_code=404, detail="Listing not found")
+    resp = PromptListingResponse.model_validate(listing)
+    resp.user_permission = get_effective_component_permission(listing, current_user)
+    return resp
 
 
 @router.post("/{listing_id}/render", response_model=PromptRenderResponse)
@@ -190,10 +197,15 @@ async def render_prompt(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("prompt render")
-    listing = await resolve_listing(PromptListing, listing_id, db, require_status=ListingStatus.approved)
+    listing = await resolve_visible_listing(
+        PromptListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
     if not listing:
-        listing = await resolve_listing(PromptListing, listing_id, db)
-        if not listing or get_effective_component_permission(listing, current_user) != "owner":
+        listing = await resolve_visible_listing(PromptListing, listing_id, db, current_user)
+        if not listing or (
+            listing.status != ListingStatus.archived
+            and get_effective_component_permission(listing, current_user) != "owner"
+        ):
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
 
     rendered = listing.template
@@ -210,16 +222,23 @@ async def save_prompt_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("req={}", req)
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, PromptListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Prompt '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, PromptListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Prompt '{target.namespace}/{target.slug}' already exists")
     listing = PromptListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner or current_user.username or current_user.email,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else (req.owner or current_user.username or current_user.email),
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -247,6 +266,27 @@ async def save_prompt_draft(
     return PromptListingResponse.model_validate(listing)
 
 
+def _reject_visibility_edits(listing, req) -> None:
+    """Refuse teamspace or visibility changes sent to the draft update route.
+
+    Visibility has exactly one authoritative path, PATCH /api/v1/registry/prompt/{listing_id}/visibility,
+    which authorizes team owners and reviewers, writes audit metadata, and blocks privatizing a
+    component that an approved public agent depends on. Accepting these fields here would either
+    silently discard them or fork that policy into a weaker second implementation, so a real change
+    is rejected. A request that repeats the values the listing already holds changes nothing and passes.
+    """
+    if req.team_id is not None and req.team_id != listing.team_id:
+        raise HTTPException(
+            status_code=400,
+            detail="team_id cannot be changed here. A listing stays in the teamspace it was created under.",
+        )
+    if req.visibility is not None and req.visibility != listing.visibility:
+        raise HTTPException(
+            status_code=400,
+            detail=f"visibility cannot be changed here. Use PATCH /api/v1/registry/prompt/{listing.id}/visibility.",
+        )
+
+
 @router.put("/{listing_id}/draft", response_model=PromptListingResponse)
 async def update_prompt_draft(
     listing_id: str,
@@ -255,13 +295,14 @@ async def update_prompt_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(PromptListing, listing_id, db)
+    listing = await resolve_listing(PromptListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
         raise HTTPException(status_code=403, detail="Not the listing owner")
     if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
         raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+    _reject_visibility_edits(listing, req)
 
     ver = listing.latest_version
     if not ver:
@@ -307,7 +348,7 @@ async def start_edit_prompt(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(PromptListing, listing_id, db)
+    listing = await resolve_listing(PromptListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -331,7 +372,7 @@ async def cancel_edit_prompt(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(PromptListing, listing_id, db)
+    listing = await resolve_listing(PromptListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -351,7 +392,7 @@ async def submit_prompt_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(PromptListing, listing_id, db)
+    listing = await resolve_listing(PromptListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -364,7 +405,12 @@ async def submit_prompt_draft(
     if not listing.template:
         raise HTTPException(status_code=400, detail="Template is required before submitting")
 
-    listing.status = ListingStatus.pending
+    if await publish_auto_approves_for_entity(listing, current_user, db):
+        listing.status = ListingStatus.approved
+        listing.latest_version.reviewed_by = current_user.id
+        listing.latest_version.reviewed_at = datetime.now(UTC)
+    else:
+        listing.status = ListingStatus.pending
     await commit_or_name_conflict(db, "prompt")
     await db.refresh(listing)
     return PromptListingResponse.model_validate(listing)

--- a/observal-server/api/routes/registry.py
+++ b/observal-server/api/routes/registry.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     apply_visibility_filter,
+    can_see_private_listings,
     check_listing_visibility_async,
     get_current_user,
     get_db,
@@ -159,7 +160,9 @@ async def update_registry_visibility(
         raise HTTPException(status_code=404, detail="Listing not found")
 
     team_id = getattr(listing, "team_id", None)
-    privileged = current_user.role in (UserRole.super_admin, UserRole.admin, UserRole.reviewer)
+    # A global reviewer is not privileged here: team-private listings belong to
+    # their teamspace, so flipping one is a team owner or team reviewer action.
+    privileged = can_see_private_listings(current_user)
     if not privileged and not await check_listing_visibility_async(listing, current_user, db):
         raise HTTPException(status_code=404, detail="Listing not found")
     creator_id = getattr(listing, "created_by", None) or getattr(listing, "submitted_by", None)

--- a/observal-server/api/routes/registry.py
+++ b/observal-server/api/routes/registry.py
@@ -7,27 +7,34 @@ import uuid
 from collections import defaultdict
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     apply_visibility_filter,
-    check_listing_visibility,
+    check_listing_visibility_async,
     get_current_user,
     get_db,
+    get_effective_agent_permission,
+    get_effective_component_permission,
+    may_view_unapproved,
     optional_current_user,
     resolve_listing,
+    resolve_visible_listing,
 )
 from api.routes.agent.helpers import _load_agent
 from models.agent import Agent, AgentStatus, AgentVersion
+from models.agent_component import AgentComponent
 from models.hook import HookListing, HookVersion
 from models.mcp import ListingStatus, McpListing, McpVersion
 from models.prompt import PromptListing, PromptVersion
 from models.sandbox import SandboxListing, SandboxVersion
 from models.skill import SkillListing, SkillVersion
+from models.team import TeamRole
 from models.user import User, UserRole
+from services.teamspace import review_publication_to_public, team_membership
 
 router = APIRouter(prefix="/api/v1/registry", tags=["registry"])
 
@@ -57,6 +64,10 @@ class RegistryResolution(BaseModel):
 
 
 RegistryItemType = Literal["agent", "mcp", "skill", "hook", "prompt", "sandbox"]
+
+
+class VisibilityUpdateRequest(BaseModel):
+    visibility: Literal["public", "team"]
 
 
 class RegistryReconcileItem(BaseModel):
@@ -93,15 +104,25 @@ async def resolve_registry_identifier(
             db,
             identifier,
             prefer_user_id=current_user.id if current_user else None,
-            org_id=current_user.org_id if current_user else None,
+            current_user=current_user,
         )
+        # _load_agent only filters on status when it resolves by name. UUID and
+        # prefix lookups return any status, so gate non-approved agents here.
+        if listing is not None and listing.status != AgentStatus.approved:
+            permission = get_effective_agent_permission(listing, current_user)
+            if not may_view_unapproved(permission, current_user):
+                listing = None
     else:
         model = _LISTING_MODELS[type]
-        listing = await resolve_listing(model, identifier, db, require_status=ListingStatus.approved)
+        listing = await resolve_visible_listing(
+            model, identifier, db, current_user, require_status=ListingStatus.approved
+        )
         if listing is None:
-            listing = await resolve_listing(model, identifier, db)
-        if listing is not None and not check_listing_visibility(listing, current_user):
-            listing = None
+            listing = await resolve_visible_listing(model, identifier, db, current_user)
+            if listing is not None:
+                permission = get_effective_component_permission(listing, current_user)
+                if not may_view_unapproved(permission, current_user):
+                    listing = None
 
     if listing is None:
         raise HTTPException(status_code=404, detail=f"{type.title()} not found")
@@ -112,6 +133,108 @@ async def resolve_registry_identifier(
         slug=listing.slug,
         qualified_name=listing.qualified_name,
     )
+
+
+@router.patch("/{item_type}/{listing_id}/visibility")
+async def update_registry_visibility(
+    item_type: RegistryItemType,
+    listing_id: str,
+    req: VisibilityUpdateRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Change a listing between public and team-member visibility."""
+    if item_type == "agent":
+        listing = await _load_agent(
+            db,
+            listing_id,
+            prefer_user_id=current_user.id,
+            current_user=current_user,
+            include_all_statuses=True,
+        )
+    else:
+        listing = await resolve_listing(_LISTING_MODELS[item_type], listing_id, db, current_user=current_user)
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    team_id = getattr(listing, "team_id", None)
+    privileged = current_user.role in (UserRole.super_admin, UserRole.admin, UserRole.reviewer)
+    if not privileged and not await check_listing_visibility_async(listing, current_user, db):
+        raise HTTPException(status_code=404, detail="Listing not found")
+    creator_id = getattr(listing, "created_by", None) or getattr(listing, "submitted_by", None)
+    if team_id is None:
+        if req.visibility == "team":
+            raise HTTPException(status_code=422, detail="Team visibility requires a teamspace")
+        if not privileged and creator_id != current_user.id:
+            raise HTTPException(status_code=403, detail="Only the listing owner can change visibility")
+    elif not privileged:
+        membership = await team_membership(db, team_id, current_user.id)
+        if not membership or membership.role not in (TeamRole.owner, TeamRole.reviewer):
+            raise HTTPException(status_code=403, detail="Only team owners and reviewers can change visibility")
+
+    if req.visibility == "team" and item_type != "agent":
+        # Installs can pin any approved version of an agent, not just its latest,
+        # so every approved version of a public agent has to keep resolving.
+        public_agent_ref = await db.scalar(
+            select(Agent.id)
+            .join(AgentVersion, AgentVersion.agent_id == Agent.id)
+            .join(AgentComponent, AgentComponent.agent_version_id == AgentVersion.id)
+            .where(
+                AgentComponent.component_type == item_type,
+                AgentComponent.component_id == listing.id,
+                Agent.is_private == False,  # noqa: E712
+                Agent.deleted_at.is_(None),
+                AgentVersion.status == AgentStatus.approved,
+            )
+            .limit(1)
+        )
+        if public_agent_ref is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot make this component team-only while an approved public agent version uses it",
+            )
+
+    if item_type == "agent":
+        from services.agent_resolver import validate_component_ids
+
+        component_refs = [
+            {"component_type": component.component_type, "component_id": component.component_id}
+            for component in listing.components
+        ]
+        errors = await validate_component_ids(
+            component_refs,
+            db,
+            require_approved=False,
+            current_user=current_user,
+            target_team_id=listing.team_id if req.visibility == "team" else None,
+            enforce_target=True,
+        )
+        if errors:
+            raise HTTPException(
+                status_code=409,
+                detail="Agent visibility conflicts with one or more component visibility settings",
+            )
+
+    was_private = bool(listing.is_private)
+    listing.is_private = req.visibility == "team"
+    returned_to_review = review_publication_to_public(listing, current_user, was_private=was_private)
+
+    request.state.audit_action = "registry.visibility.update"
+    request.state.audit_resource_type = item_type
+    request.state.audit_resource_id = str(listing.id)
+    request.state.audit_resource_name = listing.qualified_name
+    request.state.audit_detail = f"visibility={req.visibility}, returned_to_review={returned_to_review}"
+    await db.commit()
+    return {
+        "id": listing.id,
+        "type": item_type,
+        "qualified_name": listing.qualified_name,
+        "team_id": team_id,
+        "visibility": listing.visibility,
+        "status": listing.status.value,
+        "returned_to_review": returned_to_review,
+    }
 
 
 @router.post("/reconcile", response_model=list[RegistryReconcileResult])
@@ -139,8 +262,7 @@ async def reconcile_registry_items(
                 stmt = stmt.where(
                     or_(version_model.status == AgentStatus.approved, Agent.created_by == current_user.id)
                 )
-                if current_user.org_id is not None:
-                    stmt = stmt.where(or_(Agent.owner_org_id == current_user.org_id, Agent.owner_org_id.is_(None)))
+            stmt = apply_visibility_filter(stmt, model, current_user)
         else:
             stmt = apply_visibility_filter(stmt, model, current_user)
 

--- a/observal-server/api/routes/registry.py
+++ b/observal-server/api/routes/registry.py
@@ -201,10 +201,32 @@ async def update_registry_visibility(
     if item_type == "agent":
         from services.agent_resolver import validate_component_ids
 
+        # listing.components is the LATEST version's components only. Installs can
+        # pin any approved version, so an older version referencing a team-private
+        # component would keep resolving under a now-public agent and hand that
+        # component to installers who cannot read it. Validate every version that
+        # is still installable, not just the newest.
+        rows = (
+            await db.execute(
+                select(AgentComponent.component_type, AgentComponent.component_id)
+                .join(AgentVersion, AgentComponent.agent_version_id == AgentVersion.id)
+                .where(
+                    AgentVersion.agent_id == listing.id,
+                    AgentVersion.status.in_([AgentStatus.approved, AgentStatus.pending]),
+                )
+                .distinct()
+            )
+        ).all()
         component_refs = [
-            {"component_type": component.component_type, "component_id": component.component_id}
-            for component in listing.components
+            {"component_type": component_type, "component_id": component_id} for component_type, component_id in rows
         ]
+        # Fall back to the latest version when no version rows exist yet, so a
+        # freshly created draft still gets validated.
+        if not component_refs:
+            component_refs = [
+                {"component_type": component.component_type, "component_id": component.component_id}
+                for component in listing.components
+            ]
         errors = await validate_component_ids(
             component_refs,
             db,
@@ -221,7 +243,7 @@ async def update_registry_visibility(
 
     was_private = bool(listing.is_private)
     listing.is_private = req.visibility == "team"
-    returned_to_review = review_publication_to_public(listing, current_user, was_private=was_private)
+    returned_to_review = await review_publication_to_public(listing, current_user, db, was_private=was_private)
 
     request.state.audit_action = "registry.visibility.update"
     request.state.audit_resource_type = item_type

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -882,17 +882,13 @@ async def reject_agent(
 # ---------------------------------------------------------------------------
 
 
-async def _bundle_listings(bundle_id: uuid.UUID, db: AsyncSession, scope: ReviewScope, action: str) -> list:
+async def _bundle_listings(bundle_id: uuid.UUID, db: AsyncSession, scope: ReviewScope) -> list:
     """Load every listing in a bundle, refusing the bundle if one is out of scope."""
     listings = []
     for model in LISTING_MODELS.values():
         result = await db.execute(select(model).where(model.bundle_id == bundle_id))
         for listing in result.scalars().all():
-            if not can_review(listing, scope):
-                raise HTTPException(
-                    status_code=403,
-                    detail=f"Cannot {action}: '{listing.name}' is outside your review scope",
-                )
+            _authorize_item(listing, scope)
             listings.append(listing)
     return listings
 
@@ -910,7 +906,7 @@ async def approve_bundle(
         raise HTTPException(status_code=404, detail="Bundle not found")
 
     count = 0
-    for listing in await _bundle_listings(bundle_id, db, scope, "approve"):
+    for listing in await _bundle_listings(bundle_id, db, scope):
         if listing.latest_version and is_actively_editing(listing.latest_version):
             raise HTTPException(
                 status_code=409,
@@ -938,7 +934,7 @@ async def reject_bundle(
         raise HTTPException(status_code=404, detail="Bundle not found")
 
     count = 0
-    for listing in await _bundle_listings(bundle_id, db, scope, "reject"):
+    for listing in await _bundle_listings(bundle_id, db, scope):
         if listing.latest_version and is_actively_editing(listing.latest_version):
             raise HTTPException(
                 status_code=409,
@@ -1055,8 +1051,8 @@ async def approve_mcp_with_skills(
         except ValueError:
             continue
         skill = (await db.execute(select(SkillListing).where(SkillListing.id == skill_uuid))).scalar_one_or_none()
-        if skill and not can_review(skill, scope):
-            raise HTTPException(status_code=403, detail=f"Skill '{skill.name}' is outside your review scope")
+        if skill:
+            _authorize_item(skill, scope)
         if skill and skill.status == ListingStatus.pending:
             skill.status = ListingStatus.approved
             skill.rejection_reason = None

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -91,14 +91,17 @@ async def _require_review_scope(db: AsyncSession, current_user: User) -> ReviewS
 
 
 def _authorize_item(entity, scope: ReviewScope) -> None:
-    """Authorize one item from its own visibility and teamspace."""
+    """Authorize one item from its own visibility and teamspace.
+
+    A team-private item the caller cannot review answers 404, matching the read
+    paths: the queue already hides it, so a 403 naming it as team-private would
+    confirm both that the id exists and that it is private. A PUBLIC item is
+    already discoverable, so refusing it can say why without disclosing anything.
+    """
     if can_review(entity, scope):
         return
     if getattr(entity, "is_private", False):
-        raise HTTPException(
-            status_code=403,
-            detail="Team-private items are reviewed by their teamspace's owners and reviewers",
-        )
+        raise HTTPException(status_code=404, detail="Submission not found")
     raise HTTPException(
         status_code=403,
         detail="Public items are reviewed by global reviewers, not by teamspace roles",

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from sqlalchemy import String, cast, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role, resolve_prefix_id
+from api.deps import get_current_user, get_db, resolve_prefix_id
 from api.sanitize import escape_like
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.component_bundle import ComponentBundle
@@ -27,11 +27,13 @@ from models.mcp import ListingStatus, McpListing, McpVersion
 from models.prompt import PromptListing, PromptVersion
 from models.sandbox import SandboxListing, SandboxVersion
 from models.skill import SkillListing, SkillVersion
-from models.user import User, UserRole
+from models.user import User
 from schemas.mcp import ReviewActionRequest
 from services.cache import invalidate_namespace
 from services.editing_lock import is_actively_editing
 from services.redis import publish as redis_publish
+from services.security_events import EventType, SecurityEvent, Severity, emit_security_event
+from services.teamspace import ReviewScope, can_review, review_scope
 
 router = APIRouter(prefix="/api/v1/review", tags=["review"])
 
@@ -50,6 +52,73 @@ VERSION_MODELS = {
     "prompt": PromptVersion,
     "sandbox": SandboxVersion,
 }
+
+
+# ---------------------------------------------------------------------------
+# Review authorization
+#
+# Every route below used to sit behind require_role(UserRole.reviewer), the
+# GLOBAL role. That routed team-private items to reviewers outside the team and
+# left the team blocked until one of them acted, while the team's own owners and
+# reviewers got a 403. Authorization is now capability scoped: the queue, the
+# detail view, and the approve and reject actions all read the same ReviewScope,
+# so what a caller can list and what a caller can act on cannot drift apart.
+# ---------------------------------------------------------------------------
+
+
+async def _require_review_scope(db: AsyncSession, current_user: User) -> ReviewScope:
+    """Resolve the caller's review capability, refusing callers who have none.
+
+    A caller with neither a global review role nor an owner or reviewer seat in
+    any teamspace has no business on these routes at all, so this keeps the 403
+    that require_role used to raise rather than handing back an empty queue.
+    """
+    scope = await review_scope(db, current_user)
+    if scope.is_empty:
+        await emit_security_event(
+            SecurityEvent(
+                event_type=EventType.PERMISSION_DENIED,
+                severity=Severity.WARNING,
+                outcome="failure",
+                actor_id=str(current_user.id),
+                actor_email=current_user.email,
+                actor_role=current_user.role.value,
+                detail="Review access requires a global review role or a team owner or reviewer seat",
+            )
+        )
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    return scope
+
+
+def _authorize_item(entity, scope: ReviewScope) -> None:
+    """Authorize one item from its own visibility and teamspace."""
+    if can_review(entity, scope):
+        return
+    if getattr(entity, "is_private", False):
+        raise HTTPException(
+            status_code=403,
+            detail="Team-private items are reviewed by their teamspace's owners and reviewers",
+        )
+    raise HTTPException(
+        status_code=403,
+        detail="Public items are reviewed by global reviewers, not by teamspace roles",
+    )
+
+
+def _in_scope(entity, scope: ReviewScope, team_id: uuid.UUID | None) -> bool:
+    """Whether one pending item belongs in this caller's queue."""
+    if not can_review(entity, scope):
+        return False
+    return team_id is None or getattr(entity, "team_id", None) == team_id
+
+
+def _check_team_filter(team_id: uuid.UUID | None, scope: ReviewScope) -> None:
+    """Reject a ?team_id= narrowing to a teamspace the caller does not review for."""
+    if team_id is None:
+        return
+    if scope.is_admin or scope.is_global_reviewer or team_id in scope.team_ids:
+        return
+    raise HTTPException(status_code=403, detail="You do not review for this teamspace")
 
 
 async def _find_listing(listing_id: str, db: AsyncSession):
@@ -120,7 +189,7 @@ async def _check_agent_components_ready(components, db: AsyncSession) -> tuple[b
     return len(blocking) == 0, blocking
 
 
-async def _query_pending_agents(db: AsyncSession) -> list[dict]:
+async def _query_pending_agents(db: AsyncSession, scope: ReviewScope, team_id: uuid.UUID | None = None) -> list[dict]:
     # Find agents that have ANY pending version (not just latest_version_id).
     # This ensures version updates appear in the review queue after the first
     # version is approved.
@@ -140,10 +209,12 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
         if v.agent_id not in seen_agents and not is_actively_editing(v):
             seen_agents[v.agent_id] = v
 
-    # Load the agents
+    # Load the agents, dropping the ones this caller may not review. Agents carry
+    # is_private and team_id exactly like component listings do.
     agent_ids = list(seen_agents.keys())
     agents_result = await db.execute(select(Agent).where(Agent.id.in_(agent_ids)))
-    agents_map = {a.id: a for a in agents_result.scalars().all()}
+    agents_map = {a.id: a for a in agents_result.scalars().all() if _in_scope(a, scope, team_id)}
+    seen_agents = {aid: v for aid, v in seen_agents.items() if aid in agents_map}
 
     user_ids = {a.created_by for a in agents_map.values()}
     user_ids.update(v.released_by for v in seen_agents.values())
@@ -179,7 +250,12 @@ async def _query_pending_agents(db: AsyncSession) -> list[dict]:
     return items
 
 
-async def _query_pending_components(db: AsyncSession, type_filter: str | None = None) -> list[dict]:
+async def _query_pending_components(
+    db: AsyncSession,
+    scope: ReviewScope,
+    type_filter: str | None = None,
+    team_id: uuid.UUID | None = None,
+) -> list[dict]:
     optic.trace("type_filter={}", type_filter)
     models_to_query = (
         {type_filter: LISTING_MODELS[type_filter]} if type_filter and type_filter in LISTING_MODELS else LISTING_MODELS
@@ -208,9 +284,11 @@ async def _query_pending_components(db: AsyncSession, type_filter: str | None = 
         if not seen_listings:
             continue
 
-        # Load the listings
+        # Load the listings. A listing this caller may not review is dropped here,
+        # before anything about it reaches the response: a global reviewer who is
+        # not in the team must not even learn a team-private item's name.
         listings_result = await db.execute(select(model).where(model.id.in_(list(seen_listings.keys()))))
-        listings_map = {r.id: r for r in listings_result.scalars().all()}
+        listings_map = {r.id: r for r in listings_result.scalars().all() if _in_scope(r, scope, team_id)}
 
         for listing_id, pv in seen_listings.items():
             r = listings_map.get(listing_id)
@@ -280,21 +358,28 @@ async def list_pending(
         None,
         description="Filter by type: 'agents' or 'components'. Defaults to all pending items.",
     ),
+    team_id: uuid.UUID | None = Query(
+        None,
+        description="Narrow the queue to one teamspace the caller reviews for.",
+    ),
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("type={}", type)
+    scope = await _require_review_scope(db, current_user)
+    _check_team_filter(team_id, scope)
+
     if tab == "agents":
-        result = await _query_pending_agents(db)
+        result = await _query_pending_agents(db, scope, team_id)
         return result
 
     if tab == "components":
-        result = await _query_pending_components(db, type)
+        result = await _query_pending_components(db, scope, type, team_id)
         return result
 
     # Default: return both agents and components
-    agents = await _query_pending_agents(db)
-    components = await _query_pending_components(db, type)
+    agents = await _query_pending_agents(db, scope, team_id)
+    components = await _query_pending_components(db, scope, type, team_id)
 
     # Merge and sort by created_at (most recent first)
     all_items = agents + components
@@ -446,12 +531,18 @@ def _serialize_listing_detail(listing_type: str, listing) -> dict:
 async def get_review(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("listing_id={}", listing_id)
+    scope = await _require_review_scope(db, current_user)
     listing_type, listing = await _find_listing(listing_id, db)
 
     if listing:
+        # 404 rather than 403: the queue already hides items outside the caller's
+        # scope, and answering 403 here would confirm a team-private item exists
+        # to the very reviewers the scoping keeps away from it.
+        if not can_review(listing, scope):
+            raise HTTPException(status_code=404, detail="Listing not found")
         result = _serialize_listing_detail(listing_type, listing)
     else:
         # Fallback: check Agent table
@@ -460,7 +551,7 @@ async def get_review(
         except ValueError:
             raise HTTPException(status_code=404, detail="Listing not found")
         agent = (await db.execute(select(Agent).where(Agent.id == agent_uuid))).scalar_one_or_none()
-        if not agent:
+        if not agent or not can_review(agent, scope):
             raise HTTPException(status_code=404, detail="Listing not found")
         # Use the pending version for review (not latest_version which is the approved one)
         pending_ver = next(
@@ -539,12 +630,14 @@ async def get_review(
 async def approve(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("listing_id={}", listing_id)
+    scope = await _require_review_scope(db, current_user)
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
+    _authorize_item(listing, scope)
 
     # Find the pending version to approve (may not be latest_version)
     pending_ver = None
@@ -588,12 +681,14 @@ async def reject(
     listing_id: str,
     req: ReviewActionRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("listing_id={}, req={}", listing_id, req)
+    scope = await _require_review_scope(db, current_user)
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
+    _authorize_item(listing, scope)
 
     # Find the pending version to reject (may not be latest_version)
     pending_ver = None
@@ -652,14 +747,16 @@ async def approve_agent(
     agent_id: uuid.UUID,
     req: AgentApproveRequest | None = None,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("agent_id={}, req={}", agent_id, req)
     from services.versioning import parse_semver
 
+    scope = await _require_review_scope(db, current_user)
     agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    _authorize_item(agent, scope)
 
     pending_versions = (
         (
@@ -726,12 +823,14 @@ async def reject_agent(
     agent_id: uuid.UUID,
     req: AgentRejectRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("agent_id={}, req={}", agent_id, req)
+    scope = await _require_review_scope(db, current_user)
     agent = (await db.execute(select(Agent).where(Agent.id == agent_id))).scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    _authorize_item(agent, scope)
 
     pending_versions = (
         (
@@ -768,32 +867,55 @@ async def reject_agent(
 
 # ---------------------------------------------------------------------------
 # Bundle review (atomic approve/reject)
+#
+# A ComponentBundle carries no visibility of its own: it is a grouping, and each
+# member listing keeps its own is_private and team_id. The bundle actions are
+# atomic by design, so they authorize every member listing individually and
+# refuse the whole bundle when one member is outside the caller's scope. A
+# wholly team-private bundle is therefore reviewable by that team's owners and
+# reviewers, a wholly public one by a global reviewer, and a bundle that mixes
+# the two only by an admin. Approving the reachable half and skipping the rest
+# would silently half-apply an operation whose entire point is atomicity.
 # ---------------------------------------------------------------------------
+
+
+async def _bundle_listings(bundle_id: uuid.UUID, db: AsyncSession, scope: ReviewScope, action: str) -> list:
+    """Load every listing in a bundle, refusing the bundle if one is out of scope."""
+    listings = []
+    for model in LISTING_MODELS.values():
+        result = await db.execute(select(model).where(model.bundle_id == bundle_id))
+        for listing in result.scalars().all():
+            if not can_review(listing, scope):
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Cannot {action}: '{listing.name}' is outside your review scope",
+                )
+            listings.append(listing)
+    return listings
 
 
 @router.post("/bundles/{bundle_id}/approve")
 async def approve_bundle(
     bundle_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("bundle_id={}", bundle_id)
+    scope = await _require_review_scope(db, current_user)
     bundle = (await db.execute(select(ComponentBundle).where(ComponentBundle.id == bundle_id))).scalar_one_or_none()
     if not bundle:
         raise HTTPException(status_code=404, detail="Bundle not found")
 
     count = 0
-    for model in LISTING_MODELS.values():
-        result = await db.execute(select(model).where(model.bundle_id == bundle_id))
-        for listing in result.scalars().all():
-            if listing.latest_version and is_actively_editing(listing.latest_version):
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Cannot approve: '{listing.name}' is currently being edited by its owner",
-                )
-            listing.status = ListingStatus.approved
-            listing.rejection_reason = None
-            count += 1
+    for listing in await _bundle_listings(bundle_id, db, scope, "approve"):
+        if listing.latest_version and is_actively_editing(listing.latest_version):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Cannot approve: '{listing.name}' is currently being edited by its owner",
+            )
+        listing.status = ListingStatus.approved
+        listing.rejection_reason = None
+        count += 1
 
     await db.commit()
     return {"bundle_id": str(bundle_id), "name": bundle.name, "approved_count": count}
@@ -804,25 +926,24 @@ async def reject_bundle(
     bundle_id: uuid.UUID,
     req: ReviewActionRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("bundle_id={}, req={}", bundle_id, req)
+    scope = await _require_review_scope(db, current_user)
     bundle = (await db.execute(select(ComponentBundle).where(ComponentBundle.id == bundle_id))).scalar_one_or_none()
     if not bundle:
         raise HTTPException(status_code=404, detail="Bundle not found")
 
     count = 0
-    for model in LISTING_MODELS.values():
-        result = await db.execute(select(model).where(model.bundle_id == bundle_id))
-        for listing in result.scalars().all():
-            if listing.latest_version and is_actively_editing(listing.latest_version):
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Cannot reject: '{listing.name}' is currently being edited by its owner",
-                )
-            listing.status = ListingStatus.rejected
-            listing.rejection_reason = req.reason
-            count += 1
+    for listing in await _bundle_listings(bundle_id, db, scope, "reject"):
+        if listing.latest_version and is_actively_editing(listing.latest_version):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Cannot reject: '{listing.name}' is currently being edited by its owner",
+            )
+        listing.status = ListingStatus.rejected
+        listing.rejection_reason = req.reason
+        count += 1
 
     await db.commit()
     return {"bundle_id": str(bundle_id), "name": bundle.name, "rejected_count": count}
@@ -837,12 +958,15 @@ async def reject_bundle(
 async def get_related_skills(
     listing_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("listing_id={}", listing_id)
+    scope = await _require_review_scope(db, current_user)
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing or listing_type != "mcp":
         return {"skills": []}
+    if not can_review(listing, scope):
+        raise HTTPException(status_code=404, detail="Listing not found")
 
     mcp_name = listing.name
     mcp_id = str(listing.id)
@@ -860,7 +984,9 @@ async def get_related_skills(
         )
         .order_by(SkillListing.created_at.desc())
     )
-    skills = (await db.execute(stmt)).scalars().all()
+    # The suggestion list is a review surface like the queue itself, so a skill
+    # the caller may not review never appears in it.
+    skills = [s for s in (await db.execute(stmt)).scalars().all() if can_review(s, scope)]
 
     user_ids = {s.submitted_by for s in skills}
     user_map: dict[uuid.UUID, str] = {}
@@ -894,19 +1020,27 @@ class McpBulkApproveRequest(BaseModel):
     skill_ids: list[str] = []
 
 
+# approve-with-skills approves a caller-supplied set of skill ids alongside the
+# MCP, and nothing ties those skills to the MCP's teamspace, so it is scoped the
+# same way as a plain approve: the MCP and every named skill are authorized on
+# their own visibility. A skill outside the caller's scope fails the whole call
+# rather than being dropped from the batch, because a caller who asked for it
+# must be told it was refused instead of reading a smaller approved count.
 @router.post("/{listing_id}/approve-with-skills")
 async def approve_mcp_with_skills(
     listing_id: str,
     req: McpBulkApproveRequest,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.reviewer)),
+    current_user: User = Depends(get_current_user),
 ):
     optic.trace("listing_id={}, req={}", listing_id, req)
+    scope = await _require_review_scope(db, current_user)
     listing_type, listing = await _find_listing(listing_id, db)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if listing_type != "mcp":
         raise HTTPException(status_code=400, detail="Only MCP listings support bulk skill approve")
+    _authorize_item(listing, scope)
 
     listing.status = ListingStatus.approved
     listing.rejection_reason = None
@@ -918,6 +1052,8 @@ async def approve_mcp_with_skills(
         except ValueError:
             continue
         skill = (await db.execute(select(SkillListing).where(SkillListing.id == skill_uuid))).scalar_one_or_none()
+        if skill and not can_review(skill, scope):
+            raise HTTPException(status_code=403, detail=f"Skill '{skill.name}' is outside your review scope")
         if skill and skill.status == ListingStatus.pending:
             skill.status = ListingStatus.approved
             skill.rejection_reason = None

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -4,25 +4,24 @@
 # SPDX-FileCopyrightText: 2026 Shreem Seth <shreemseth26@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from fastapi_cache.decorator import cache
 from loguru import logger as optic
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import services.dynamic_settings as ds
 from api.deps import (
-    apply_visibility_filter,
-    check_listing_visibility,
+    apply_registry_scope,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    may_view_unapproved,
     optional_current_user,
-    registry_identity,
     require_role,
     resolve_listing,
+    resolve_visible_listing,
 )
 from api.routes._component_archive import archive_listing, unarchive_listing
 from api.routes.component_versions import create_version_router
@@ -39,6 +38,7 @@ from schemas.sandbox import (
 )
 from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.registry_namespace import identity_exists
+from services.teamspace import publish_auto_approves_for_entity, resolve_publish_target
 
 router = APIRouter(prefix="/api/v1/sandboxes", tags=["sandboxes"])
 
@@ -50,17 +50,24 @@ async def submit_sandbox(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("sandbox submit: name={}", req.name)
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, SandboxListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Sandbox '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, SandboxListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Sandbox '{target.namespace}/{target.slug}' already exists")
 
     listing = SandboxListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else req.owner,
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -79,9 +86,11 @@ async def submit_sandbox(
         source_url=req.source_url,
         source_ref=req.source_ref,
         sandbox_path=req.sandbox_path,
-        status=ListingStatus.pending,
+        status=ListingStatus.approved if target.auto_approve else ListingStatus.pending,
         released_by=current_user.id,
         released_at=datetime.now(UTC),
+        reviewed_by=current_user.id if target.auto_approve else None,
+        reviewed_at=datetime.now(UTC) if target.auto_approve else None,
     )
     db.add(version)
     await db.flush()
@@ -93,12 +102,13 @@ async def submit_sandbox(
 
 
 @router.get("", response_model=list[SandboxListingSummary])
-@cache(expire=ds.get_sync_int("data.cache_ttl_registry", 30), namespace="registry")
 async def list_sandboxes(
     response: Response,
     runtime_type: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
+    team_id: uuid.UUID | None = Query(None),
+    public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
@@ -132,7 +142,7 @@ async def list_sandboxes(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_visibility_filter(stmt, SandboxListing, current_user)
+    stmt = apply_registry_scope(stmt, SandboxListing, current_user, team_id=team_id, public_only=public_only)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [SandboxListing.created_at.desc()]
     if search_rank is not None:
@@ -166,22 +176,19 @@ async def get_sandbox(
     current_user: User | None = Depends(optional_current_user),
 ):
     optic.debug("sandbox get: listing_id={}", listing_id)
-    listing = await resolve_listing(SandboxListing, listing_id, db, require_status=ListingStatus.approved)
-    if listing:
-        resp = SandboxListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    listing = await resolve_listing(SandboxListing, listing_id, db)
-    if not listing:
-        raise HTTPException(status_code=404, detail="Listing not found")
-
-    if check_listing_visibility(listing, current_user):
-        resp = SandboxListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    raise HTTPException(status_code=404, detail="Listing not found")
+    listing = await resolve_visible_listing(
+        SandboxListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
+    if listing is None:
+        listing = await resolve_visible_listing(SandboxListing, listing_id, db, current_user)
+        may_view = listing is not None and may_view_unapproved(
+            get_effective_component_permission(listing, current_user), current_user
+        )
+        if not may_view:
+            raise HTTPException(status_code=404, detail="Listing not found")
+    resp = SandboxListingResponse.model_validate(listing)
+    resp.user_permission = get_effective_component_permission(listing, current_user)
+    return resp
 
 
 @router.post("/draft", response_model=SandboxListingResponse)
@@ -191,16 +198,23 @@ async def save_sandbox_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("req={}", req)
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, SandboxListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Sandbox '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, SandboxListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Sandbox '{target.namespace}/{target.slug}' already exists")
     listing = SandboxListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner or current_user.username or current_user.email,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else (req.owner or current_user.username or current_user.email),
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -232,6 +246,27 @@ async def save_sandbox_draft(
     return SandboxListingResponse.model_validate(listing)
 
 
+def _reject_visibility_edits(listing, req) -> None:
+    """Refuse teamspace or visibility changes sent to the draft update route.
+
+    Visibility has exactly one authoritative path, PATCH /api/v1/registry/sandbox/{listing_id}/visibility,
+    which authorizes team owners and reviewers, writes audit metadata, and blocks privatizing a
+    component that an approved public agent depends on. Accepting these fields here would either
+    silently discard them or fork that policy into a weaker second implementation, so a real change
+    is rejected. A request that repeats the values the listing already holds changes nothing and passes.
+    """
+    if req.team_id is not None and req.team_id != listing.team_id:
+        raise HTTPException(
+            status_code=400,
+            detail="team_id cannot be changed here. A listing stays in the teamspace it was created under.",
+        )
+    if req.visibility is not None and req.visibility != listing.visibility:
+        raise HTTPException(
+            status_code=400,
+            detail=f"visibility cannot be changed here. Use PATCH /api/v1/registry/sandbox/{listing.id}/visibility.",
+        )
+
+
 @router.put("/{listing_id}/draft", response_model=SandboxListingResponse)
 async def update_sandbox_draft(
     listing_id: str,
@@ -240,13 +275,14 @@ async def update_sandbox_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SandboxListing, listing_id, db)
+    listing = await resolve_listing(SandboxListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
         raise HTTPException(status_code=403, detail="Not the listing owner")
     if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
         raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+    _reject_visibility_edits(listing, req)
 
     ver = listing.latest_version
     if not ver:
@@ -296,7 +332,7 @@ async def start_edit_sandbox(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SandboxListing, listing_id, db)
+    listing = await resolve_listing(SandboxListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -320,7 +356,7 @@ async def cancel_edit_sandbox(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SandboxListing, listing_id, db)
+    listing = await resolve_listing(SandboxListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -340,7 +376,7 @@ async def submit_sandbox_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SandboxListing, listing_id, db)
+    listing = await resolve_listing(SandboxListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -353,7 +389,12 @@ async def submit_sandbox_draft(
     if not listing.image:
         raise HTTPException(status_code=400, detail="Image is required before submitting")
 
-    listing.status = ListingStatus.pending
+    if await publish_auto_approves_for_entity(listing, current_user, db):
+        listing.status = ListingStatus.approved
+        listing.latest_version.reviewed_by = current_user.id
+        listing.latest_version.reviewed_at = datetime.now(UTC)
+    else:
+        listing.status = ListingStatus.pending
     await commit_or_name_conflict(db, "sandbox")
     await db.refresh(listing)
     return SandboxListingResponse.model_validate(listing)

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     apply_registry_scope,
+    apply_visibility_filter,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
@@ -174,6 +175,10 @@ async def my_sandboxes(
         .where(SandboxListing.submitted_by == current_user.id)
         .order_by(SandboxListing.created_at.desc())
     )
+    # Authorship is not a standing grant: a member removed from a teamspace keeps
+    # the author column on its listings but must not keep reading them.
+    stmt = apply_visibility_filter(stmt, SandboxListing, current_user)
+
     result = await db.execute(stmt)
     listings = [SandboxListingSummary.model_validate(r) for r in result.scalars().all()]
     return listings

--- a/observal-server/api/routes/sandbox.py
+++ b/observal-server/api/routes/sandbox.py
@@ -107,7 +107,10 @@ async def list_sandboxes(
     runtime_type: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
-    team_id: uuid.UUID | None = Query(None),
+    team_id: uuid.UUID | None = Query(None, description="Only listings owned by this teamspace"),
+    composable_for_team_id: uuid.UUID | None = Query(
+        None, description="Public listings plus this teamspace's private ones, for agent composition"
+    ),
     public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -142,7 +145,14 @@ async def list_sandboxes(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_registry_scope(stmt, SandboxListing, current_user, team_id=team_id, public_only=public_only)
+    stmt = apply_registry_scope(
+        stmt,
+        SandboxListing,
+        current_user,
+        team_id=team_id,
+        composable_for_team_id=composable_for_team_id,
+        public_only=public_only,
+    )
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [SandboxListing.created_at.desc()]
     if search_rank is not None:

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.deps import (
     apply_registry_scope,
+    apply_visibility_filter,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
@@ -268,6 +269,10 @@ async def my_skills(
         .where(SkillListing.submitted_by == current_user.id)
         .order_by(SkillListing.created_at.desc())
     )
+    # Authorship is not a standing grant: a member removed from a teamspace keeps
+    # the author column on its listings but must not keep reading them.
+    stmt = apply_visibility_filter(stmt, SkillListing, current_user)
+
     result = await db.execute(stmt)
     listings = [SkillListingSummary.model_validate(r) for r in result.scalars().all()]
     return listings

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -6,28 +6,28 @@
 # SPDX-FileCopyrightText: 2026 tsitu0 <tomsitu0102@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
-from fastapi_cache.decorator import cache
 from loguru import logger as optic
 from sqlalchemy import String, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import services.dynamic_settings as ds
 from api.deps import (
-    apply_visibility_filter,
-    check_listing_visibility,
+    apply_registry_scope,
     commit_or_name_conflict,
     get_db,
     get_effective_component_permission,
+    may_view_unapproved,
     optional_current_user,
-    registry_identity,
     require_role,
     resolve_listing,
+    resolve_visible_listing,
 )
 from api.routes._component_archive import archive_listing, archived_install_warning, unarchive_listing
 from api.routes.component_versions import create_version_router
+from api.sanitize import escape_like
 from api.search import keyword_search
 from models.mcp import ListingStatus
 from models.skill import SkillDownload, SkillListing, SkillVersion
@@ -45,6 +45,7 @@ from schemas.skill_commands import normalize_slash_command
 from services.editing_lock import _is_lock_expired, acquire_edit_lock, release_edit_lock
 from services.registry_namespace import identity_exists
 from services.skill_validator import SkillValidationError, validate_skill_md, validate_skill_md_content_frontmatter
+from services.teamspace import publish_auto_approves_for_entity, resolve_publish_target
 
 router = APIRouter(prefix="/api/v1/skills", tags=["skills"])
 
@@ -127,17 +128,24 @@ async def submit_skill(
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=f"Invalid slash_command: {exc}") from exc
 
-    namespace, slug = registry_identity(current_user, name)
-    if await identity_exists(db, SkillListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Skill '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, SkillListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Skill '{target.namespace}/{target.slug}' already exists")
 
     listing = SkillListing(
         name=name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else req.owner,
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -158,9 +166,11 @@ async def submit_skill(
         task_type=req.task_type,
         slash_command=slash_command,
         supported_harnesses=req.supported_harnesses,
-        status=ListingStatus.pending,
+        status=ListingStatus.approved if target.auto_approve else ListingStatus.pending,
         released_by=current_user.id,
         released_at=datetime.now(UTC),
+        reviewed_by=current_user.id if target.auto_approve else None,
+        reviewed_at=datetime.now(UTC) if target.auto_approve else None,
     )
     db.add(version)
     await db.flush()
@@ -172,13 +182,15 @@ async def submit_skill(
 
 
 @router.get("", response_model=list[SkillListingSummary])
-@cache(expire=ds.get_sync_int("data.cache_ttl_registry", 30), namespace="registry")
 async def list_skills(
     response: Response,
     task_type: str | None = Query(None),
     target_agent: str | None = Query(None),
+    harness: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
+    team_id: uuid.UUID | None = Query(None),
+    public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
@@ -192,6 +204,8 @@ async def list_skills(
     )
     if task_type:
         stmt = stmt.where(SkillVersion.task_type == task_type)
+    if harness:
+        stmt = stmt.where(cast(SkillVersion.supported_harnesses, String).ilike(f'%"{escape_like(harness)}"%'))
     if namespace:
         stmt = stmt.where(SkillListing.namespace == namespace.strip().lower())
     target_agents_text = cast(SkillVersion.target_agents, String)
@@ -210,13 +224,19 @@ async def list_skills(
                 SkillListing.owner,
                 SkillVersion.description,
                 SkillVersion.task_type,
+                SkillVersion.skill_path,
+                SkillVersion.slash_command,
+                SkillVersion.git_url,
+                SkillVersion.skill_md_content,
+                SkillVersion.delivery_mode,
                 target_agents_text,
+                cast(SkillVersion.supported_harnesses, String),
             ],
             name_field=SkillListing.name,
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_visibility_filter(stmt, SkillListing, current_user)
+    stmt = apply_registry_scope(stmt, SkillListing, current_user, team_id=team_id, public_only=public_only)
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [SkillListing.created_at.desc()]
     if search_rank is not None:
@@ -250,22 +270,19 @@ async def get_skill(
     current_user: User | None = Depends(optional_current_user),
 ):
     optic.debug("fetching skill {}", listing_id)
-    listing = await resolve_listing(SkillListing, listing_id, db, require_status=ListingStatus.approved)
-    if listing:
-        resp = SkillListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    listing = await resolve_listing(SkillListing, listing_id, db)
-    if not listing:
-        raise HTTPException(status_code=404, detail="Listing not found")
-
-    if check_listing_visibility(listing, current_user):
-        resp = SkillListingResponse.model_validate(listing)
-        resp.user_permission = get_effective_component_permission(listing, current_user)
-        return resp
-
-    raise HTTPException(status_code=404, detail="Listing not found")
+    listing = await resolve_visible_listing(
+        SkillListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
+    if listing is None:
+        listing = await resolve_visible_listing(SkillListing, listing_id, db, current_user)
+        may_view = listing is not None and may_view_unapproved(
+            get_effective_component_permission(listing, current_user), current_user
+        )
+        if not may_view:
+            raise HTTPException(status_code=404, detail="Listing not found")
+    resp = SkillListingResponse.model_validate(listing)
+    resp.user_permission = get_effective_component_permission(listing, current_user)
+    return resp
 
 
 @router.post("/{listing_id}/install", response_model=SkillInstallResponse)
@@ -277,10 +294,12 @@ async def install_skill(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.debug("installing skill {}", listing_id)
-    listing = await resolve_listing(SkillListing, listing_id, db, require_status=ListingStatus.approved)
+    listing = await resolve_visible_listing(
+        SkillListing, listing_id, db, current_user, require_status=ListingStatus.approved
+    )
     if not listing:
-        listing = await resolve_listing(SkillListing, listing_id, db)
-        if not listing or not check_listing_visibility(listing, current_user):
+        listing = await resolve_visible_listing(SkillListing, listing_id, db, current_user)
+        if not listing:
             raise HTTPException(status_code=404, detail="Listing not found or not approved")
         if (
             listing.status != ListingStatus.archived
@@ -341,16 +360,23 @@ async def save_skill_draft(
     content_analysis = _validate_stored_skill_md(req.skill_md_content, req.slash_command)
     slash_command = content_analysis.slash_command
 
-    namespace, slug = registry_identity(current_user, req.name)
-    if await identity_exists(db, SkillListing, namespace, slug):
-        raise HTTPException(status_code=409, detail=f"Skill '{namespace}/{slug}' already exists")
+    target = await resolve_publish_target(
+        db,
+        current_user,
+        req.name,
+        team_id=req.team_id,
+        visibility=req.visibility,
+    )
+    if await identity_exists(db, SkillListing, target.namespace, target.slug):
+        raise HTTPException(status_code=409, detail=f"Skill '{target.namespace}/{target.slug}' already exists")
     listing = SkillListing(
         name=req.name,
-        namespace=namespace,
-        slug=slug,
-        owner=req.owner or current_user.username or current_user.email,
+        namespace=target.namespace,
+        slug=target.slug,
+        owner=target.owner if target.team_id else (req.owner or current_user.username or current_user.email),
         submitted_by=current_user.id,
-        owner_org_id=current_user.org_id,
+        team_id=target.team_id,
+        is_private=target.visibility == "team",
     )
     db.add(listing)
     await db.flush()
@@ -383,6 +409,27 @@ async def save_skill_draft(
     return SkillListingResponse.model_validate(listing)
 
 
+def _reject_visibility_edits(listing, req) -> None:
+    """Refuse teamspace or visibility changes sent to the draft update route.
+
+    Visibility has exactly one authoritative path, PATCH /api/v1/registry/skill/{listing_id}/visibility,
+    which authorizes team owners and reviewers, writes audit metadata, and blocks privatizing a
+    component that an approved public agent depends on. Accepting these fields here would either
+    silently discard them or fork that policy into a weaker second implementation, so a real change
+    is rejected. A request that repeats the values the listing already holds changes nothing and passes.
+    """
+    if req.team_id is not None and req.team_id != listing.team_id:
+        raise HTTPException(
+            status_code=400,
+            detail="team_id cannot be changed here. A listing stays in the teamspace it was created under.",
+        )
+    if req.visibility is not None and req.visibility != listing.visibility:
+        raise HTTPException(
+            status_code=400,
+            detail=f"visibility cannot be changed here. Use PATCH /api/v1/registry/skill/{listing.id}/visibility.",
+        )
+
+
 @router.put("/{listing_id}/draft", response_model=SkillListingResponse)
 async def update_skill_draft(
     listing_id: str,
@@ -391,13 +438,14 @@ async def update_skill_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SkillListing, listing_id, db)
+    listing = await resolve_listing(SkillListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
         raise HTTPException(status_code=403, detail="Not the listing owner")
     if listing.status not in (ListingStatus.draft, ListingStatus.rejected, ListingStatus.pending):
         raise HTTPException(status_code=400, detail="Only draft, rejected, or pending listings can be edited")
+    _reject_visibility_edits(listing, req)
 
     ver = listing.latest_version
     if not ver:
@@ -463,7 +511,7 @@ async def start_edit_skill(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SkillListing, listing_id, db)
+    listing = await resolve_listing(SkillListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -487,7 +535,7 @@ async def cancel_edit_skill(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SkillListing, listing_id, db)
+    listing = await resolve_listing(SkillListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -507,7 +555,7 @@ async def submit_skill_draft(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     optic.trace("listing_id={}", listing_id)
-    listing = await resolve_listing(SkillListing, listing_id, db)
+    listing = await resolve_listing(SkillListing, listing_id, db, current_user=current_user)
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
     if get_effective_component_permission(listing, current_user) != "owner":
@@ -525,7 +573,12 @@ async def submit_skill_draft(
     if not listing.description:
         raise HTTPException(status_code=400, detail="Description is required before submitting")
 
-    listing.status = ListingStatus.pending
+    if await publish_auto_approves_for_entity(listing, current_user, db):
+        listing.status = ListingStatus.approved
+        listing.latest_version.reviewed_by = current_user.id
+        listing.latest_version.reviewed_at = datetime.now(UTC)
+    else:
+        listing.status = ListingStatus.pending
     await commit_or_name_conflict(db, "skill")
     await db.refresh(listing)
     return SkillListingResponse.model_validate(listing)

--- a/observal-server/api/routes/skill.py
+++ b/observal-server/api/routes/skill.py
@@ -189,7 +189,10 @@ async def list_skills(
     harness: str | None = Query(None),
     namespace: str | None = Query(None),
     search: str | None = Query(None),
-    team_id: uuid.UUID | None = Query(None),
+    team_id: uuid.UUID | None = Query(None, description="Only listings owned by this teamspace"),
+    composable_for_team_id: uuid.UUID | None = Query(
+        None, description="Public listings plus this teamspace's private ones, for agent composition"
+    ),
     public_only: bool = Query(False),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -236,7 +239,14 @@ async def list_skills(
         )
         if search_filter is not None:
             stmt = stmt.where(search_filter)
-    stmt = apply_registry_scope(stmt, SkillListing, current_user, team_id=team_id, public_only=public_only)
+    stmt = apply_registry_scope(
+        stmt,
+        SkillListing,
+        current_user,
+        team_id=team_id,
+        composable_for_team_id=composable_for_team_id,
+        public_only=public_only,
+    )
     total = await db.scalar(select(func.count()).select_from(stmt.subquery()))
     order_by = [SkillListing.created_at.desc()]
     if search_rank is not None:

--- a/observal-server/api/routes/teams.py
+++ b/observal-server/api/routes/teams.py
@@ -209,6 +209,7 @@ async def _team_owned_listing_counts(db: AsyncSession, team_id: uuid.UUID) -> di
     delete its listings: it strips their teamspace and leaves them behind.
     """
     from models.agent import Agent
+    from models.component_source import ComponentSource
     from models.hook import HookListing
     from models.mcp import McpListing
     from models.prompt import PromptListing
@@ -223,10 +224,16 @@ async def _team_owned_listing_counts(db: AsyncSession, team_id: uuid.UUID) -> di
         HookListing: ("hook", "hooks"),
         PromptListing: ("prompt", "prompts"),
         SandboxListing: ("sandbox", "sandboxes"),
+        ComponentSource: ("component source", "component sources"),
     }
     counts: dict[str, int] = {}
     for model, (singular, plural) in labels.items():
-        total = await db.scalar(select(func.count(model.id)).where(model.team_id == team_id))
+        stmt = select(func.count(model.id)).where(model.team_id == team_id)
+        # Soft-deleted agents are already gone as far as their owner is concerned,
+        # so they must not keep a teamspace alive forever.
+        if hasattr(model, "deleted_at"):
+            stmt = stmt.where(model.deleted_at.is_(None))
+        total = await db.scalar(stmt)
         if total:
             counts[singular if total == 1 else plural] = total
     return counts
@@ -258,9 +265,10 @@ async def delete_team(
         raise HTTPException(
             status_code=409,
             detail=(
-                f"Teamspace '{team.handle}' still owns {detail}. Transfer or delete those listings before "
-                "deleting the teamspace, otherwise their members lose access and the namespace is "
-                "left claimable by someone else."
+                f"Teamspace '{team.handle}' still owns {detail}. Transfer each listing to a user with "
+                "POST /api/v1/{entity_type}/{id}/transfer-ownership, which moves it out of the "
+                "teamspace, or delete it. Deleting the teamspace first would strip its members' access and "
+                "leave the handle claimable by someone else."
             ),
         )
 

--- a/observal-server/api/routes/teams.py
+++ b/observal-server/api/routes/teams.py
@@ -202,6 +202,36 @@ async def update_team(
     )
 
 
+async def _team_owned_listing_counts(db: AsyncSession, team_id: uuid.UUID) -> dict[str, int]:
+    """Count everything published under a teamspace, by kind.
+
+    The team_id foreign keys are ON DELETE SET NULL, so deleting a team does not
+    delete its listings: it strips their teamspace and leaves them behind.
+    """
+    from models.agent import Agent
+    from models.hook import HookListing
+    from models.mcp import McpListing
+    from models.prompt import PromptListing
+    from models.sandbox import SandboxListing
+    from models.skill import SkillListing
+
+    # (singular, plural) so a count of one does not read "1 skills".
+    labels = {
+        Agent: ("agent", "agents"),
+        McpListing: ("MCP server", "MCP servers"),
+        SkillListing: ("skill", "skills"),
+        HookListing: ("hook", "hooks"),
+        PromptListing: ("prompt", "prompts"),
+        SandboxListing: ("sandbox", "sandboxes"),
+    }
+    counts: dict[str, int] = {}
+    for model, (singular, plural) in labels.items():
+        total = await db.scalar(select(func.count(model.id)).where(model.team_id == team_id))
+        if total:
+            counts[singular if total == 1 else plural] = total
+    return counts
+
+
 @router.delete("/{team_id}", status_code=204)
 async def delete_team(
     team_id: uuid.UUID,
@@ -209,6 +239,31 @@ async def delete_team(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     team = await _require_owner_or_admin(db, team_id, current_user)
+
+    # Refuse while the teamspace still owns listings. ON DELETE SET NULL would
+    # otherwise leave every one of them with is_private=True and team_id=NULL:
+    # the membership check can no longer match anybody, so each listing silently
+    # collapses to creator-only access while still reporting visibility "team",
+    # and no member other than its original submitter can reach it again. The
+    # handle also becomes free to claim, which would hand those listings'
+    # namespace to whoever registers it next. Make the owner deal with the
+    # listings first rather than destroying access as a side effect.
+    owned = await _team_owned_listing_counts(db, team.id)
+    if owned:
+        # Public listings block too. Changing visibility does not clear team_id, and
+        # deleting the team frees the handle for anyone to claim, which would hand a
+        # new owner the namespace those listings still carry. Only transferring or
+        # deleting them actually detaches them, so the message says exactly that.
+        detail = ", ".join(f"{count} {label}" for label, count in sorted(owned.items()))
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Teamspace '{team.handle}' still owns {detail}. Transfer or delete those listings before "
+                "deleting the teamspace, otherwise their members lose access and the namespace is "
+                "left claimable by someone else."
+            ),
+        )
+
     await db.delete(team)
     await db.commit()
 

--- a/observal-server/api/routes/teams.py
+++ b/observal-server/api/routes/teams.py
@@ -205,8 +205,11 @@ async def update_team(
 async def _team_owned_listing_counts(db: AsyncSession, team_id: uuid.UUID) -> dict[str, int]:
     """Count everything published under a teamspace, by kind.
 
-    The team_id foreign keys are ON DELETE SET NULL, so deleting a team does not
-    delete its listings: it strips their teamspace and leaves them behind.
+    The team_id foreign keys are ON DELETE RESTRICT as of migration 019, so the
+    database refuses the delete on its own. This count exists only to answer with a
+    message naming what is in the way instead of surfacing an integrity error, and
+    it is deliberately not the enforcement: counting and then deleting is racy, and
+    a publish landing in between is caught by the constraint rather than here.
     """
     from models.agent import Agent
     from models.component_source import ComponentSource
@@ -228,12 +231,10 @@ async def _team_owned_listing_counts(db: AsyncSession, team_id: uuid.UUID) -> di
     }
     counts: dict[str, int] = {}
     for model, (singular, plural) in labels.items():
-        stmt = select(func.count(model.id)).where(model.team_id == team_id)
-        # Soft-deleted agents are already gone as far as their owner is concerned,
-        # so they must not keep a teamspace alive forever.
-        if hasattr(model, "deleted_at"):
-            stmt = stmt.where(model.deleted_at.is_(None))
-        total = await db.scalar(stmt)
+        # Soft-deleted agents count too. They are restorable and still carry the
+        # teamspace's namespace, so freeing the handle while one exists lets a new
+        # team claim it and inherit that agent on restore.
+        total = await db.scalar(select(func.count(model.id)).where(model.team_id == team_id))
         if total:
             counts[singular if total == 1 else plural] = total
     return counts

--- a/observal-server/api/routes/teams.py
+++ b/observal-server/api/routes/teams.py
@@ -274,7 +274,11 @@ async def delete_team(
         )
 
     await db.delete(team)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Teamspace still owns registry items") from exc
 
 
 @router.get("/{team_id}/members", response_model=list[TeamMemberResponse])

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -86,8 +86,12 @@ class Agent(Base):
     namespace: Mapped[str] = mapped_column(String(32), nullable=False)
     slug: Mapped[str] = mapped_column(String(64), nullable=False)
     owner: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
+    )
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
     )
     co_authors: Mapped[list] = mapped_column(JSON, default=list)
     latest_version_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -114,6 +118,7 @@ class Agent(Base):
             postgresql_where=deleted_at.is_(None),
             sqlite_where=deleted_at.is_(None),
         ),
+        Index("ix_agents_team_id", "team_id"),
     )
 
     versions: Mapped[list["AgentVersion"]] = relationship(
@@ -129,6 +134,10 @@ class Agent(Base):
     @property
     def qualified_name(self) -> str:
         return f"{self.namespace}/{self.slug}"
+
+    @property
+    def visibility(self) -> str:
+        return "team" if self.is_private else "public"
 
     # ------------------------------------------------------------------
     # Deprecated compatibility properties - delegate to latest_version.

--- a/observal-server/models/agent.py
+++ b/observal-server/models/agent.py
@@ -91,7 +91,7 @@ class Agent(Base):
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="RESTRICT"), nullable=True
     )
     co_authors: Mapped[list] = mapped_column(JSON, default=list)
     latest_version_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/observal-server/models/component_source.py
+++ b/observal-server/models/component_source.py
@@ -4,7 +4,7 @@
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Interval, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Interval, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -13,13 +13,19 @@ from models.base import Base
 
 class ComponentSource(Base):
     __tablename__ = "component_sources"
-    __table_args__ = (UniqueConstraint("url", "component_type", name="uq_component_sources_url_type"),)
+    __table_args__ = (
+        UniqueConstraint("url", "component_type", name="uq_component_sources_url_type"),
+        Index("ix_component_sources_team_id", "team_id"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     url: Mapped[str] = mapped_column(Text, nullable=False)
     provider: Mapped[str] = mapped_column(String(50), nullable=False)  # github, gitlab, bitbucket
     component_type: Mapped[str] = mapped_column(String(50), nullable=False)  # mcp, skill, hook, prompt, sandbox
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+    )
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
@@ -33,3 +39,7 @@ class ComponentSource(Base):
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
     )
+
+    @property
+    def visibility(self) -> str:
+        return "public" if self.is_public else "team"

--- a/observal-server/models/component_source.py
+++ b/observal-server/models/component_source.py
@@ -24,7 +24,7 @@ class ComponentSource(Base):
     component_type: Mapped[str] = mapped_column(String(50), nullable=False)  # mcp, skill, hook, prompt, sandbox
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="RESTRICT"), nullable=True
     )
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True

--- a/observal-server/models/hook.py
+++ b/observal-server/models/hook.py
@@ -21,6 +21,7 @@ class HookListing(Base):
         UniqueConstraint("namespace", "slug", name="uq_hook_listings_namespace_slug"),
         Index("ix_hook_listings_namespace", "namespace"),
         Index("ix_hook_listings_submitted_by", "submitted_by"),
+        Index("ix_hook_listings_team_id", "team_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -31,6 +32,9 @@ class HookListing(Base):
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
+    )
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
@@ -57,12 +61,16 @@ class HookListing(Base):
         foreign_keys="HookVersion.listing_id",
     )
     latest_version: Mapped[HookVersion | None] = relationship(
-        foreign_keys=[latest_version_id], lazy="selectin", uselist=False
+        foreign_keys=[latest_version_id], lazy="selectin", uselist=False, post_update=True
     )
 
     @property
     def qualified_name(self) -> str:
         return f"{self.namespace}/{self.slug}"
+
+    @property
+    def visibility(self) -> str:
+        return "team" if self.is_private else "public"
 
     # ------------------------------------------------------------------
     # Deprecated compatibility properties - delegate to latest_version.

--- a/observal-server/models/hook.py
+++ b/observal-server/models/hook.py
@@ -34,7 +34,7 @@ class HookListing(Base):
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="RESTRICT"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -31,6 +31,7 @@ class McpListing(Base):
         UniqueConstraint("namespace", "slug", name="uq_mcp_listings_namespace_slug"),
         Index("ix_mcp_listings_namespace", "namespace"),
         Index("ix_mcp_listings_submitted_by", "submitted_by"),
+        Index("ix_mcp_listings_team_id", "team_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -42,6 +43,9 @@ class McpListing(Base):
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
+    )
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
@@ -72,12 +76,16 @@ class McpListing(Base):
         foreign_keys="McpVersion.listing_id",
     )
     latest_version: Mapped[McpVersion | None] = relationship(
-        foreign_keys=[latest_version_id], lazy="selectin", uselist=False
+        foreign_keys=[latest_version_id], lazy="selectin", uselist=False, post_update=True
     )
 
     @property
     def qualified_name(self) -> str:
         return f"{self.namespace}/{self.slug}"
+
+    @property
+    def visibility(self) -> str:
+        return "team" if self.is_private else "public"
 
     # ------------------------------------------------------------------
     # Deprecated compatibility properties - delegate to latest_version.

--- a/observal-server/models/mcp.py
+++ b/observal-server/models/mcp.py
@@ -45,7 +45,7 @@ class McpListing(Base):
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="RESTRICT"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True

--- a/observal-server/models/prompt.py
+++ b/observal-server/models/prompt.py
@@ -34,7 +34,7 @@ class PromptListing(Base):
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="RESTRICT"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True

--- a/observal-server/models/prompt.py
+++ b/observal-server/models/prompt.py
@@ -21,6 +21,7 @@ class PromptListing(Base):
         UniqueConstraint("namespace", "slug", name="uq_prompt_listings_namespace_slug"),
         Index("ix_prompt_listings_namespace", "namespace"),
         Index("ix_prompt_listings_submitted_by", "submitted_by"),
+        Index("ix_prompt_listings_team_id", "team_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -31,6 +32,9 @@ class PromptListing(Base):
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
+    )
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
@@ -55,12 +59,16 @@ class PromptListing(Base):
         foreign_keys="PromptVersion.listing_id",
     )
     latest_version: Mapped[PromptVersion | None] = relationship(
-        foreign_keys=[latest_version_id], lazy="selectin", uselist=False
+        foreign_keys=[latest_version_id], lazy="selectin", uselist=False, post_update=True
     )
 
     @property
     def qualified_name(self) -> str:
         return f"{self.namespace}/{self.slug}"
+
+    @property
+    def visibility(self) -> str:
+        return "team" if self.is_private else "public"
 
     # ------------------------------------------------------------------
     # Deprecated compatibility properties - delegate to latest_version.

--- a/observal-server/models/sandbox.py
+++ b/observal-server/models/sandbox.py
@@ -21,6 +21,7 @@ class SandboxListing(Base):
         UniqueConstraint("namespace", "slug", name="uq_sandbox_listings_namespace_slug"),
         Index("ix_sandbox_listings_namespace", "namespace"),
         Index("ix_sandbox_listings_submitted_by", "submitted_by"),
+        Index("ix_sandbox_listings_team_id", "team_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -31,6 +32,9 @@ class SandboxListing(Base):
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
+    )
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
@@ -55,12 +59,16 @@ class SandboxListing(Base):
         foreign_keys="SandboxVersion.listing_id",
     )
     latest_version: Mapped[SandboxVersion | None] = relationship(
-        foreign_keys=[latest_version_id], lazy="selectin", uselist=False
+        foreign_keys=[latest_version_id], lazy="selectin", uselist=False, post_update=True
     )
 
     @property
     def qualified_name(self) -> str:
         return f"{self.namespace}/{self.slug}"
+
+    @property
+    def visibility(self) -> str:
+        return "team" if self.is_private else "public"
 
     # ------------------------------------------------------------------
     # Deprecated compatibility properties - delegate to latest_version.

--- a/observal-server/models/sandbox.py
+++ b/observal-server/models/sandbox.py
@@ -34,7 +34,7 @@ class SandboxListing(Base):
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="RESTRICT"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True

--- a/observal-server/models/skill.py
+++ b/observal-server/models/skill.py
@@ -34,7 +34,7 @@ class SkillListing(Base):
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
     )
     team_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="RESTRICT"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True

--- a/observal-server/models/skill.py
+++ b/observal-server/models/skill.py
@@ -21,6 +21,7 @@ class SkillListing(Base):
         UniqueConstraint("namespace", "slug", name="uq_skill_listings_namespace_slug"),
         Index("ix_skill_listings_namespace", "namespace"),
         Index("ix_skill_listings_submitted_by", "submitted_by"),
+        Index("ix_skill_listings_team_id", "team_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -31,6 +32,9 @@ class SkillListing(Base):
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     owner_org_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=True
+    )
+    team_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("teams.id", ondelete="SET NULL"), nullable=True
     )
     bundle_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("component_bundles.id"), nullable=True
@@ -57,12 +61,16 @@ class SkillListing(Base):
         foreign_keys="SkillVersion.listing_id",
     )
     latest_version: Mapped[SkillVersion | None] = relationship(
-        foreign_keys=[latest_version_id], lazy="selectin", uselist=False
+        foreign_keys=[latest_version_id], lazy="selectin", uselist=False, post_update=True
     )
 
     @property
     def qualified_name(self) -> str:
         return f"{self.namespace}/{self.slug}"
+
+    @property
+    def visibility(self) -> str:
+        return "team" if self.is_private else "public"
 
     # ------------------------------------------------------------------
     # Deprecated compatibility properties - delegate to latest_version.

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.10.7"
+version = "1.11.0"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.11.0"
+version = "1.10.7"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/observal-server/schemas/agent.py
+++ b/observal-server/schemas/agent.py
@@ -15,7 +15,7 @@ from typing import Literal
 from pydantic import BaseModel, field_validator
 
 from models.agent import AgentStatus
-from schemas.constants import AGENT_NAME_REGEX, make_name_validator
+from schemas.constants import AGENT_NAME_REGEX, Visibility, make_name_validator
 from services.versioning import validate_semver
 
 VALID_COMPONENT_TYPES = {"mcp", "skill", "hook", "prompt", "sandbox"}
@@ -46,6 +46,8 @@ class AgentCreateRequest(BaseModel):
     description: str = ""
     category: str | None = None
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     prompt: str = ""
     model_name: str
     model_config_json: dict = {}
@@ -81,6 +83,8 @@ class AgentUpdateRequest(BaseModel):
     description: str | None = None
     category: str | None = None
     owner: str | None = None
+    team_id: uuid.UUID | None = None
+    visibility: Visibility | None = None
     prompt: str | None = None
     model_name: str | None = None
     model_config_json: dict | None = None
@@ -141,6 +145,9 @@ class AgentResponse(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     prompt: str
     model_name: str
     model_config_json: dict
@@ -175,6 +182,9 @@ class AgentSummary(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     model_name: str
     supported_harnesses: list[str]
     required_capabilities: list[str] = []
@@ -197,6 +207,8 @@ class AgentSummary(BaseModel):
 
 class AgentValidateRequest(BaseModel):
     components: list[ComponentRef] = []
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
 
 
 class ValidationIssue(BaseModel):

--- a/observal-server/schemas/component_source.py
+++ b/observal-server/schemas/component_source.py
@@ -6,11 +6,14 @@ from datetime import datetime, timedelta
 
 from pydantic import BaseModel, Field
 
+from schemas.constants import Visibility
+
 
 class ComponentSourceCreate(BaseModel):
     url: str = Field(..., min_length=10, pattern=r"^https://")
     component_type: str = Field(..., pattern="^(mcp|skill|hook|prompt|sandbox)$")
-    is_public: bool = True
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
 
 
 class ComponentSourceResponse(BaseModel):
@@ -18,8 +21,8 @@ class ComponentSourceResponse(BaseModel):
     url: str
     provider: str
     component_type: str
-    is_public: bool
-    owner_org_id: uuid.UUID | None
+    team_id: uuid.UUID | None
+    visibility: Visibility
     auto_sync_interval: timedelta | None
     last_synced_at: datetime | None
     sync_status: str | None

--- a/observal-server/schemas/constants.py
+++ b/observal-server/schemas/constants.py
@@ -17,10 +17,13 @@ harness-specific data (features, paths, scopes) is defined in
 from __future__ import annotations
 
 import re
+from typing import Literal
 
 from observal_shared.harness_registry import get_harness_capability_matrix, get_valid_harnesses
 
 # ── Name validation ───────────────────────────────────────────
+
+Visibility = Literal["public", "team"]
 
 AGENT_NAME_REGEX = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 

--- a/observal-server/schemas/hook.py
+++ b/observal-server/schemas/hook.py
@@ -14,6 +14,7 @@ from schemas.constants import (
     VALID_HOOK_EXECUTION_MODES,
     VALID_HOOK_HANDLER_TYPES,
     VALID_HOOK_SCOPES,
+    Visibility,
     make_harness_list_validator,
     make_option_validator,
 )
@@ -24,6 +25,8 @@ class HookSubmitRequest(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     event: str
     execution_mode: str = "async"
     priority: int = 100
@@ -58,6 +61,8 @@ class HookDraftRequest(BaseModel):
     version: str = "0.1.0"
     description: str = ""
     owner: str = ""
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     event: str = "PreToolUse"
     execution_mode: str = "async"
     priority: int = 100
@@ -81,6 +86,8 @@ class HookUpdateRequest(BaseModel):
     version: str | None = None
     description: str | None = None
     owner: str | None = None
+    team_id: uuid.UUID | None = None
+    visibility: Visibility | None = None
     event: str | None = None
     execution_mode: str | None = None
     priority: int | None = None
@@ -106,6 +113,9 @@ class HookListingResponse(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     event: str
     execution_mode: str
     priority: int
@@ -142,6 +152,9 @@ class HookListingSummary(BaseModel):
     event: str
     scope: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     status: ListingStatus
     rejection_reason: str | None = None
     updated_at: datetime | None = None

--- a/observal-server/schemas/mcp.py
+++ b/observal-server/schemas/mcp.py
@@ -12,6 +12,7 @@ from models.mcp import ListingStatus
 from schemas.constants import (
     VALID_MCP_CATEGORIES,
     VALID_MCP_FRAMEWORKS,
+    Visibility,
     make_harness_list_validator,
     make_option_validator,
 )
@@ -53,6 +54,8 @@ class McpSubmitRequest(BaseModel):
     description: str = Field(min_length=1)
     category: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     framework: str | None = None
     docker_image: str | None = None
     command: str | None = None
@@ -92,6 +95,8 @@ class McpDraftRequest(BaseModel):
     description: str = ""
     category: str = "other"
     owner: str = ""
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     git_url: str | None = None
     framework: str | None = None
     docker_image: str | None = None
@@ -116,6 +121,8 @@ class McpUpdateRequest(BaseModel):
     description: str | None = None
     category: str | None = None
     owner: str | None = None
+    team_id: uuid.UUID | None = None
+    visibility: Visibility | None = None
     git_url: str | None = None
     framework: str | None = None
     docker_image: str | None = None
@@ -156,6 +163,9 @@ class McpListingResponse(BaseModel):
     description: str
     category: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     supported_harnesses: list[str]
     environment_variables: list[McpEnvVar] = []
     setup_instructions: str | None
@@ -198,6 +208,9 @@ class McpListingSummary(BaseModel):
     description: str
     category: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     supported_harnesses: list[str]
     status: ListingStatus
     rejection_reason: str | None = None

--- a/observal-server/schemas/prompt.py
+++ b/observal-server/schemas/prompt.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pydantic import BaseModel, field_validator
 
 from models.mcp import ListingStatus
-from schemas.constants import VALID_PROMPT_CATEGORIES, make_harness_list_validator, make_option_validator
+from schemas.constants import VALID_PROMPT_CATEGORIES, Visibility, make_harness_list_validator, make_option_validator
 
 
 class PromptSubmitRequest(BaseModel):
@@ -16,6 +16,8 @@ class PromptSubmitRequest(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     category: str
     template: str
     variables: list[dict] = []
@@ -32,6 +34,8 @@ class PromptDraftRequest(BaseModel):
     version: str = "0.1.0"
     description: str = ""
     owner: str = ""
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     category: str = "general"
     template: str = ""
     variables: list[dict] = []
@@ -47,6 +51,8 @@ class PromptUpdateRequest(BaseModel):
     version: str | None = None
     description: str | None = None
     owner: str | None = None
+    team_id: uuid.UUID | None = None
+    visibility: Visibility | None = None
     category: str | None = None
     template: str | None = None
     variables: list[dict] | None = None
@@ -64,6 +70,9 @@ class PromptListingResponse(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     category: str
     template: str
     variables: list[dict]
@@ -95,6 +104,9 @@ class PromptListingSummary(BaseModel):
     description: str
     category: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     status: ListingStatus
     rejection_reason: str | None = None
     updated_at: datetime | None = None

--- a/observal-server/schemas/sandbox.py
+++ b/observal-server/schemas/sandbox.py
@@ -12,6 +12,7 @@ from models.mcp import ListingStatus
 from schemas.constants import (
     VALID_SANDBOX_NETWORK_POLICIES,
     VALID_SANDBOX_RUNTIME_TYPES,
+    Visibility,
     make_harness_list_validator,
     make_option_validator,
 )
@@ -41,6 +42,8 @@ class SandboxSubmitRequest(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     runtime_type: str
     image: str
     resource_limits: dict = {}
@@ -72,6 +75,8 @@ class SandboxDraftRequest(BaseModel):
     version: str = "0.1.0"
     description: str = ""
     owner: str = ""
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     runtime_type: str = "docker"
     image: str = ""
     resource_limits: dict = {}
@@ -97,6 +102,8 @@ class SandboxUpdateRequest(BaseModel):
     version: str | None = None
     description: str | None = None
     owner: str | None = None
+    team_id: uuid.UUID | None = None
+    visibility: Visibility | None = None
     runtime_type: str | None = None
     image: str | None = None
     resource_limits: dict | None = None
@@ -125,6 +132,9 @@ class SandboxListingResponse(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     runtime_type: str
     image: str
     resource_limits: dict
@@ -176,6 +186,9 @@ class SandboxListingSummary(BaseModel):
     source_ref: str | None = None
     sandbox_path: str | None = None
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     supported_harnesses: list[str]
     status: ListingStatus
     rejection_reason: str | None = None

--- a/observal-server/schemas/skill.py
+++ b/observal-server/schemas/skill.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pydantic import BaseModel, field_validator
 
 from models.mcp import ListingStatus
-from schemas.constants import VALID_SKILL_TASK_TYPES, make_harness_list_validator, make_option_validator
+from schemas.constants import VALID_SKILL_TASK_TYPES, Visibility, make_harness_list_validator, make_option_validator
 from schemas.skill_commands import normalize_slash_command
 
 
@@ -19,6 +19,8 @@ class SkillSubmitRequest(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     skill_path: str = "/"
     git_url: str | None = None
     git_ref: str | None = None
@@ -45,6 +47,8 @@ class SkillDraftRequest(BaseModel):
     version: str = "0.1.0"
     description: str = ""
     owner: str = ""
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
     skill_path: str = "/"
     git_url: str | None = None
     git_ref: str | None = None
@@ -70,6 +74,8 @@ class SkillUpdateRequest(BaseModel):
     version: str | None = None
     description: str | None = None
     owner: str | None = None
+    team_id: uuid.UUID | None = None
+    visibility: Visibility | None = None
     skill_path: str | None = None
     git_url: str | None = None
     git_ref: str | None = None
@@ -97,6 +103,9 @@ class SkillListingResponse(BaseModel):
     version: str
     description: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     task_type: str
     target_agents: list[str]
     supported_harnesses: list[str]
@@ -135,6 +144,9 @@ class SkillListingSummary(BaseModel):
     description: str
     task_type: str
     owner: str
+    team_id: uuid.UUID | None = None
+    visibility: Visibility = "public"
+    is_private: bool = False
     target_agents: list[str]
     status: ListingStatus
     rejection_reason: str | None = None

--- a/observal-server/services/agent_builder.py
+++ b/observal-server/services/agent_builder.py
@@ -24,11 +24,15 @@ from services.agent_resolver import ResolvedAgent, ResolvedComponent
 
 def _resolved_to_manifest_component(comp: ResolvedComponent) -> ManifestComponent:
     """Convert a ResolvedComponent to a ManifestComponent."""
+    # git_url is optional on a resolved component: registry-direct skills and
+    # command or url based MCP servers have no repository. The manifest field is a
+    # plain string whose empty value means "no repository", so normalize here rather
+    # than letting None reach validation.
     kwargs: dict = {
         "name": comp.name,
         "version": comp.version,
-        "git_url": comp.git_url,
-        "description": comp.description,
+        "git_url": comp.git_url or "",
+        "description": comp.description or "",
         "order": comp.order_index,
     }
     if comp.git_ref:

--- a/observal-server/services/agent_resolver.py
+++ b/observal-server/services/agent_resolver.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, computed_field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.deps import apply_publish_scope, apply_visibility_filter
 from models.agent import Agent
 from models.hook import HookListing
 from models.mcp import ListingStatus, McpListing
@@ -145,6 +146,7 @@ async def resolve_agent(
     db: AsyncSession,
     *,
     require_approved: bool = True,
+    current_user=None,
 ) -> ResolvedAgent:
     """Resolve all components for an agent.
 
@@ -180,6 +182,9 @@ async def resolve_agent(
         model = _LISTING_MODELS[comp_type]
         ids = [c.component_id for c in comps]
         stmt = select(model).where(model.id.in_(ids))
+        if current_user is not None:
+            stmt = apply_visibility_filter(stmt, model, current_user)
+        stmt = apply_publish_scope(stmt, model, agent.team_id if agent.is_private else None)
         result = await db.execute(stmt)
         for listing in result.scalars().all():
             found[listing.id] = listing
@@ -265,6 +270,9 @@ async def validate_component_ids(
     db: AsyncSession,
     *,
     require_approved: bool = True,
+    current_user=None,
+    target_team_id: uuid.UUID | None = None,
+    enforce_target: bool = False,
 ) -> list[ResolutionError]:
     """Validate a list of component references before attaching them to an agent.
 
@@ -298,6 +306,10 @@ async def validate_component_ids(
             continue
 
         stmt = select(model).where(model.id == cid)
+        if current_user is not None:
+            stmt = apply_visibility_filter(stmt, model, current_user)
+        if enforce_target:
+            stmt = apply_publish_scope(stmt, model, target_team_id)
         listing = (await db.execute(stmt)).scalar_one_or_none()
 
         if listing is None:

--- a/observal-server/services/insights/self_learn.py
+++ b/observal-server/services/insights/self_learn.py
@@ -825,7 +825,6 @@ async def _create_skill_listing(
         slug=slugify(validated.name),
         owner=validated.owner,
         submitted_by=submitter_id,
-        owner_org_id=agent.owner_org_id,
     )
     db.add(listing)
     await db.flush()
@@ -950,7 +949,6 @@ async def _create_hook_listing(
         slug=slugify(validated.name),
         owner=validated.owner,
         submitted_by=submitter_id,
-        owner_org_id=agent.owner_org_id,
     )
     db.add(listing)
     await db.flush()
@@ -1132,7 +1130,6 @@ async def _create_prompt_listing(
         slug=slugify(validated.name),
         owner=validated.owner,
         submitted_by=submitter_id,
-        owner_org_id=agent.owner_org_id,
     )
     db.add(listing)
     await db.flush()

--- a/observal-server/services/ownership.py
+++ b/observal-server/services/ownership.py
@@ -13,7 +13,6 @@ def transfer_entity_owner(entity, entity_type: str, current_user, target_user):
 
     entity.owner = new_owner
     entity.namespace = target_user.username
-    entity.owner_org_id = target_user.org_id
     if entity_type == "agents":
         entity.created_by = target_user.id
     else:

--- a/observal-server/services/teamspace.py
+++ b/observal-server/services/teamspace.py
@@ -59,6 +59,78 @@ async def team_membership(db: AsyncSession, team_id: uuid.UUID, user_id: uuid.UU
     ).scalar_one_or_none()
 
 
+# The team roles that clear review for their own teamspace. A plain member
+# publishes into the queue; it is these two that empty it.
+REVIEWING_TEAM_ROLES = (TeamRole.owner, TeamRole.reviewer)
+
+
+@dataclass(frozen=True)
+class ReviewScope:
+    """What one caller is allowed to review.
+
+    ``is_admin`` reviews everything, team-private items included, because an admin
+    already administers the whole deployment. ``is_global_reviewer`` without
+    ``is_admin`` is the plain global reviewer role: public items only. ``team_ids``
+    are the teamspaces where the caller is an owner or a reviewer, and they carry
+    the right to review that teamspace's own private items and nothing else.
+    """
+
+    is_admin: bool
+    is_global_reviewer: bool
+    team_ids: frozenset[uuid.UUID]
+
+    @property
+    def is_empty(self) -> bool:
+        """True when the caller may not review anything at all."""
+        return not self.is_global_reviewer and not self.team_ids
+
+
+async def review_scope(db: AsyncSession, user: User) -> ReviewScope:
+    """Resolve the caller's review capability once, for both listing and acting.
+
+    The review queue and the approve and reject actions must agree on what a
+    caller may touch, so both read this single answer instead of re-deriving it.
+    """
+    if is_admin(user):
+        # An admin reviews every item regardless of teamspace, so their own
+        # memberships would not widen anything and the query is skipped.
+        return ReviewScope(is_admin=True, is_global_reviewer=True, team_ids=frozenset())
+
+    rows = await db.execute(
+        select(TeamMembership.team_id).where(
+            TeamMembership.user_id == user.id,
+            TeamMembership.role.in_(REVIEWING_TEAM_ROLES),
+        )
+    )
+    return ReviewScope(
+        is_admin=False,
+        is_global_reviewer=is_global_reviewer(user),
+        team_ids=frozenset(row[0] for row in rows),
+    )
+
+
+def can_review(entity, scope: ReviewScope) -> bool:
+    """Whether this caller may review one listing, agent version, or agent.
+
+    Decided from the item's own visibility, never from what the caller asked for.
+    A team-private item belongs to its teamspace: only that teamspace's owners and
+    reviewers, plus admins, may act on it, which is what keeps private titles away
+    from a global reviewer who is not in the team. A public item is the global
+    catalog: only a global reviewer and above may act on it, so a team owner cannot
+    walk a listing out of their own namespace into everyone's registry. That is the
+    same escalation team_role_self_publishes closes at publish time.
+
+    A private item with no teamspace is a personal listing. Nobody holds a team
+    role over it, so it stays admin-only.
+    """
+    if scope.is_admin:
+        return True
+    if getattr(entity, "is_private", False):
+        team_id = getattr(entity, "team_id", None)
+        return team_id is not None and team_id in scope.team_ids
+    return scope.is_global_reviewer
+
+
 async def user_team_ids(db: AsyncSession, user_id: uuid.UUID) -> list[uuid.UUID]:
     rows = await db.execute(select(TeamMembership.team_id).where(TeamMembership.user_id == user_id))
     return list(rows.scalars().all())
@@ -117,7 +189,11 @@ async def resolve_publish_target(
     if not team:
         raise HTTPException(status_code=404, detail="Teamspace not found")
     membership = await team_membership(db, team.id, user.id)
-    if not membership and not is_global_reviewer(user):
+    # Publishing into a teamspace you do not belong to is an admin capability, not a
+    # reviewer one. A global reviewer cannot read another team's private listings, so
+    # letting one publish a team-private item here would create a listing its author
+    # can no longer see. Admins keep it because they can still read the result.
+    if not membership and not is_admin(user):
         raise HTTPException(status_code=403, detail="You are not a member of this teamspace")
 
     auto_approve = is_global_reviewer(user) or team_role_self_publishes(membership, target_visibility)

--- a/observal-server/services/teamspace.py
+++ b/observal-server/services/teamspace.py
@@ -221,7 +221,7 @@ async def publish_auto_approves_for_entity(entity, user: User, db: AsyncSession)
     return is_global_reviewer(user) or team_role_self_publishes(membership, visibility)
 
 
-def review_publication_to_public(entity, user: User, *, was_private: bool) -> bool:
+async def review_publication_to_public(entity, user: User, db: AsyncSession, *, was_private: bool) -> bool:
     """Send a listing back to the review queue when it becomes publicly visible.
 
     Turning a team-private listing public publishes it into the global registry, so
@@ -250,10 +250,37 @@ def review_publication_to_public(entity, user: User, *, was_private: bool) -> bo
         # yet, so becoming public changes nothing about its review state.
         return False
 
-    entity.status = _pending_status(entity)
+    # EVERY approved version returns to the queue, not just the latest. Older
+    # versions were approved by a team role for a team-only audience, and installs
+    # can pin any approved version, so leaving them approved would publish content
+    # no global reviewer ever saw.
+    version_model, listing_column = _version_model_for(entity)
+    approved = _approved_status(entity)
+    pending = _pending_status(entity)
+    rows = (
+        await db.execute(select(version_model).where(listing_column == entity.id, version_model.status == approved))
+    ).scalars()
+    for row in rows:
+        row.status = pending
+        row.reviewed_by = None
+        row.reviewed_at = None
+
+    # The listing's own status mirrors its latest version, so set it explicitly in
+    # case the latest version was not among the rows above.
+    entity.status = pending
     version.reviewed_by = None
     version.reviewed_at = None
     return True
+
+
+def _version_model_for(entity):
+    """Return (version model, the column linking a version back to its listing)."""
+    from models.agent import Agent, AgentVersion
+
+    if isinstance(entity, Agent):
+        return AgentVersion, AgentVersion.agent_id
+    version_model = type(entity).__mapper__.relationships["latest_version"].entity.class_
+    return version_model, version_model.listing_id
 
 
 def _approved_status(entity):

--- a/observal-server/services/teamspace.py
+++ b/observal-server/services/teamspace.py
@@ -6,13 +6,15 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from fastapi import HTTPException
 from sqlalchemy import select
 
 from models.team import Team, TeamMembership, TeamRole
 from models.user import User, UserRole
-from services.registry_namespace import validate_namespace
+from services.registry_namespace import namespace_for_user, slugify, validate_namespace
 
 if TYPE_CHECKING:
     import uuid
@@ -40,6 +42,10 @@ def is_admin(user: User) -> bool:
     return user.role in (UserRole.admin, UserRole.super_admin)
 
 
+def is_global_reviewer(user: User) -> bool:
+    return user.role in (UserRole.reviewer, UserRole.admin, UserRole.super_admin)
+
+
 def is_team_role(role: TeamRole | str, expected: TeamRole) -> bool:
     value = role.value if isinstance(role, TeamRole) else str(role)
     return value == expected.value
@@ -56,6 +62,136 @@ async def team_membership(db: AsyncSession, team_id: uuid.UUID, user_id: uuid.UU
 async def user_team_ids(db: AsyncSession, user_id: uuid.UUID) -> list[uuid.UUID]:
     rows = await db.execute(select(TeamMembership.team_id).where(TeamMembership.user_id == user_id))
     return list(rows.scalars().all())
+
+
+def team_role_self_publishes(membership: TeamMembership | None, visibility: str) -> bool:
+    """Whether a team role alone clears review, for a listing of this visibility.
+
+    Team roles are self-service: a team owner can promote any member to owner, so
+    letting a team role auto-approve a PUBLIC listing would be a privilege escalation
+    path straight into the global catalog. Public listings published from a team
+    namespace therefore still go through the global review queue. Team-visibility
+    publishing stays self-service because the result is only visible to that team.
+    """
+    if visibility != "team":
+        return False
+    return membership is not None and membership.role in (TeamRole.owner, TeamRole.reviewer)
+
+
+@dataclass(frozen=True)
+class PublishTarget:
+    namespace: str
+    slug: str
+    team_id: uuid.UUID | None
+    visibility: str
+    owner: str
+    auto_approve: bool
+
+
+async def resolve_publish_target(
+    db: AsyncSession,
+    user: User,
+    name: str,
+    *,
+    team_id: uuid.UUID | None = None,
+    visibility: str | None = None,
+) -> PublishTarget:
+    """Resolve and authorize the namespace and visibility for a new listing."""
+    target_visibility = (visibility or "public").strip().lower()
+    if target_visibility not in {"public", "team"}:
+        raise HTTPException(status_code=422, detail="visibility must be 'public' or 'team'")
+
+    if team_id is None:
+        if target_visibility == "team":
+            raise HTTPException(status_code=422, detail="Team visibility requires a teamspace")
+        return PublishTarget(
+            namespace=namespace_for_user(user),
+            slug=slugify(name),
+            team_id=None,
+            visibility="public",
+            owner=user.username or user.email,
+            auto_approve=False,
+        )
+
+    team = await db.get(Team, team_id)
+    if not team:
+        raise HTTPException(status_code=404, detail="Teamspace not found")
+    membership = await team_membership(db, team.id, user.id)
+    if not membership and not is_global_reviewer(user):
+        raise HTTPException(status_code=403, detail="You are not a member of this teamspace")
+
+    auto_approve = is_global_reviewer(user) or team_role_self_publishes(membership, target_visibility)
+    return PublishTarget(
+        namespace=team.handle,
+        slug=slugify(name),
+        team_id=team.id,
+        visibility=target_visibility,
+        owner=team.handle,
+        auto_approve=auto_approve,
+    )
+
+
+async def publish_auto_approves_for_entity(entity, user: User, db: AsyncSession) -> bool:
+    """Return whether this actor can publish an already saved team item without review.
+
+    The entity carries its own visibility, so a public listing sitting in a team
+    namespace is held for global review even when the submitter is a team owner or
+    team reviewer. See team_role_self_publishes for why.
+    """
+    if getattr(entity, "team_id", None) is None:
+        return False
+    membership = await team_membership(db, entity.team_id, user.id)
+    visibility = "team" if entity.is_private else "public"
+    return is_global_reviewer(user) or team_role_self_publishes(membership, visibility)
+
+
+def review_publication_to_public(entity, user: User, *, was_private: bool) -> bool:
+    """Send a listing back to the review queue when it becomes publicly visible.
+
+    Turning a team-private listing public publishes it into the global registry, so
+    it has to clear global review. Without this, the auto-approval rule in
+    team_role_self_publishes is trivially bypassed in two steps: publish as team
+    visibility, which a team owner or team reviewer approves for themselves because
+    only their own teamspace can see it, then flip the same approved row to public
+    and reach every user without a reviewer ever seeing it.
+
+    Only a global reviewer, admin, or super_admin keeps an approved status through
+    the transition, because they already hold the authority the queue represents.
+
+    Restricting a public listing back to team visibility is not a publication and
+    needs no review, so this returns False for that direction.
+
+    Returns True when the entity was moved back to pending.
+    """
+    if not was_private or entity.is_private or is_global_reviewer(user):
+        return False
+
+    version = getattr(entity, "latest_version", None)
+    if version is None:
+        raise RuntimeError(f"{type(entity).__name__} has no latest_version; cannot re-enter review")
+    if version.status != _approved_status(entity):
+        # A draft, pending, or rejected listing has not been approved for anything
+        # yet, so becoming public changes nothing about its review state.
+        return False
+
+    entity.status = _pending_status(entity)
+    version.reviewed_by = None
+    version.reviewed_at = None
+    return True
+
+
+def _approved_status(entity):
+    from models.agent import Agent, AgentStatus
+    from models.mcp import ListingStatus
+
+    return AgentStatus.approved if isinstance(entity, Agent) else ListingStatus.approved
+
+
+def _pending_status(entity):
+    from models.agent import Agent, AgentStatus
+    from models.mcp import ListingStatus
+
+    return AgentStatus.pending if isinstance(entity, Agent) else ListingStatus.pending
 
 
 async def reserve_handle(

--- a/observal-server/tests/test_agent_pull.py
+++ b/observal-server/tests/test_agent_pull.py
@@ -223,8 +223,13 @@ def test_agent_to_response_populates_latest_version_string():
 
 
 @pytest.mark.asyncio
-async def test_install_agent_no_latest_version_returns_400():
-    """install_agent returns 400 when agent has no approved/published version."""
+async def test_install_agent_not_approved_returns_404():
+    """A non-approved agent is not installable, and must not be distinguishable.
+
+    The status gate runs before the no-version branch, so an agent without a
+    published version reports 404 rather than confirming it exists. Owning the
+    agent does not change that: install is gated on approval, not on permission.
+    """
     from fastapi import HTTPException
 
     from api.routes.agent.install import install_agent
@@ -232,7 +237,7 @@ async def test_install_agent_no_latest_version_returns_400():
 
     agent = _make_agent(with_approved_version=False)
     user = _make_user()
-    user.id = agent.created_by  # owner, so auth passes
+    user.id = agent.created_by
 
     req = AgentInstallRequest(harness="claude-code")
     request = MagicMock()
@@ -247,7 +252,53 @@ async def test_install_agent_no_latest_version_returns_400():
     with (
         patch("api.routes.agent.install._load_agent", new=AsyncMock(return_value=agent)),
         patch("api.routes.agent.install.get_effective_agent_permission", return_value="owner"),
-        patch("api.routes.agent.install.audit", new=AsyncMock()),
+        patch("api.routes.agent.install._ds.get_sync_bool", return_value=False),
+        patch("services.download_tracker.record_agent_download", new=AsyncMock()),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await install_agent(
+            agent_id=str(agent.id),
+            req=req,
+            request=request,
+            db=db,
+            current_user=user,
+        )
+
+    assert exc.value.status_code == 404
+    assert "not approved" in exc.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_install_agent_no_version_returns_400_for_draft_install():
+    """With security.allow_draft_install on, the creator reaches the no-version branch.
+
+    That setting is the only way past the approval gate, so it is the only way the
+    400 is reachable. The creator already knows the agent exists, so naming the
+    real problem leaks nothing.
+    """
+    from fastapi import HTTPException
+
+    from api.routes.agent.install import install_agent
+    from schemas.agent import AgentInstallRequest
+
+    agent = _make_agent(with_approved_version=False)
+    user = _make_user()
+    user.id = agent.created_by
+
+    req = AgentInstallRequest(harness="claude-code")
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.scheme = "http"
+    request.url.hostname = "localhost"
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=MagicMock(all=lambda: []))))
+    db.commit = AsyncMock()
+
+    with (
+        patch("api.routes.agent.install._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.install.get_effective_agent_permission", return_value="owner"),
+        patch("api.routes.agent.install._ds.get_sync_bool", return_value=True),
         patch("services.download_tracker.record_agent_download", new=AsyncMock()),
         pytest.raises(HTTPException) as exc,
     ):
@@ -260,7 +311,7 @@ async def test_install_agent_no_latest_version_returns_400():
         )
 
     assert exc.value.status_code == 400
-    assert "no" in exc.value.detail.lower() or "version" in exc.value.detail.lower()
+    assert "version" in exc.value.detail.lower()
 
 
 @pytest.mark.asyncio
@@ -292,7 +343,6 @@ async def test_install_agent_with_approved_version_succeeds():
         patch("api.routes.agent.install.get_effective_agent_permission", return_value="owner"),
         patch("api.routes.agent.install.generate_agent_config", return_value=fake_config),
         patch("api.routes.agent.install.emit_registry_event"),
-        patch("api.routes.agent.install.audit", new=AsyncMock()),
         patch("api.routes.config.derive_endpoints", return_value={"api": "http://localhost:8000", "otlp_http": ""}),
         patch("services.download_tracker.record_agent_download", new=AsyncMock()),
     ):

--- a/observal-server/tests/test_agent_versions_api.py
+++ b/observal-server/tests/test_agent_versions_api.py
@@ -755,9 +755,11 @@ async def test_diff_versions_returns_yaml_diff():
 
     db = AsyncMock()
     calls = [0]
+    statements = []
 
     async def _execute(stmt):
         calls[0] += 1
+        statements.append(str(stmt))
         mock = MagicMock()
         mock.scalar_one_or_none.return_value = ver1 if calls[0] == 1 else ver2
         return mock
@@ -779,6 +781,7 @@ async def test_diff_versions_returns_yaml_diff():
     assert isinstance(result["yaml_diff"], str)
     assert len(result["yaml_diff"]) > 0
     assert isinstance(result["component_changes"], list)
+    assert all("agent_versions.status" in statement for statement in statements)
 
 
 @pytest.mark.asyncio

--- a/observal-server/tests/test_component_versions_api.py
+++ b/observal-server/tests/test_component_versions_api.py
@@ -47,7 +47,13 @@ def _make_version(listing_id, ver=SEMVER_VALID, status=ListingStatus.pending, re
     return v
 
 
-def _make_listing(owner_id):
+# The version routes resolve through api.deps.resolve_visible_listing, which calls
+# the module-global resolve_listing inside api.deps. That is the only seam a patch
+# can intercept: api.routes.component_versions no longer binds resolve_listing.
+RESOLVE_SEAM = "api.deps.resolve_listing"
+
+
+def _make_listing(owner_id, *, is_private=False, team_id=None):
     listing = MagicMock()
     listing.id = uuid.uuid4()
     listing.name = "test-listing"
@@ -55,6 +61,11 @@ def _make_listing(owner_id):
     listing.latest_version_id = None
     listing.versions = []
     listing.latest_version = None
+    # Set explicitly: an unset MagicMock attribute is truthy, which would make
+    # every listing look team-private to check_listing_visibility_async.
+    listing.is_private = is_private
+    listing.team_id = team_id
+    listing.co_authors = []
     return listing
 
 
@@ -161,9 +172,7 @@ async def test_list_versions_empty():
     listing_id = str(uuid.uuid4())
     db = _db_with_versions([])
 
-    with patch(
-        "api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=_make_listing(uuid.uuid4()))
-    ):
+    with patch(RESOLVE_SEAM, new=AsyncMock(return_value=_make_listing(uuid.uuid4()))):
         result = await _list_versions(
             listing_id=listing_id,
             page=1,
@@ -193,7 +202,7 @@ async def test_list_versions_with_data():
     listing_id = str(listing.id)
     db = _db_with_versions([ver])
 
-    with patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)):
+    with patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)):
         result = await _list_versions(
             listing_id=listing_id,
             page=1,
@@ -226,7 +235,7 @@ async def test_get_version_found():
 
     db = _db_returning_one(ver)
 
-    with patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)):
+    with patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)):
         result = await _get_version(
             listing_id=str(listing.id),
             version=SEMVER_VALID,
@@ -255,7 +264,7 @@ async def test_get_version_not_found():
     db = _db_returning_one(None)
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         pytest.raises(HTTPException) as exc,
     ):
         await _get_version(
@@ -293,7 +302,7 @@ async def test_publish_version_bad_semver():
     req = VersionPublishRequest(version=SEMVER_INVALID, description="test", changelog=None, extra=None)
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         pytest.raises(HTTPException) as exc,
     ):
         await _publish_version(
@@ -326,7 +335,7 @@ async def test_publish_version_not_owner():
     req = VersionPublishRequest(version=SEMVER_VALID, description="test", changelog=None, extra=None)
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         pytest.raises(HTTPException) as exc,
     ):
         await _publish_version(
@@ -364,7 +373,7 @@ async def test_publish_version_duplicate_409():
     db = _db_returning_one(existing_ver)
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         pytest.raises(HTTPException) as exc,
     ):
         await _publish_version(
@@ -404,7 +413,7 @@ async def test_publish_version_happy_path():
     db.commit = AsyncMock()
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         patch("api.routes.component_versions.audit", new=AsyncMock()),
     ):
         result = await _publish_version(
@@ -450,7 +459,7 @@ async def test_review_version_approve_updates_latest():
     db.commit = AsyncMock()
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         patch("api.routes.component_versions.audit", new=AsyncMock()),
     ):
         result = await _review_version(
@@ -490,7 +499,7 @@ async def test_review_version_reject_stores_reason():
     db.commit = AsyncMock()
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         patch("api.routes.component_versions.audit", new=AsyncMock()),
     ):
         result = await _review_version(
@@ -531,7 +540,7 @@ async def test_review_version_non_pending_422():
     db.execute = AsyncMock(return_value=ver_result)
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         pytest.raises(HTTPException) as exc,
     ):
         await _review_version(
@@ -569,7 +578,7 @@ async def test_review_version_not_found_404():
     db.execute = AsyncMock(return_value=ver_result)
 
     with (
-        patch("api.routes.component_versions.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(RESOLVE_SEAM, new=AsyncMock(return_value=listing)),
         pytest.raises(HTTPException) as exc,
     ):
         await _review_version(

--- a/observal-server/tests/test_registry_namespace.py
+++ b/observal-server/tests/test_registry_namespace.py
@@ -363,7 +363,7 @@ async def test_transfer_moves_every_listing_type_to_target_namespace(entity_type
     assert entity.namespace == "bob"
     assert entity.slug == "tool"
     assert getattr(entity, owner_field) == target.id
-    assert entity.owner_org_id == target.org_id
+    assert entity.owner_org_id is None
     assert entity.co_authors == [str(other_coauthor)]
     assert response.qualified_name == "bob/tool"
     db.commit.assert_awaited_once()

--- a/observal-server/tests/test_teamspace.py
+++ b/observal-server/tests/test_teamspace.py
@@ -12,7 +12,15 @@ from fastapi import HTTPException
 
 from models.team import TeamRole
 from models.user import UserRole
-from services.teamspace import count_owners, is_admin, reserve_handle, slugify_handle, team_membership
+from services.teamspace import (
+    count_owners,
+    is_admin,
+    publish_auto_approves_for_entity,
+    reserve_handle,
+    resolve_publish_target,
+    slugify_handle,
+    team_membership,
+)
 
 
 class _Scalar:
@@ -94,6 +102,114 @@ def test_slugify_handle_targets_namespace_regex():
     assert slugify_handle("") == "team"
     # underscores are stripped (NAMESPACE_RE has no underscores)
     assert slugify_handle("my_team") == "my-team"
+
+
+# ── publish targets ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_publish_target_defaults_to_public_user_namespace():
+    user = _user(username="alice")
+    target = await resolve_publish_target(_FakeDB([]), user, "Internal Tool")
+    assert (target.namespace, target.slug, target.team_id, target.visibility) == (
+        "alice",
+        "internal-tool",
+        None,
+        "public",
+    )
+    assert target.auto_approve is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_publish_target_allows_team_member_and_private_visibility():
+    team_id = uuid.uuid4()
+    team = SimpleNamespace(id=team_id, handle="platform-tools")
+    member = SimpleNamespace(role=TeamRole.member)
+    db = _FakeDB([member])
+    db.get = AsyncMock(return_value=team)
+    target = await resolve_publish_target(db, _user(), "Internal Tool", team_id=team_id, visibility="team")
+    assert target.namespace == "platform-tools"
+    assert target.visibility == "team"
+    assert target.team_id == team_id
+    assert target.auto_approve is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_publish_target_rejects_non_member():
+    team_id = uuid.uuid4()
+    db = _FakeDB([None])
+    db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+    with pytest.raises(HTTPException) as exc:
+        await resolve_publish_target(db, _user(), "Internal Tool", team_id=team_id)
+    assert exc.value.status_code == 403
+
+
+# ── auto-approval matrix ────────────────────────────────────────────
+# Team roles are self-service, so they clear review for team-visibility listings
+# only. Publishing PUBLIC out of a team namespace always waits for global review.
+
+# (label, user role, team role or None, visibility, expected auto_approve)
+_AUTO_APPROVE_MATRIX = [
+    ("team-owner-public", UserRole.user, TeamRole.owner, "public", False),
+    ("team-owner-team", UserRole.user, TeamRole.owner, "team", True),
+    ("team-reviewer-public", UserRole.user, TeamRole.reviewer, "public", False),
+    ("team-reviewer-team", UserRole.user, TeamRole.reviewer, "team", True),
+    ("team-member-public", UserRole.user, TeamRole.member, "public", False),
+    ("team-member-team", UserRole.user, TeamRole.member, "team", False),
+    ("global-reviewer-public", UserRole.reviewer, None, "public", True),
+    ("global-reviewer-team", UserRole.reviewer, None, "team", True),
+    ("admin-public", UserRole.admin, None, "public", True),
+    ("admin-team", UserRole.admin, None, "team", True),
+    ("super-admin-public", UserRole.super_admin, None, "public", True),
+    ("super-admin-team", UserRole.super_admin, None, "team", True),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("user_role", "team_role", "visibility", "expected"),
+    [pytest.param(*row[1:], id=row[0]) for row in _AUTO_APPROVE_MATRIX],
+)
+async def test_resolve_publish_target_auto_approve_matrix(user_role, team_role, visibility, expected):
+    team_id = uuid.uuid4()
+    membership = SimpleNamespace(role=team_role) if team_role is not None else None
+    db = _FakeDB([membership])
+    db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+
+    target = await resolve_publish_target(db, _user(user_role), "Internal Tool", team_id=team_id, visibility=visibility)
+
+    assert target.visibility == visibility
+    assert target.auto_approve is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("user_role", "team_role", "visibility", "expected"),
+    [pytest.param(*row[1:], id=row[0]) for row in _AUTO_APPROVE_MATRIX],
+)
+async def test_publish_auto_approves_for_entity_matrix(user_role, team_role, visibility, expected):
+    membership = SimpleNamespace(role=team_role) if team_role is not None else None
+    entity = SimpleNamespace(team_id=uuid.uuid4(), is_private=visibility == "team")
+
+    got = await publish_auto_approves_for_entity(entity, _user(user_role), _FakeDB([membership]))
+
+    assert got is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("visibility", ["public", "team"])
+async def test_publish_auto_approves_for_entity_rejects_non_member(visibility):
+    entity = SimpleNamespace(team_id=uuid.uuid4(), is_private=visibility == "team")
+    assert await publish_auto_approves_for_entity(entity, _user(), _FakeDB([None])) is False
+
+
+@pytest.mark.asyncio
+async def test_publish_auto_approves_for_entity_ignores_personal_listings():
+    """No teamspace means no self-publish path and no membership lookup at all."""
+    db = _FakeDB([])
+    entity = SimpleNamespace(team_id=None, is_private=False)
+    assert await publish_auto_approves_for_entity(entity, _user(UserRole.super_admin), db) is False
+    db.execute.assert_not_awaited()
 
 
 # ── reserve_handle ──────────────────────────────────────────────────

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.10.7"
+version = "1.11.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1684,7 +1684,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.11.0"
+version = "1.10.7"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -7,6 +7,7 @@
 
 import logging
 import time
+import uuid
 from urllib.parse import urlparse, urlunparse
 
 import httpx
@@ -264,6 +265,32 @@ def resolve_registry_reference(item_type: str, reference: str) -> str:
 
 def canonical_name(item: dict) -> str:
     return item.get("qualified_name") or item.get("name", "")
+
+
+def resolve_team_id(reference: str) -> str:
+    """Resolve a team UUID or handle using the authenticated team list."""
+    value = reference.strip().lstrip("@").lower()
+    try:
+        return str(uuid.UUID(value))
+    except ValueError:
+        pass
+    teams = get("/api/v1/teams/all")
+    for team in teams:
+        if str(team.get("handle", "")).lower() == value:
+            return str(team["id"])
+    raise typer.BadParameter(f"No teamspace with handle '{reference}'", param_hint="team")
+
+
+def add_publish_target(payload: dict, team: str | None, visibility: str | None) -> None:
+    """Add and validate the teamspace target fields for a publish request."""
+    target_visibility = (visibility or "public").strip().lower()
+    if target_visibility not in {"public", "team"}:
+        raise typer.BadParameter("visibility must be 'public' or 'team'", param_hint="visibility")
+    if target_visibility == "team" and not team:
+        raise typer.BadParameter("--visibility team requires --team", param_hint="team")
+    payload["visibility"] = target_visibility
+    if team:
+        payload["team_id"] = resolve_team_id(team)
 
 
 def get(path: str, params: dict | None = None) -> dict:

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -1018,7 +1018,19 @@ def agent_publish(
         "components": data.get("components", []),
     }
 
-    if not update:
+    if update:
+        # The update endpoint refuses both fields by design: visibility has its own
+        # authorized endpoint and a teamspace move is a transfer, not an edit.
+        # Accepting them here and dropping them would report success for something
+        # that never happened.
+        if team is not None:
+            rprint(
+                "[red]--team cannot be used with --update.[/red] Moving an agent between teamspaces "
+                "is a transfer, not an edit. Use [bold]observal agent transfer-owner[/bold] or "
+                "recreate the agent under the target teamspace."
+            )
+            raise typer.Exit(code=1)
+    else:
         client.add_publish_target(payload, team, visibility)
 
     if draft:
@@ -1062,10 +1074,19 @@ def agent_publish(
             except (Exception, SystemExit):
                 pass
 
+        # Visibility first: it is the change that can be refused (composition
+        # conflicts, team role, review reset). Running it after the update would
+        # leave a half-applied publish, the agent edited but still team-private,
+        # reported as success.
+        if visibility is not None:
+            with spinner("Updating visibility..."):
+                vis = client.patch(f"/api/v1/registry/agent/{agent_id}/visibility", {"visibility": visibility})
+            if vis.get("returned_to_review"):
+                rprint(
+                    "[yellow]Agent returned to the review queue; it is not public until a reviewer approves.[/yellow]"
+                )
         with spinner("Updating agent..."):
             result = client.put(f"/api/v1/agents/{agent_id}", payload)
-        if visibility is not None:
-            client.patch(f"/api/v1/registry/agent/{agent_id}/visibility", {"visibility": visibility})
         rprint(f"[green]✓ Agent updated![/green] ID: [bold]{result['id']}[/bold]  v{result.get('version', '?')}")
     else:
         with spinner("Submitting agent for review..."):

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -447,7 +447,7 @@ def agent_bulk_create(
 def agent_list(
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
-    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
+    team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
     interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive search mode"),
     limit: int = typer.Option(50, "--limit", "-n", min=1, max=200, help="Page size (1-200)"),
     page: int = typer.Option(1, "--page", "-p", min=1, help="Page number (1-indexed)"),

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -115,6 +115,8 @@ def agent_create(
     supported_harnesses: list[str] | None = typer.Option(
         None, "--harness", help="Supported harnesses (repeat for multiple)"
     ),
+    team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
     """Create a new agent (interactive wizard, from file, or via flags).
 
@@ -135,6 +137,8 @@ def agent_create(
 
         with open(from_file) as f:
             payload = json.load(f)
+        if team or visibility:
+            client.add_publish_target(payload, team, visibility)
         with spinner("Creating agent..."):
             result = client.post("/api/v1/agents", payload)
         status = result.get("status", "pending")
@@ -189,6 +193,7 @@ def agent_create(
             "components": [],
         }
 
+        client.add_publish_target(payload, team, visibility)
         with spinner("Creating agent..."):
             result = client.post("/api/v1/agents", payload)
         status = result.get("status", "pending")
@@ -298,21 +303,20 @@ def agent_create(
         rprint("[yellow]Aborted.[/yellow]")
         raise typer.Exit(0)
 
+    payload = {
+        "name": name,
+        "version": version,
+        "description": description,
+        "owner": owner,
+        "prompt": prompt_text,
+        "model_name": model_name,
+        "model_config_json": model_cfg,
+        "supported_harnesses": supported_harnesses,
+        "components": components,
+    }
+    client.add_publish_target(payload, team, visibility)
     with spinner("Creating agent..."):
-        result = client.post(
-            "/api/v1/agents",
-            {
-                "name": name,
-                "version": version,
-                "description": description,
-                "owner": owner,
-                "prompt": prompt_text,
-                "model_name": model_name,
-                "model_config_json": model_cfg,
-                "supported_harnesses": supported_harnesses,
-                "components": components,
-            },
-        )
+        result = client.post("/api/v1/agents", payload)
     status = result.get("status", "pending")
     rprint(f"\n[green]✓ Agent submitted for review![/green] ID: [bold]{result['id']}[/bold]")
     rprint(f"[yellow]Status: {status} - an admin must approve it before it becomes visible.[/yellow]")
@@ -442,6 +446,8 @@ def agent_bulk_create(
 @agent_app.command(name="list")
 def agent_list(
     search: str | None = typer.Option(None, "--search", "-s"),
+    namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
+    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
     interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive search mode"),
     limit: int = typer.Option(50, "--limit", "-n", min=1, max=200, help="Page size (1-200)"),
     page: int = typer.Option(1, "--page", "-p", min=1, help="Page number (1-indexed)"),
@@ -466,6 +472,10 @@ def agent_list(
     params: dict = {"limit": limit, "offset": (page - 1) * limit}
     if search:
         params["search"] = search
+    if namespace:
+        params["namespace"] = namespace.lstrip("@").lower()
+    if team:
+        params["team_id"] = client.resolve_team_id(team)
 
     with spinner("Fetching agents..."):
         data, headers = client.get_with_headers("/api/v1/agents", params=params)
@@ -896,6 +906,8 @@ def agent_add(
 @agent_app.command(name="build")
 def agent_build(
     directory: str = typer.Option(".", "--dir", "-d", help="Directory containing observal-agent.yaml"),
+    team: str | None = typer.Option(None, "--team", help="Validate private components for this teamspace"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Agent visibility: public or team"),
 ):
     """Validate agent definition against the server (dry-run).
 
@@ -941,6 +953,13 @@ def agent_build(
 
     console.print(table)
 
+    scope_payload = {"components": components}
+    client.add_publish_target(scope_payload, team, visibility)
+    with spinner("Checking agent composition scope..."):
+        scope_result = client.post("/api/v1/agents/validate", scope_payload)
+    for issue in scope_result.get("issues", []):
+        errors.append(issue.get("message", "Component is not valid for this agent target"))
+
     if errors:
         rprint(f"\n[red]{len(errors)} component(s) failed validation:[/red]")
         for e in errors:
@@ -957,6 +976,8 @@ def agent_publish(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit: str | None = typer.Option(None, "--submit", help="Submit a draft agent for review (agent ID)"),
     bump: str | None = typer.Option(None, "--bump", help="Version bump type: patch, minor, or major (skips prompt)"),
+    team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
     """Publish the agent definition to the server.
 
@@ -996,6 +1017,9 @@ def agent_publish(
         "supported_harnesses": data.get("supported_harnesses", []),
         "components": data.get("components", []),
     }
+
+    if not update:
+        client.add_publish_target(payload, team, visibility)
 
     if draft:
         with spinner("Saving draft..."):
@@ -1040,13 +1064,17 @@ def agent_publish(
 
         with spinner("Updating agent..."):
             result = client.put(f"/api/v1/agents/{agent_id}", payload)
+        if visibility is not None:
+            client.patch(f"/api/v1/registry/agent/{agent_id}/visibility", {"visibility": visibility})
         rprint(f"[green]✓ Agent updated![/green] ID: [bold]{result['id']}[/bold]  v{result.get('version', '?')}")
     else:
         with spinner("Submitting agent for review..."):
             result = client.post("/api/v1/agents", payload)
         status = result.get("status", "pending")
-        rprint(f"[green]✓ Agent submitted for review![/green] ID: [bold]{result['id']}[/bold]")
-        rprint(f"[yellow]Status: {status} - an admin must approve it before it becomes visible.[/yellow]")
+        rprint(f"[green]✓ Agent submitted![/green] ID: [bold]{result['id']}[/bold]")
+        rprint(f"  Pull: [cyan]observal pull {client.canonical_name(result)}[/cyan]")
+        if status != "approved":
+            rprint(f"[yellow]Status: {status} - an admin must approve it before it becomes visible.[/yellow]")
 
 
 @agent_app.command(name="release")

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -1023,6 +1023,16 @@ def agent_publish(
         # authorized endpoint and a teamspace move is a transfer, not an edit.
         # Accepting them here and dropping them would report success for something
         # that never happened.
+        if visibility is not None:
+            # There is no single server call that edits an agent and republishes it,
+            # so doing both means one can succeed while the other fails and the agent
+            # is left half-published. Reordering only chooses which half breaks.
+            rprint(
+                "[red]--visibility cannot be combined with --update.[/red] They are two server "
+                "operations with no atomic form, so a failure would leave the agent half-published. "
+                "Run the update first, then change visibility on the agent."
+            )
+            raise typer.Exit(code=1)
         if team is not None:
             rprint(
                 "[red]--team cannot be used with --update.[/red] Moving an agent between teamspaces "
@@ -1074,17 +1084,6 @@ def agent_publish(
             except (Exception, SystemExit):
                 pass
 
-        # Visibility first: it is the change that can be refused (composition
-        # conflicts, team role, review reset). Running it after the update would
-        # leave a half-applied publish, the agent edited but still team-private,
-        # reported as success.
-        if visibility is not None:
-            with spinner("Updating visibility..."):
-                vis = client.patch(f"/api/v1/registry/agent/{agent_id}/visibility", {"visibility": visibility})
-            if vis.get("returned_to_review"):
-                rprint(
-                    "[yellow]Agent returned to the review queue; it is not public until a reviewer approves.[/yellow]"
-                )
         with spinner("Updating agent..."):
             result = client.put(f"/api/v1/agents/{agent_id}", payload)
         rprint(f"[green]✓ Agent updated![/green] ID: [bold]{result['id']}[/bold]  v{result.get('version', '?')}")

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -303,7 +303,7 @@ def hook_list(
     event: str | None = typer.Option(None, "--event", "-e", help="Filter by event type"),
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
-    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
+    team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved hooks from the registry.

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -119,6 +119,8 @@ def hook_submit(
     scope: str | None = typer.Option(None, "--scope", help="agent, session, or global"),
     supported_harnesses: list[str] | None = typer.Option(None, "--harness", help="Supported harness (repeatable)"),
     example: bool = typer.Option(False, "--example", help="Print example hook payloads and exit"),
+    team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
     """Submit a new hook for review.
 
@@ -284,6 +286,7 @@ def hook_submit(
         if requires:
             payload["requirements"] = requires
 
+    client.add_publish_target(payload, team, visibility)
     if draft:
         with spinner("Saving draft..."):
             result = client.post("/api/v1/hooks/draft", payload)
@@ -292,12 +295,15 @@ def hook_submit(
         with spinner("Submitting hook..."):
             result = client.post("/api/v1/hooks/submit", payload)
         rprint(f"[green]✓ Hook submitted![/green] ID: [bold]{result['id']}[/bold]")
+    rprint(f"  Install: [cyan]observal registry hook install {client.canonical_name(result)}[/cyan]")
 
 
 @hook_app.command(name="list")
 def hook_list(
     event: str | None = typer.Option(None, "--event", "-e", help="Filter by event type"),
     search: str | None = typer.Option(None, "--search", "-s"),
+    namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
+    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved hooks from the registry.
@@ -317,6 +323,10 @@ def hook_list(
         params["event"] = event
     if search:
         params["search"] = search
+    if namespace:
+        params["namespace"] = namespace.lstrip("@").lower()
+    if team:
+        params["team_id"] = client.resolve_team_id(team)
     with spinner("Fetching hooks..."):
         data = client.get("/api/v1/hooks", params=params)
     if not data:

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -473,7 +473,7 @@ def _build_config_preview(server_name: str, parsed: dict) -> dict:
 # ── Implementation functions (shared by canonical + deprecated) ──
 
 
-def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False):
+def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False, team=None, visibility=None):
     # ── Path B/C: Direct JSON config (no git URL needed) ─────
     optic.trace("git_url={}, name={}", git_url, name)
     if direct_config:
@@ -600,12 +600,14 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
                 "docker_image": git_analysis.get("docker_image"),
             }
 
+        client.add_publish_target(submit_payload, team, visibility)
         endpoint = "/api/v1/mcps/draft" if draft else "/api/v1/mcps/submit"
         label = "Saving draft..." if draft else "Submitting..."
         with spinner(label):
             result = client.post(endpoint, submit_payload)
         msg = "Draft saved!" if draft else "Submitted!"
         rprint(f"\n[green]{msg}[/green] ID: [bold]{result['id']}[/bold]")
+        rprint(f"  Install: [cyan]observal registry mcp install {client.canonical_name(result)}[/cyan]")
         rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
         return
 
@@ -906,24 +908,30 @@ def _submit_impl(git_url, name, category, yes, direct_config=False, draft=False)
             "setup_instructions": prefill.get("setup_instructions"),
         }
 
+    client.add_publish_target(submit_payload, team, visibility)
     endpoint = "/api/v1/mcps/draft" if draft else "/api/v1/mcps/submit"
     label = "Saving draft..." if draft else "Submitting..."
     with spinner(label):
         result = client.post(endpoint, submit_payload)
     msg = "Draft saved!" if draft else "Submitted!"
     rprint(f"\n[green]{msg}[/green] ID: [bold]{result['id']}[/bold]")
+    rprint(f"  Install: [cyan]observal registry mcp install {client.canonical_name(result)}[/cyan]")
     if _framework:
         rprint(f"  Framework: [cyan]{_framework}[/cyan]")
     rprint(f"  Status: {status_badge(result.get('status', 'pending'))}")
 
 
-def _list_impl(category, search, limit, sort, output, interactive=False):
-    optic.trace("category={}, search={}", category, search)
+def _list_impl(category, search, limit, sort, output, interactive=False, namespace=None, team=None):
+    optic.trace("category={}, search={}, namespace={}, team={}", category, search, namespace, team)
     params = {}
     if category:
         params["category"] = category
     if search:
         params["search"] = search
+    if namespace:
+        params["namespace"] = namespace.lstrip("@").lower()
+    if team:
+        params["team_id"] = client.resolve_team_id(team)
 
     with spinner("Fetching MCP servers..."):
         data = client.get("/api/v1/mcps", params=params)
@@ -1249,6 +1257,8 @@ def submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (MCP ID)"),
     example: bool = typer.Option(False, "--example", help="Print example MCP configs and exit"),
+    team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
     """Submit an MCP server to the registry.
 
@@ -1299,13 +1309,24 @@ def submit(
     if config:
         rprint("[dim]Note: --config is now the default. You can just run `observal mcp submit`.[/dim]")
     rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
-    _submit_impl(git_url, name, category, yes, direct_config=True, draft=draft)
+    _submit_impl(
+        git_url,
+        name,
+        category,
+        yes,
+        direct_config=True,
+        draft=draft,
+        team=team,
+        visibility=visibility,
+    )
 
 
 @mcp_app.command(name="list")
 def list_mcps(
     category: str | None = typer.Option(None, "--category", "-c", help="Filter by category"),
     search: str | None = typer.Option(None, "--search", "-s", help="Search by name/description"),
+    namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
+    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
     interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive search mode"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
     sort: str = typer.Option("name", "--sort", help="Sort by: name, category, version"),
@@ -1337,7 +1358,7 @@ def list_mcps(
         # Sort by category, limit to 10 results
         observal registry mcp list --sort category --limit 10
     """
-    _list_impl(category, search, limit, sort, output, interactive=interactive)
+    _list_impl(category, search, limit, sort, output, interactive=interactive, namespace=namespace, team=team)
 
 
 @mcp_app.command(name="my")

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1326,7 +1326,7 @@ def list_mcps(
     category: str | None = typer.Option(None, "--category", "-c", help="Filter by category"),
     search: str | None = typer.Option(None, "--search", "-s", help="Search by name/description"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
-    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
+    team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
     interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive search mode"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
     sort: str = typer.Option("name", "--sort", help="Sort by: name, category, version"),

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import typer
 from rich import print as rprint
+from rich.markup import escape
 
 from observal_cli import client
 from observal_cli.render import spinner
@@ -86,7 +87,10 @@ def _require_admin() -> None:
     role = user.get("role", "")
     if role != "super_admin":
         rprint("[red]Permission denied.[/red] The migrate command requires super_admin role.")
-        rprint(f"[dim]  Current role: {role}[/dim]")
+        # The role comes from the server response, so it has to be escaped before it
+        # reaches Rich. A value containing markup such as "[/]" would otherwise raise
+        # MarkupError and replace this clean exit with a traceback.
+        rprint(f"[dim]  Current role: {escape(str(role))}[/dim]")
         raise typer.Exit(1)
 
 

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -149,7 +149,7 @@ def prompt_list(
     category: str | None = typer.Option(None, "--category", "-c"),
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
-    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
+    team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved prompts in the registry.

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -49,6 +49,8 @@ def prompt_submit(
     template: str | None = typer.Option(None, "--template", "-t", help="Template body"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (prompt ID)"),
+    team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
     """Submit a new prompt template for review.
 
@@ -130,6 +132,7 @@ def prompt_submit(
             rprint(f"[red]Error:[/red] Invalid category: {payload.get('category')}")
             raise typer.Exit(1)
 
+    client.add_publish_target(payload, team, visibility)
     if draft:
         with spinner("Saving draft..."):
             result = client.post("/api/v1/prompts/draft", payload)
@@ -138,12 +141,15 @@ def prompt_submit(
         with spinner("Submitting prompt..."):
             result = client.post("/api/v1/prompts/submit", payload)
         rprint(f"[green]✓ Prompt submitted![/green] ID: [bold]{result['id']}[/bold]")
+    rprint(f"  Install: [cyan]observal registry prompt render {client.canonical_name(result)}[/cyan]")
 
 
 @prompt_app.command(name="list")
 def prompt_list(
     category: str | None = typer.Option(None, "--category", "-c"),
     search: str | None = typer.Option(None, "--search", "-s"),
+    namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
+    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved prompts in the registry.
@@ -162,6 +168,10 @@ def prompt_list(
         params["category"] = category
     if search:
         params["search"] = search
+    if namespace:
+        params["namespace"] = namespace.lstrip("@").lower()
+    if team:
+        params["team_id"] = client.resolve_team_id(team)
     with spinner("Fetching prompts..."):
         data = client.get("/api/v1/prompts", params=params)
     if not data:

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -106,6 +106,8 @@ def sandbox_submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (sandbox ID)"),
     example: bool = typer.Option(False, "--example", help="Print example sandbox payloads and exit"),
+    team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
     """Submit a new sandbox environment for review.
 
@@ -222,6 +224,7 @@ def sandbox_submit(
             rprint(f"[red]Error:[/red] Invalid harness: {bad_harnesses[0]}")
             raise typer.Exit(1)
 
+    client.add_publish_target(payload, team, visibility)
     if draft:
         with spinner("Saving draft..."):
             result = client.post("/api/v1/sandboxes/draft", payload)
@@ -230,12 +233,15 @@ def sandbox_submit(
         with spinner("Submitting sandbox..."):
             result = client.post("/api/v1/sandboxes/submit", payload)
         rprint(f"[green]✓ Sandbox submitted![/green] ID: [bold]{result['id']}[/bold]")
+    rprint(f"  Install: [cyan]observal registry sandbox install {client.canonical_name(result)}[/cyan]")
 
 
 @sandbox_app.command(name="list")
 def sandbox_list(
     runtime: str | None = typer.Option(None, "--runtime", "-r"),
     search: str | None = typer.Option(None, "--search", "-s"),
+    namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
+    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved sandboxes in the registry.
@@ -254,6 +260,10 @@ def sandbox_list(
         params["runtime"] = runtime
     if search:
         params["search"] = search
+    if namespace:
+        params["namespace"] = namespace.lstrip("@").lower()
+    if team:
+        params["team_id"] = client.resolve_team_id(team)
     with spinner("Fetching sandboxes..."):
         data = client.get("/api/v1/sandboxes", params=params)
     if not data:

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -241,7 +241,7 @@ def sandbox_list(
     runtime: str | None = typer.Option(None, "--runtime", "-r"),
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
-    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
+    team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved sandboxes in the registry.

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -126,6 +126,8 @@ def skill_submit(
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (skill ID)"),
     example: bool = typer.Option(False, "--example", help="Print example skill payloads and exit"),
+    team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
+    visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
     """Submit a new skill for review.
 
@@ -270,6 +272,7 @@ def skill_submit(
             payload["script_content"] = script_content
             payload["script_filename"] = script_filename
 
+    client.add_publish_target(payload, team, visibility)
     endpoint = "/api/v1/skills/draft" if draft else "/api/v1/skills/submit"
     label = "draft" if draft else "skill"
     with spinner(f"Saving {label}..."):
@@ -277,6 +280,7 @@ def skill_submit(
     validated = result.get("validated", False)
     validated_tag = "[green]✓ validated[/green]" if validated else "[yellow]unvalidated[/yellow]"
     rprint(f"[green]✓ {label.capitalize()} submitted![/green] ID: [bold]{result['id']}[/bold]  {validated_tag}")
+    rprint(f"  Install: [cyan]observal registry skill install {client.canonical_name(result)}[/cyan]")
 
 
 # ── List / My ─────────────────────────────────────────────────────────────────
@@ -286,7 +290,10 @@ def skill_submit(
 def skill_list(
     task_type: str | None = typer.Option(None, "--task-type", "-t"),
     target_agent: str | None = typer.Option(None, "--target-agent"),
+    harness: str | None = typer.Option(None, "--harness", help="Only skills supporting this harness"),
     search: str | None = typer.Option(None, "--search", "-s"),
+    namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
+    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved skills in the registry.
@@ -306,8 +313,14 @@ def skill_list(
         params["task_type"] = task_type
     if target_agent:
         params["target_agent"] = target_agent
+    if harness:
+        params["harness"] = harness
     if search:
         params["search"] = search
+    if namespace:
+        params["namespace"] = namespace.lstrip("@").lower()
+    if team:
+        params["team_id"] = client.resolve_team_id(team)
     with spinner("Fetching skills..."):
         data = client.get("/api/v1/skills", params=params)
     if not data:

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -293,7 +293,7 @@ def skill_list(
     harness: str | None = typer.Option(None, "--harness", help="Only skills supporting this harness"),
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
-    team: str | None = typer.Option(None, "--team", help="Include public items and private items from this teamspace"),
+    team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
     output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
 ):
     """List approved skills in the registry.

--- a/observal_cli/cmd_team.py
+++ b/observal_cli/cmd_team.py
@@ -17,14 +17,6 @@ members_app = typer.Typer(name="members", help="Manage team membership.", no_arg
 team_app.add_typer(members_app, name="members")
 
 
-def _require_teamspaces() -> None:
-    """Gate team commands on server support; clean message on older servers."""
-    if not client.server_supports("teamspaces"):
-        rprint("[yellow]Teamspaces are not supported by this server.[/yellow]")
-        rprint("[dim]Update your server to v1.11.0 or later to use team commands.[/dim]")
-        raise typer.Exit(1)
-
-
 def _resolve_team_id(team: str) -> str:
     """Accept a UUID or a team handle; resolve to a UUID via the all-teams list."""
     import uuid as _uuid
@@ -56,7 +48,6 @@ def list_teams(
 
         observal team list --output json
     """
-    _require_teamspaces()
     path = "/api/v1/teams/all" if all_teams else "/api/v1/teams"
     rows = client.get(path)
     if output == "json":
@@ -95,7 +86,6 @@ def show_team(
 
         observal team show 36e0c516-7a7f-4fec-ad2c-b47eb426b8a7
     """
-    _require_teamspaces()
     team_id = _resolve_team_id(team)
     detail = client.get(f"/api/v1/teams/{team_id}")
     members = client.get(f"/api/v1/teams/{team_id}/members")
@@ -131,7 +121,6 @@ def create_team(
 
         observal team create 'SRE' -h sre -d 'Site reliability'
     """
-    _require_teamspaces()
     body: dict = {"name": name}
     if handle:
         body["handle"] = handle
@@ -156,7 +145,6 @@ def delete_team(
 
         observal team delete 36e0c516-7a7f-4fec-ad2c-b47eb426b8a7 -y
     """
-    _require_teamspaces()
     team_id = _resolve_team_id(team)
     if not yes and not typer.confirm(f"Delete teamspace '{team}'? This cannot be undone."):
         raise typer.Abort()
@@ -176,7 +164,6 @@ def leave_team(
 
         observal team leave sre
     """
-    _require_teamspaces()
     team_id = _resolve_team_id(team)
     client.post(f"/api/v1/teams/{team_id}/leave")
     rprint("[green]Left teamspace.[/green]")
@@ -195,7 +182,6 @@ def list_members(
 
         observal team members list sre --output json
     """
-    _require_teamspaces()
     team_id = _resolve_team_id(team)
     rows = client.get(f"/api/v1/teams/{team_id}/members")
     if output == "json":
@@ -226,7 +212,6 @@ def add_member(
 
         observal team members add sre @bob -r owner
     """
-    _require_teamspaces()
     team_id = _resolve_team_id(team)
     body: dict = {"role": role}
     if "@" in user and not user.startswith("@"):
@@ -251,7 +236,6 @@ def remove_member(
 
         observal team members remove sre alice@example.com -y
     """
-    _require_teamspaces()
     team_id = _resolve_team_id(team)
     members = client.get(f"/api/v1/teams/{team_id}/members")
     target = None

--- a/observal_cli/features.py
+++ b/observal_cli/features.py
@@ -42,8 +42,6 @@ FEATURE_VERSIONS: dict[str, str] = {
     "self_upgrade": "1.0.0",
     "server_upgrade": "1.0.0",
     "version_negotiation": "1.0.0",
-    # v1.11.0
-    "teamspaces": "1.11.0",
 }
 
 

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -102,12 +102,15 @@ Goes through review queue. Use for "new version", "bump", or "release".
    ```bash
    observal registry mcp list --search 'github docker' --output json
    observal registry skill list --search 'frontend design' --output json
+   observal registry skill list --team platform-tools --output json
    observal agent add mcp COMPONENT_UUID --dir ./my-agent
    observal agent add skill COMPONENT_UUID --dir ./my-agent
    ```
 3. Validate: `observal agent build --dir ./my-agent`
 4. Publish: `observal agent publish --dir ./my-agent`
    - `--draft` saves without submitting. `--submit` submits a saved draft.
+   - Use `--team TEAM_HANDLE --visibility public` for a public teamspace agent.
+   - Use `--team TEAM_HANDLE --visibility team` for a private agent visible only to team members.
 
 ---
 
@@ -135,6 +138,8 @@ observal agent unarchive AGENT_NAME --yes
 
 ```bash
 observal agent list --output json
+observal agent list --namespace platform-tools --output json
+observal agent list --team platform-tools --output json
 observal agent list --search 'incident resolution' --output json
 observal agent list --search keyword --output json
 observal agent list --page 2 --limit 20 --output json
@@ -143,7 +148,7 @@ observal agent show AGENT_NAME --output json
 observal agent versions AGENT_NAME --output json
 ```
 
-After `list`, use row numbers (1, 2, 3...) in subsequent commands.
+After `list`, use row numbers (1, 2, 3...) in subsequent commands. Team members see approved private teamspace agents in normal results. Direct references use `TEAM_HANDLE/AGENT_SLUG`.
 
 ---
 

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -148,7 +148,7 @@ observal agent show AGENT_NAME --output json
 observal agent versions AGENT_NAME --output json
 ```
 
-After `list`, use row numbers (1, 2, 3...) in subsequent commands. Team members see approved private teamspace agents in normal results. Direct references use `TEAM_HANDLE/AGENT_SLUG`.
+After `list`, use row numbers (1, 2, 3...) in subsequent commands. Team members see approved private teamspace agents in normal results. `--team TEAM_HANDLE` narrows to what that teamspace owns. Direct references use `TEAM_HANDLE/AGENT_SLUG`.
 
 ---
 

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -42,7 +42,7 @@ observal registry mcp show NAME --output json
 observal registry hook show NAME --output json
 ```
 
-After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--interactive` for fuzzy picker. Team members see approved private teamspace items in the same lists. Use `--team TEAM_HANDLE` to include public items plus that team's private items, or `--namespace TEAM_HANDLE` to narrow to the team's namespace. Direct references use `TEAM_HANDLE/ITEM_SLUG`. Skill search covers descriptions, task types, target agents, slash commands, source paths, delivery mode, and SKILL.md content.
+After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--interactive` for fuzzy picker. Team members see approved private teamspace items in the same lists. Use `--team TEAM_HANDLE` to list only what that teamspace owns, including its private items when you are a member. Direct references use `TEAM_HANDLE/ITEM_SLUG`. Skill search covers descriptions, task types, target agents, slash commands, source paths, delivery mode, and SKILL.md content.
 
 **MCP categories:** `browser-automation`, `cloud-platforms`, `code-execution`, `communication`, `databases`, `developer-tools`, `devops`, `file-systems`, `finance`, `knowledge-memory`, `monitoring`, `multimedia`, `productivity`, `search`, `security`, `version-control`, `ai-ml`, `data-analytics`, `general`
 

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -26,8 +26,10 @@ Use natural-language keywords with `--search`; do not require exact whole-query 
 
 ```bash
 observal registry mcp list --category developer-tools --output json
-observal registry skill list --search 'frontend design' --output json
-observal registry skill list --task-type code-review --output json
+observal registry mcp list --namespace platform-tools --output json
+observal registry skill list --namespace platform-tools --output json
+observal registry skill list --team platform-tools --search 'frontend design' --output json
+observal registry skill list --task-type code-review --harness claude-code --output json
 observal registry hook list --event UserPromptSubmit --output json
 observal registry prompt list --category coding --output json
 observal registry sandbox list --runtime docker --output json
@@ -40,7 +42,7 @@ observal registry mcp show NAME --output json
 observal registry hook show NAME --output json
 ```
 
-After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--interactive` for fuzzy picker.
+After `list`, use row numbers (1, 2, 3...) in subsequent commands. Add `--interactive` for fuzzy picker. Team members see approved private teamspace items in the same lists. Use `--team TEAM_HANDLE` to include public items plus that team's private items, or `--namespace TEAM_HANDLE` to narrow to the team's namespace. Direct references use `TEAM_HANDLE/ITEM_SLUG`. Skill search covers descriptions, task types, target agents, slash commands, source paths, delivery mode, and SKILL.md content.
 
 **MCP categories:** `browser-automation`, `cloud-platforms`, `code-execution`, `communication`, `databases`, `developer-tools`, `devops`, `file-systems`, `finance`, `knowledge-memory`, `monitoring`, `multimedia`, `productivity`, `search`, `security`, `version-control`, `ai-ml`, `data-analytics`, `general`
 
@@ -58,6 +60,7 @@ Paste the MCP JSON config. Optionally include `--git` so Observal clones the rep
 observal registry mcp submit --example
 observal registry mcp submit --name my-mcp --category developer-tools --yes
 observal registry mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
+observal registry mcp submit --name internal-mcp --category developer-tools --team platform-tools --visibility team --yes
 ```
 
 The command still expects pasted JSON. If a local image must be built, follow the returned setup instructions, for example `docker build -t name:latest .`. Manual installs also print these setup instructions before the MCP can be used.
@@ -70,6 +73,7 @@ There are two delivery modes for skills:
 ```bash
 observal registry skill submit --example
 observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main --name my-skill --description 'What it does' --task-type general
+observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --name internal-skill --description 'Team skill' --task-type general --team platform-tools --visibility team
 ```
 
 **Registry direct** (inline SKILL.md + optional script, no git repo needed):

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -34,6 +34,7 @@ For requests like "find me an agent for incident resolution" or "what skill help
 ```bash
 observal agent list --search 'incident resolution' --output json
 observal registry skill list --search 'frontend design' --output json
+observal registry skill list --team platform-tools --search 'frontend design' --output json
 observal registry mcp list --search 'github docker' --output json
 ```
 
@@ -83,8 +84,7 @@ Check for newer versions of installed agents and components.
 
 ```bash
 observal outdated
-observal outdated --harness claude-code
-observal outdated --output json
+observal outdated --harness claude-code --output json
 ```
 
 Reads `~/.observal/lockfile.json` and compares each pinned version against the registry's latest. Reports a table of outdated items with current vs latest version.

--- a/observal_cli/tests/test_cmd_team.py
+++ b/observal_cli/tests/test_cmd_team.py
@@ -14,14 +14,6 @@ from observal_cli.main import app
 
 runner = CliRunner()
 
-# All team commands are gated on server_supports("teamspaces"); mock it True.
-
-
-@pytest.fixture(autouse=True)
-def _support_teamspaces():
-    with patch("observal_cli.client.server_supports", return_value=True):
-        yield
-
 
 def _teams_all():
     return [
@@ -149,9 +141,19 @@ def test_team_show_unknown_handle_errors(bad: str):
     assert result.exit_code != 0
 
 
-def test_team_commands_blocked_when_server_unsupported():
-    """On an older server without teamspaces, commands exit cleanly with a message."""
-    with patch("observal_cli.client.server_supports", return_value=False):
+def test_team_commands_do_not_probe_the_server_version():
+    """No client-side version gate stands in front of the team commands.
+
+    The gate this replaces asked the server for its version before every team
+    command and refused based on a hardcoded minimum. That minimum could only ever
+    be wrong: the CLI and server versions both come from this repository, so the
+    negotiated version could never exceed it. A server that genuinely lacks the
+    endpoints answers for itself.
+    """
+    with (
+        patch("observal_cli.client.server_supports") as supports,
+        patch("observal_cli.client.get", return_value=_teams_all()),
+    ):
         result = runner.invoke(app, ["team", "list"])
-    assert result.exit_code == 1
-    assert "not supported" in result.output
+    assert result.exit_code == 0
+    supports.assert_not_called()

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.10.7",
+  "version": "1.11.0",
   "type": "module",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.11.0",
+  "version": "1.10.7",
   "type": "module",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.10.7"
+version = "1.11.0"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.11.0"
+version = "1.10.7"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/e2e/teamspace-review.spec.ts
+++ b/tests/e2e/teamspace-review.spec.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, Page, test } from "@playwright/test";
+
+import { API_BASE } from "./helpers";
+
+/**
+ * The teamspace Review tab is the ONLY surface a team reviewer has.
+ *
+ * The admin review page is gated to global reviewer and admin roles, so a team
+ * reviewer whose global role is plain "user" cannot reach it. If this tab stops
+ * rendering, that role loses its entire purpose and team-private submissions
+ * pile up with nobody able to clear them.
+ */
+
+const PASSWORD = "F3-Adversarial-Pw!7";
+const TEAM_HANDLE = "f3acme";
+
+type Principal = { email: string; role: string };
+
+const OWNER: Principal = { email: "f3.alice@demo.example", role: "user" };
+const TEAM_REVIEWER: Principal = { email: "f3.bob@demo.example", role: "user" };
+const PLAIN_MEMBER: Principal = { email: "f3.carol@demo.example", role: "user" };
+const NON_MEMBER: Principal = { email: "f3.mallory@demo.example", role: "user" };
+
+// Cached per email: the login limiter allows only a handful of attempts per
+// bucket per minute, and every test here logs in.
+const _tokens = new Map<string, string>();
+
+async function tokenFor(email: string): Promise<string> {
+  const cached = _tokens.get(email);
+  if (cached) return cached;
+  // The limiter keys on a bearer token hash before falling back to the client
+  // IP, so a distinct dummy token per principal keeps principals out of one
+  // another's bucket.
+  const res = await fetch(`${API_BASE}/api/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer e2e-${email}` },
+    body: JSON.stringify({ email, password: PASSWORD }),
+  });
+  const data = await res.json();
+  if (!data.access_token) throw new Error(`login failed for ${email}: ${JSON.stringify(data)}`);
+  _tokens.set(email, data.access_token as string);
+  return data.access_token as string;
+}
+
+async function loginAs(page: Page, principal: Principal) {
+  const token = await tokenFor(principal.email);
+  await page.goto("/");
+  await page.evaluate(
+    ([t, r]) => {
+      sessionStorage.setItem("observal_access_token", t);
+      sessionStorage.setItem("observal_user_role", r);
+    },
+    [token, principal.role],
+  );
+  await page.reload();
+}
+
+async function openTeamspace(page: Page) {
+  await page.goto(`/teamspaces/${TEAM_HANDLE}`);
+  await expect(page.getByRole("tab", { name: /members/i })).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("teamspace review tab", () => {
+  test("a team owner sees the Review tab", async ({ page }) => {
+    await loginAs(page, OWNER);
+    await openTeamspace(page);
+    await expect(page.getByRole("tab", { name: /review/i })).toBeVisible();
+  });
+
+  test("a team reviewer sees the Review tab and its pending items", async ({ page }) => {
+    await loginAs(page, TEAM_REVIEWER);
+    await openTeamspace(page);
+
+    const reviewTab = page.getByRole("tab", { name: /review/i });
+    await expect(reviewTab).toBeVisible();
+    await reviewTab.click();
+
+    // Either pending work with actions, or an explicit empty state. A blank
+    // panel would mean the queue silently failed to load.
+    const approve = page.getByRole("button", { name: /approve/i }).first();
+    const empty = page.getByText(/nothing waiting|no pending|all clear/i).first();
+    await expect(approve.or(empty)).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("a plain team member does not see the Review tab", async ({ page }) => {
+    await loginAs(page, PLAIN_MEMBER);
+    await openTeamspace(page);
+    await expect(page.getByRole("tab", { name: /review/i })).toHaveCount(0);
+  });
+
+  test("the Agents and Components tabs are reachable from the teamspace", async ({ page }) => {
+    // The teamspace card used to link only to /components, leaving team-published
+    // agents findable only by setting a filter on the agents page by hand.
+    await loginAs(page, OWNER);
+    await openTeamspace(page);
+    for (const name of [/agents/i, /components/i]) {
+      const tab = page.getByRole("tab", { name });
+      await expect(tab).toBeVisible();
+      await tab.click();
+    }
+  });
+
+  test("a non-member cannot reach the teamspace review surface", async ({ page }) => {
+    await loginAs(page, NON_MEMBER);
+    await page.goto(`/teamspaces/${TEAM_HANDLE}`);
+    await expect(page.getByRole("tab", { name: /review/i })).toHaveCount(0);
+  });
+});
+
+test.describe("visibility confirmation", () => {
+  test("making a team-private listing public asks for confirmation first", async ({ page }) => {
+    const token = await tokenFor(OWNER.email);
+
+    // Seed a team-private skill this owner can flip.
+    const seeded = await fetch(`${API_BASE}/api/v1/skills/submit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        name: `e2e-vis-${Date.now()}`,
+        version: "1.0.0",
+        description: "visibility dialog fixture",
+        owner: TEAM_HANDLE,
+        task_type: "testing",
+        delivery_mode: "registry_direct",
+        skill_md_content: "# fixture\n",
+        team_id: await teamId(token),
+        visibility: "team",
+      }),
+    }).then((r) => r.json());
+    expect(seeded.id).toBeTruthy();
+
+    await loginAs(page, OWNER);
+    // The route is /components/$componentId with the plural type as a search param.
+    await page.goto(`/components/${seeded.id}?type=skills`);
+
+    // Visibility is a PickerSelect labelled "Listing visibility", not a button.
+    const picker = page.getByLabel("Listing visibility");
+    await expect(picker).toBeVisible({ timeout: 15_000 });
+    await page.getByRole("button", { name: "Show options" }).first().click();
+    await page.getByRole("button", { name: "Public", exact: true }).click();
+
+    // The dialog must name both consequences: everyone can see it, and it leaves
+    // the catalog until a reviewer approves. Users cannot guess the second one.
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(/review/i);
+    await expect(dialog).toContainText(/everyone|public|anyone/i);
+
+    // Cancelling must leave the listing team-private.
+    await dialog.getByRole("button", { name: /cancel|no|keep/i }).first().click();
+    await expect(dialog).toHaveCount(0);
+
+    const after = await fetch(`${API_BASE}/api/v1/skills/${seeded.id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }).then((r) => r.json());
+    expect(after.is_private).toBe(true);
+  });
+});
+
+async function teamId(token: string): Promise<string> {
+  const teams = await fetch(`${API_BASE}/api/v1/teams`, {
+    headers: { Authorization: `Bearer ${token}` },
+  }).then((r) => r.json());
+  const team = teams.find((t: { handle: string }) => t.handle === TEAM_HANDLE);
+  if (!team) throw new Error(`teamspace ${TEAM_HANDLE} not seeded`);
+  return team.id;
+}

--- a/tests/test_agent_composition.py
+++ b/tests/test_agent_composition.py
@@ -11,9 +11,10 @@ and route endpoints for multi-component agent composition.
 """
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 from pydantic import ValidationError
 
 # ── Schema Tests ────────────────────────────────────────────────────
@@ -1091,3 +1092,175 @@ class TestResolverAndBuilderModulesImportable:
 
         assert callable(build_agent_manifest)
         assert callable(build_composition_summary)
+
+
+class TestManifestWithoutGitUrl:
+    """Components with no repository must still produce a manifest.
+
+    Registry-direct skills and command or url based MCP servers have no git_url.
+    ManifestComponent.git_url is a plain string, so a None must be normalized to ""
+    instead of failing validation and returning a 500 from GET /agents/{id}/manifest.
+    """
+
+    def _resolved(self):
+        from services.agent_resolver import ResolvedAgent, ResolvedComponent
+
+        return ResolvedAgent(
+            agent_id=uuid.uuid4(),
+            agent_name="no-git-agent",
+            agent_version="1.0.0",
+            components=[
+                ResolvedComponent(
+                    component_type="skill",
+                    component_id=uuid.uuid4(),
+                    name="direct-skill",
+                    version="1.0.0",
+                    git_url=None,
+                    description="",
+                    order_index=0,
+                    extra={"skill_md_content": "# direct", "task_type": "testing"},
+                ),
+                ResolvedComponent(
+                    component_type="mcp",
+                    component_id=uuid.uuid4(),
+                    name="command-mcp",
+                    version="1.0.0",
+                    git_url=None,
+                    description="",
+                    order_index=1,
+                    extra={"transport": "stdio"},
+                ),
+            ],
+        )
+
+    def test_manifest_builds_without_git_url(self):
+        from services.agent_builder import build_agent_manifest
+
+        data = build_agent_manifest(self._resolved())
+        assert data["name"] == "no-git-agent"
+        assert len(data["components"]["skills"]) == 1
+        assert len(data["components"]["mcps"]) == 1
+
+    def test_component_conversion_normalizes_none(self):
+        from services.agent_builder import _resolved_to_manifest_component
+
+        comp = self._resolved().components[0]
+        manifest_component = _resolved_to_manifest_component(comp)
+        assert manifest_component.git_url == ""
+        assert manifest_component.description == ""
+
+
+# ── Update Route Publish Target Tests ───────────────────────────────
+
+
+def _update_app(user, db):
+    """Build an app exposing the agent routes with auth and db overridden."""
+    from fastapi import FastAPI
+
+    from api.deps import get_current_user, get_db
+    from api.routes.agent import router
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+def _update_user():
+    from models.user import User, UserRole
+
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.role = UserRole.user
+    user.email = "owner@example.com"
+    user.username = "owner"
+    user.org_id = None
+    return user
+
+
+def _update_agent_mock(user, *, is_private=False, team_id=None):
+    from datetime import UTC, datetime
+
+    from models.agent import AgentStatus
+
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "update-target"
+    agent.version = "1.0.0"
+    agent.description = "An agent to update"
+    agent.owner = "owner"
+    agent.prompt = "Do things"
+    agent.model_name = "claude-sonnet-4"
+    agent.model_config_json = {}
+    agent.external_mcps = []
+    agent.supported_harnesses = []
+    agent.status = AgentStatus.approved
+    agent.rejection_reason = None
+    agent.created_by = user.id
+    agent.created_at = datetime.now(UTC)
+    agent.updated_at = datetime.now(UTC)
+    agent.deleted_at = None
+    agent.co_authors = []
+    agent.is_private = is_private
+    agent.team_id = team_id
+    agent.components = []
+    return agent
+
+
+class TestUpdateAgentRejectsPublishTargetChanges:
+    """PUT /agents/{id} must not silently drop visibility or team_id.
+
+    Visibility has a dedicated authorized endpoint and a teamspace move is a
+    different operation, so both are refused here rather than ignored.
+    """
+
+    @pytest.mark.asyncio
+    async def test_visibility_change_is_rejected(self):
+        user = _update_user()
+        agent = _update_agent_mock(user, is_private=True, team_id=uuid.uuid4())
+        db = AsyncMock()
+        app = _update_app(user, db)
+
+        with patch("api.routes.agent.crud._load_agent", return_value=agent):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.put(f"/api/v1/agents/{agent.id}", json={"visibility": "public"})
+
+        assert r.status_code == 422
+        assert f"/api/v1/registry/agent/{agent.id}/visibility" in r.json()["detail"]
+        assert agent.is_private is True
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_matching_visibility_is_accepted(self):
+        user = _update_user()
+        agent = _update_agent_mock(user, is_private=False)
+        db = AsyncMock()
+        app = _update_app(user, db)
+
+        with (
+            patch("api.routes.agent.crud._load_agent", return_value=agent),
+            patch("api.routes.agent.crud._resolve_component_names", return_value={}),
+            patch("api.routes.agent.crud.emit_registry_event"),
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.put(f"/api/v1/agents/{agent.id}", json={"visibility": "public"})
+
+        assert r.status_code == 200
+        assert agent.is_private is False
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_teamspace_move_is_rejected(self):
+        user = _update_user()
+        agent = _update_agent_mock(user, is_private=True, team_id=uuid.uuid4())
+        db = AsyncMock()
+        app = _update_app(user, db)
+
+        with patch("api.routes.agent.crud._load_agent", return_value=agent):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.put(f"/api/v1/agents/{agent.id}", json={"team_id": str(uuid.uuid4())})
+
+        assert r.status_code == 422
+        assert "Teamspace cannot be changed here" in r.json()["detail"]
+        db.commit.assert_not_awaited()

--- a/tests/test_co_authors.py
+++ b/tests/test_co_authors.py
@@ -30,6 +30,7 @@ import pytest
 from fastapi import HTTPException
 
 from api.routes.co_authors import TransferOwnershipRequest, transfer_ownership
+from models.team import TeamRole
 
 ENTITY_TYPES = ["agents", "mcps", "skills", "hooks", "prompts", "sandboxes"]
 
@@ -64,11 +65,16 @@ def _target_user():
     )
 
 
-async def _transfer(entity_type, listing, current_user, target_user, db):
+async def _transfer(entity_type, listing, current_user, target_user, db, *, team_role=None):
+    """Run a transfer. ``team_role`` is the caller's role in the listing's teamspace."""
+    membership = SimpleNamespace(role=team_role) if team_role is not None else None
     with (
         patch("api.routes.co_authors._get_entity_for_transfer", new=AsyncMock(return_value=listing)),
         patch("api.routes.co_authors._resolve_target_user", new=AsyncMock(return_value=target_user)),
         patch("api.routes.co_authors.identity_exists", new=AsyncMock(return_value=False)),
+        patch("api.routes.co_authors.team_membership", new=AsyncMock(return_value=membership)),
+        patch("api.routes.co_authors.is_admin", return_value=False),
+        patch("api.routes.co_authors.review_publication_to_public", new=AsyncMock(return_value=True)),
     ):
         return await transfer_ownership(
             entity_type,
@@ -82,25 +88,44 @@ async def _transfer(entity_type, listing, current_user, target_user, db):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("entity_type", ENTITY_TYPES)
 @pytest.mark.parametrize("is_private", [False, True])
-async def test_transfer_of_team_listing_is_refused(entity_type, is_private):
+async def test_transfer_of_team_listing_needs_a_teamspace_owner(entity_type, is_private):
+    """A plain member cannot walk a listing out of the teamspace."""
     current_user = SimpleNamespace(id=uuid.uuid4())
     team_id = uuid.uuid4()
     listing = _listing(entity_type, current_user.id, team_id=team_id, is_private=is_private)
-    target_user = _target_user()
     db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
 
     with pytest.raises(HTTPException) as exc:
-        await _transfer(entity_type, listing, current_user, target_user, db)
+        await _transfer(entity_type, listing, current_user, _target_user(), db, team_role=TeamRole.member)
 
-    assert exc.value.status_code == 409
-    assert "teamspace" in exc.value.detail
+    assert exc.value.status_code == 403
     # Nothing is rehomed, republished, or committed.
     assert listing.team_id == team_id
     assert listing.is_private is is_private
     assert listing.namespace == "platform"
-    owner_field = "created_by" if entity_type == "agents" else "submitted_by"
-    assert getattr(listing, owner_field) == current_user.id
     db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_type", ENTITY_TYPES)
+@pytest.mark.parametrize("is_private", [False, True])
+async def test_teamspace_owner_transfer_detaches_the_listing(entity_type, is_private):
+    """Transfer is the way OUT of a teamspace.
+
+    Refusing outright used to be a dead end: deleting a teamspace requires
+    emptying it, emptying it requires transferring, and transferring refused every
+    team-owned listing. Leaving the teamspace also drops team visibility, because
+    team-private requires a teamspace.
+    """
+    current_user = SimpleNamespace(id=uuid.uuid4())
+    listing = _listing(entity_type, current_user.id, team_id=uuid.uuid4(), is_private=is_private)
+    db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
+
+    await _transfer(entity_type, listing, current_user, _target_user(), db, team_role=TeamRole.owner)
+
+    assert listing.team_id is None
+    assert listing.is_private is False
+    db.commit.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -132,6 +157,10 @@ async def test_team_check_runs_before_the_target_user_is_resolved():
     with (
         patch("api.routes.co_authors._get_entity_for_transfer", new=AsyncMock(return_value=listing)),
         patch("api.routes.co_authors._resolve_target_user", new=resolve_target),
+        patch(
+            "api.routes.co_authors.team_membership", new=AsyncMock(return_value=SimpleNamespace(role=TeamRole.member))
+        ),
+        patch("api.routes.co_authors.is_admin", return_value=False),
         pytest.raises(HTTPException) as exc,
     ):
         await transfer_ownership(
@@ -142,5 +171,5 @@ async def test_team_check_runs_before_the_target_user_is_resolved():
             current_user,
         )
 
-    assert exc.value.status_code == 409
+    assert exc.value.status_code == 403
     resolve_target.assert_not_awaited()

--- a/tests/test_co_authors.py
+++ b/tests/test_co_authors.py
@@ -1,24 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for ownership transfer of teamspace listings.
-
-Transfer rewrites ``namespace`` to the target user's handle and moves the owner
-column. It never touched ``team_id`` or ``is_private``, so a team listing came
-out sitting in a user namespace while still pointing at the teamspace it left,
-and a team-private listing stayed private under an owner with no membership.
-Neither silent repair is acceptable:
-
-- clearing ``team_id`` and forcing ``visibility=public`` would publish a
-  team-private listing as a side effect of a transfer nobody on the team
-  approved, and the publish is irreversible once it is fetched;
-- clearing ``team_id`` while keeping ``is_private=True`` would produce a private
-  listing with no team, which is the legacy user-private shape Feature 3 removes.
-
-So the transfer is refused for any listing that belongs to a teamspace. The
-listing has to leave the teamspace first, which is an explicit, auditable act by
-someone with authority over the team.
-"""
+"""Tests for ownership transfer of personal and teamspace listings."""
 
 from __future__ import annotations
 
@@ -29,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import HTTPException
 
-from api.routes.co_authors import TransferOwnershipRequest, transfer_ownership
+from api.routes.co_authors import TransferOwnershipRequest, _get_entity_for_transfer, transfer_ownership
 from models.team import TeamRole
 
 ENTITY_TYPES = ["agents", "mcps", "skills", "hooks", "prompts", "sandboxes"]
@@ -65,15 +48,11 @@ def _target_user():
     )
 
 
-async def _transfer(entity_type, listing, current_user, target_user, db, *, team_role=None):
-    """Run a transfer. ``team_role`` is the caller's role in the listing's teamspace."""
-    membership = SimpleNamespace(role=team_role) if team_role is not None else None
+async def _transfer(entity_type, listing, current_user, target_user, db):
     with (
         patch("api.routes.co_authors._get_entity_for_transfer", new=AsyncMock(return_value=listing)),
         patch("api.routes.co_authors._resolve_target_user", new=AsyncMock(return_value=target_user)),
         patch("api.routes.co_authors.identity_exists", new=AsyncMock(return_value=False)),
-        patch("api.routes.co_authors.team_membership", new=AsyncMock(return_value=membership)),
-        patch("api.routes.co_authors.is_admin", return_value=False),
         patch("api.routes.co_authors.review_publication_to_public", new=AsyncMock(return_value=True)),
     ):
         return await transfer_ownership(
@@ -95,8 +74,16 @@ async def test_transfer_of_team_listing_needs_a_teamspace_owner(entity_type, is_
     listing = _listing(entity_type, current_user.id, team_id=team_id, is_private=is_private)
     db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
 
-    with pytest.raises(HTTPException) as exc:
-        await _transfer(entity_type, listing, current_user, _target_user(), db, team_role=TeamRole.member)
+    with (
+        patch("api.routes.co_authors.resolve_listing", new=AsyncMock(return_value=listing)),
+        patch(
+            "api.routes.co_authors.team_membership",
+            new=AsyncMock(return_value=SimpleNamespace(role=TeamRole.member)),
+        ),
+        patch("api.routes.co_authors.is_admin", return_value=False),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _get_entity_for_transfer(entity_type, listing.qualified_name, current_user, db)
 
     assert exc.value.status_code == 403
     # Nothing is rehomed, republished, or committed.
@@ -121,7 +108,7 @@ async def test_teamspace_owner_transfer_detaches_the_listing(entity_type, is_pri
     listing = _listing(entity_type, current_user.id, team_id=uuid.uuid4(), is_private=is_private)
     db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
 
-    await _transfer(entity_type, listing, current_user, _target_user(), db, team_role=TeamRole.owner)
+    await _transfer(entity_type, listing, current_user, _target_user(), db)
 
     assert listing.team_id is None
     assert listing.is_private is False
@@ -155,12 +142,11 @@ async def test_team_check_runs_before_the_target_user_is_resolved():
     db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
 
     with (
-        patch("api.routes.co_authors._get_entity_for_transfer", new=AsyncMock(return_value=listing)),
-        patch("api.routes.co_authors._resolve_target_user", new=resolve_target),
         patch(
-            "api.routes.co_authors.team_membership", new=AsyncMock(return_value=SimpleNamespace(role=TeamRole.member))
+            "api.routes.co_authors._get_entity_for_transfer",
+            new=AsyncMock(side_effect=HTTPException(status_code=403, detail="Not authorized")),
         ),
-        patch("api.routes.co_authors.is_admin", return_value=False),
+        patch("api.routes.co_authors._resolve_target_user", new=resolve_target),
         pytest.raises(HTTPException) as exc,
     ):
         await transfer_ownership(

--- a/tests/test_co_authors.py
+++ b/tests/test_co_authors.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ownership transfer of teamspace listings.
+
+Transfer rewrites ``namespace`` to the target user's handle and moves the owner
+column. It never touched ``team_id`` or ``is_private``, so a team listing came
+out sitting in a user namespace while still pointing at the teamspace it left,
+and a team-private listing stayed private under an owner with no membership.
+Neither silent repair is acceptable:
+
+- clearing ``team_id`` and forcing ``visibility=public`` would publish a
+  team-private listing as a side effect of a transfer nobody on the team
+  approved, and the publish is irreversible once it is fetched;
+- clearing ``team_id`` while keeping ``is_private=True`` would produce a private
+  listing with no team, which is the legacy user-private shape Feature 3 removes.
+
+So the transfer is refused for any listing that belongs to a teamspace. The
+listing has to leave the teamspace first, which is an explicit, auditable act by
+someone with authority over the team.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.co_authors import TransferOwnershipRequest, transfer_ownership
+
+ENTITY_TYPES = ["agents", "mcps", "skills", "hooks", "prompts", "sandboxes"]
+
+
+class _Listing(SimpleNamespace):
+    @property
+    def qualified_name(self):
+        return f"{self.namespace}/{self.slug}"
+
+
+def _listing(entity_type, owner_id, *, team_id=None, is_private=False):
+    owner_field = "created_by" if entity_type == "agents" else "submitted_by"
+    return _Listing(
+        id=uuid.uuid4(),
+        owner="platform",
+        namespace="platform" if team_id else "alice",
+        slug="tool",
+        co_authors=[],
+        team_id=team_id,
+        is_private=is_private,
+        owner_org_id=None,
+        **{owner_field: owner_id},
+    )
+
+
+def _target_user():
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        username="bob",
+        email="bob@example.com",
+        auth_provider="local",
+    )
+
+
+async def _transfer(entity_type, listing, current_user, target_user, db):
+    with (
+        patch("api.routes.co_authors._get_entity_for_transfer", new=AsyncMock(return_value=listing)),
+        patch("api.routes.co_authors._resolve_target_user", new=AsyncMock(return_value=target_user)),
+        patch("api.routes.co_authors.identity_exists", new=AsyncMock(return_value=False)),
+    ):
+        return await transfer_ownership(
+            entity_type,
+            listing.qualified_name,
+            TransferOwnershipRequest(username="bob"),
+            db,
+            current_user,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_type", ENTITY_TYPES)
+@pytest.mark.parametrize("is_private", [False, True])
+async def test_transfer_of_team_listing_is_refused(entity_type, is_private):
+    current_user = SimpleNamespace(id=uuid.uuid4())
+    team_id = uuid.uuid4()
+    listing = _listing(entity_type, current_user.id, team_id=team_id, is_private=is_private)
+    target_user = _target_user()
+    db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
+
+    with pytest.raises(HTTPException) as exc:
+        await _transfer(entity_type, listing, current_user, target_user, db)
+
+    assert exc.value.status_code == 409
+    assert "teamspace" in exc.value.detail
+    # Nothing is rehomed, republished, or committed.
+    assert listing.team_id == team_id
+    assert listing.is_private is is_private
+    assert listing.namespace == "platform"
+    owner_field = "created_by" if entity_type == "agents" else "submitted_by"
+    assert getattr(listing, owner_field) == current_user.id
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entity_type", ENTITY_TYPES)
+async def test_transfer_of_personal_listing_still_works(entity_type):
+    current_user = SimpleNamespace(id=uuid.uuid4())
+    listing = _listing(entity_type, current_user.id)
+    target_user = _target_user()
+    db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
+
+    response = await _transfer(entity_type, listing, current_user, target_user, db)
+
+    assert response.qualified_name == "bob/tool"
+    assert listing.team_id is None
+    assert listing.is_private is False
+    owner_field = "created_by" if entity_type == "agents" else "submitted_by"
+    assert getattr(listing, owner_field) == target_user.id
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_team_check_runs_before_the_target_user_is_resolved():
+    """A refused transfer must not disclose whether the target account exists."""
+    current_user = SimpleNamespace(id=uuid.uuid4())
+    listing = _listing("mcps", current_user.id, team_id=uuid.uuid4())
+    resolve_target = AsyncMock(side_effect=AssertionError("target user resolved before the teamspace check"))
+    db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock())
+
+    with (
+        patch("api.routes.co_authors._get_entity_for_transfer", new=AsyncMock(return_value=listing)),
+        patch("api.routes.co_authors._resolve_target_user", new=resolve_target),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await transfer_ownership(
+            "mcps",
+            listing.qualified_name,
+            TransferOwnershipRequest(username="bob"),
+            db,
+            current_user,
+        )
+
+    assert exc.value.status_code == 409
+    resolve_target.assert_not_awaited()

--- a/tests/test_component_update_visibility.py
+++ b/tests/test_component_update_visibility.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for visibility and teamspace fields on the component update routes.
+
+PUT /api/v1/{type}/{listing_id}/draft accepts `visibility` and `team_id` because the
+five *UpdateRequest schemas declare them. The route must never silently discard them.
+Visibility has one authoritative path, PATCH /api/v1/registry/{item_type}/{listing_id}/visibility,
+which carries the audit metadata and the guard that blocks privatizing a component an
+approved public agent depends on, so the update route rejects a real change and points
+at that endpoint. Repeating the values a listing already holds is a no-op and succeeds.
+
+All five component types are covered by the same parametrized cases: no per-type behavior.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user, get_db
+from models.mcp import ListingStatus
+from models.user import User, UserRole
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _user(role=UserRole.user, user_id=None):
+    u = MagicMock(spec=User)
+    u.id = user_id or uuid.uuid4()
+    u.role = role
+    u.email = "test@example.com"
+    u.username = "testuser"
+    u.org_id = None
+    return u
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = AsyncMock()
+    return db
+
+
+def _app_with(router, user):
+    db = _mock_db()
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app, db
+
+
+def _version_mock():
+    """A latest_version row that holds no edit lock, so saves are not blocked."""
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.is_editing = False
+    v.editing_by = None
+    v.editing_since = None
+    v.description = "original description"
+    return v
+
+
+def _listing_mock(submitted_by, *, is_private=False, team_id=None):
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.name = "test-listing"
+    m.namespace = "testowner"
+    m.slug = "test-listing"
+    m.qualified_name = "testowner/test-listing"
+    m.version = "1.0.0"
+    m.description = "A test listing"
+    m.owner = "testowner"
+    m.status = ListingStatus.draft
+    m.rejection_reason = None
+    m.submitted_by = submitted_by
+    m.co_authors = []
+    # Visibility is the axis under test: set both halves explicitly. A bare MagicMock
+    # attribute is truthy, which would make every listing look team-private.
+    m.is_private = is_private
+    m.team_id = team_id
+    m.visibility = "team" if is_private else "public"
+    m.latest_version = _version_mock()
+    m.supported_harnesses = []
+    m.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+    m.updated_at = datetime(2025, 1, 1, tzinfo=UTC)
+    m.category = "general"
+    m.git_url = None
+    m.command = None
+    m.args = None
+    m.url = None
+    m.headers = None
+    m.auto_approve = []
+    m.transport = None
+    m.framework = None
+    m.docker_image = None
+    m.mcp_validated = False
+    m.changelog = None
+    m.setup_instructions = None
+    m.environment_variables = []
+    m.custom_fields = []
+    m.validation_results = []
+    m.download_count = 0
+    m.unique_users = 0
+    m.template = "Hello {{ name }}"
+    m.variables = []
+    m.model_hints = []
+    m.tags = []
+    m.task_type = "code-review"
+    m.target_agents = []
+    m.skill_path = "/"
+    m.git_ref = None
+    m.skill_md_content = None
+    m.delivery_mode = "git_fetch"
+    m.script_content = None
+    m.script_filename = None
+    m.validated = False
+    m.slash_command = None
+    m.event = "PreToolUse"
+    m.execution_mode = "blocking"
+    m.priority = 0
+    m.handler_type = "command"
+    m.handler_config = {}
+    m.input_schema = None
+    m.output_schema = None
+    m.scope = "project"
+    m.tool_filter = None
+    m.file_pattern = None
+    m.requirements = []
+    m.source_url = None
+    m.source_ref = None
+    m.source_path = None
+    m.runtime_type = "docker"
+    m.image = "python:3.11"
+    m.dockerfile_url = None
+    m.resource_limits = {}
+    m.runtime_config = {}
+    m.network_policy = "none"
+    m.allowed_mounts = []
+    m.env_vars = []
+    m.entrypoint = None
+    m.sandbox_path = None
+    return m
+
+
+# ── Endpoint configs for parametrization ─────────────────
+
+# The registry item_type doubles as the route module name (api.routes.<item_type>) and as
+# the path segment of the authoritative visibility endpoint.
+ENDPOINTS = [
+    ("mcp", "/api/v1/mcps"),
+    ("skill", "/api/v1/skills"),
+    ("hook", "/api/v1/hooks"),
+    ("prompt", "/api/v1/prompts"),
+    ("sandbox", "/api/v1/sandboxes"),
+]
+
+
+def _get_router(item_type):
+    import importlib
+
+    return importlib.import_module(f"api.routes.{item_type}").router
+
+
+async def _put_draft(item_type, base_path, listing, user, body):
+    """PUT the update route with resolve_listing pinned to the given listing."""
+    app, db = _app_with(_get_router(item_type), user)
+    module = f"api.routes.{item_type}"
+    with patch(f"{module}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        mock_resolve.return_value = listing
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"{base_path}/{listing.id}/draft", json=body)
+    return r, db
+
+
+# ── Tests ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("item_type,base_path", ENDPOINTS)
+class TestVisibilityChangeRejected:
+    """A visibility change is refused and points at the authoritative endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_public_to_team_rejected(self, item_type, base_path):
+        owner = _user()
+        listing = _listing_mock(owner.id)
+        r, db = await _put_draft(item_type, base_path, listing, owner, {"visibility": "team"})
+
+        assert r.status_code == 400
+        detail = r.json()["detail"]
+        assert f"PATCH /api/v1/registry/{item_type}/{listing.id}/visibility" in detail
+        assert listing.is_private is False
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_team_to_public_rejected(self, item_type, base_path):
+        owner = _user()
+        team_id = uuid.uuid4()
+        listing = _listing_mock(owner.id, is_private=True, team_id=team_id)
+        r, db = await _put_draft(item_type, base_path, listing, owner, {"visibility": "public"})
+
+        assert r.status_code == 400
+        assert f"PATCH /api/v1/registry/{item_type}/{listing.id}/visibility" in r.json()["detail"]
+        assert listing.is_private is True
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admin_is_not_exempt(self, item_type, base_path):
+        """Role does not open a second visibility path: admins use the same endpoint."""
+        admin = _user(role=UserRole.admin)
+        listing = _listing_mock(uuid.uuid4())
+        r, db = await _put_draft(item_type, base_path, listing, admin, {"visibility": "team"})
+
+        assert r.status_code == 400
+        assert listing.is_private is False
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejected_before_other_fields_are_applied(self, item_type, base_path):
+        """A rejected request must not half-apply the rest of the payload."""
+        owner = _user()
+        listing = _listing_mock(owner.id)
+        ver = listing.latest_version
+        r, db = await _put_draft(
+            item_type,
+            base_path,
+            listing,
+            owner,
+            {"visibility": "team", "description": "should not be saved"},
+        )
+
+        assert r.status_code == 400
+        assert ver.description == "original description"
+        db.commit.assert_not_awaited()
+
+
+@pytest.mark.parametrize("item_type,base_path", ENDPOINTS)
+class TestTeamIdChangeRejected:
+    """A teamspace move is refused: no endpoint reassigns a listing's teamspace."""
+
+    @pytest.mark.asyncio
+    async def test_personal_listing_cannot_join_a_team(self, item_type, base_path):
+        owner = _user()
+        listing = _listing_mock(owner.id)
+        r, db = await _put_draft(item_type, base_path, listing, owner, {"team_id": str(uuid.uuid4())})
+
+        assert r.status_code == 400
+        assert "team_id cannot be changed here" in r.json()["detail"]
+        assert listing.team_id is None
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_team_listing_cannot_move_to_another_team(self, item_type, base_path):
+        owner = _user()
+        team_id = uuid.uuid4()
+        listing = _listing_mock(owner.id, is_private=True, team_id=team_id)
+        r, db = await _put_draft(item_type, base_path, listing, owner, {"team_id": str(uuid.uuid4())})
+
+        assert r.status_code == 400
+        assert "team_id cannot be changed here" in r.json()["detail"]
+        assert listing.team_id == team_id
+        db.commit.assert_not_awaited()
+
+
+@pytest.mark.parametrize("item_type,base_path", ENDPOINTS)
+class TestUnchangedUpdatesSucceed:
+    """Edits that do not move visibility still save, including echoed current values."""
+
+    @pytest.mark.asyncio
+    async def test_plain_update_succeeds(self, item_type, base_path):
+        owner = _user()
+        listing = _listing_mock(owner.id)
+        ver = listing.latest_version
+        r, db = await _put_draft(item_type, base_path, listing, owner, {"description": "updated description"})
+
+        assert r.status_code == 200, r.text
+        assert ver.description == "updated description"
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_echoed_public_visibility_is_a_noop(self, item_type, base_path):
+        """The web edit form resends the listing's current visibility on every save."""
+        owner = _user()
+        listing = _listing_mock(owner.id)
+        ver = listing.latest_version
+        r, db = await _put_draft(
+            item_type,
+            base_path,
+            listing,
+            owner,
+            {"visibility": "public", "description": "updated description"},
+        )
+
+        assert r.status_code == 200, r.text
+        assert ver.description == "updated description"
+        assert listing.is_private is False
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_echoed_team_visibility_and_team_id_is_a_noop(self, item_type, base_path):
+        owner = _user()
+        team_id = uuid.uuid4()
+        listing = _listing_mock(owner.id, is_private=True, team_id=team_id)
+        ver = listing.latest_version
+        r, db = await _put_draft(
+            item_type,
+            base_path,
+            listing,
+            owner,
+            {"visibility": "team", "team_id": str(team_id), "description": "updated description"},
+        )
+
+        assert r.status_code == 200, r.text
+        assert ver.description == "updated description"
+        assert listing.is_private is True
+        assert listing.team_id == team_id
+        db.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_all_types_share_one_rejection_message():
+    """The five routes must not diverge: same wording, same status, per type only in the URL."""
+    messages = set()
+    for item_type, base_path in ENDPOINTS:
+        owner = _user()
+        listing = _listing_mock(owner.id)
+        r, _db = await _put_draft(item_type, base_path, listing, owner, {"visibility": "team"})
+        assert r.status_code == 400
+        messages.add(r.json()["detail"].replace(f"/registry/{item_type}/{listing.id}/", "/registry/TYPE/ID/"))
+    assert len(messages) == 1, messages

--- a/tests/test_dashboard_leaderboard.py
+++ b/tests/test_dashboard_leaderboard.py
@@ -3,7 +3,13 @@
 
 from __future__ import annotations
 
+import uuid
+from unittest.mock import MagicMock
+
 from api.routes.dashboard import agent_leaderboard, component_leaderboard, top_agents
+from models.user import User, UserRole
+
+_LISTING_TABLES = ["mcp_listings", "skill_listings", "hook_listings", "prompt_listings", "sandbox_listings"]
 
 
 class _EmptyResult:
@@ -24,13 +30,37 @@ class _CaptureDb:
 
 
 def _sql(stmt) -> str:
-    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    """Compile a statement to a single-line SQL string with bind values inlined."""
+    return " ".join(str(stmt.compile(compile_kwargs={"literal_binds": True})).split())
+
+
+def _caller(role: UserRole = UserRole.user) -> User:
+    user = MagicMock(spec=User)
+    user.id = uuid.uuid4()
+    user.role = role
+    return user
+
+
+def _membership_predicate(table: str, user: User) -> str:
+    """The correlated EXISTS that gates team-private rows on the caller's own membership."""
+    return (
+        "EXISTS (SELECT team_memberships.id FROM team_memberships "
+        f"WHERE team_memberships.team_id = {table}.team_id "
+        f"AND team_memberships.user_id = '{user.id.hex}')"
+    )
+
+
+def _download_queries(db: _CaptureDb) -> list:
+    return [stmt for stmt in db.statements if "agent_download_records" in _sql(stmt)]
+
+
+# ── Deleted-agent exclusion ───────────────────────────────────────────────────
 
 
 async def test_agent_leaderboard_excludes_deleted_agents():
     db = _CaptureDb()
 
-    await agent_leaderboard.__wrapped__(window="all", limit=20, user=None, db=db)
+    await agent_leaderboard(window="all", limit=20, user=None, db=db, current_user=None)
 
     assert db.statements
     assert all("agents.deleted_at IS NULL" in _sql(stmt) for stmt in db.statements)
@@ -39,7 +69,7 @@ async def test_agent_leaderboard_excludes_deleted_agents():
 async def test_top_agents_excludes_deleted_agents():
     db = _CaptureDb()
 
-    await top_agents.__wrapped__(limit=6, db=db)
+    await top_agents(limit=6, db=db, current_user=None)
 
     assert db.statements
     assert "agents.deleted_at IS NULL" in _sql(db.statements[0])
@@ -48,8 +78,97 @@ async def test_top_agents_excludes_deleted_agents():
 async def test_component_leaderboard_ignores_downloads_from_deleted_agents():
     db = _CaptureDb()
 
-    await component_leaderboard.__wrapped__(window="all", limit=20, user=None, db=db)
+    await component_leaderboard(window="all", limit=20, user=None, db=db, current_user=None)
 
-    download_queries = [stmt for stmt in db.statements if "agent_download_records" in _sql(stmt)]
+    download_queries = _download_queries(db)
     assert len(download_queries) == 5
     assert all("agents.deleted_at IS NULL" in _sql(stmt) for stmt in download_queries)
+
+
+# ── Visibility scoping (Feature 3: team_id is the only privacy axis) ──────────
+
+
+async def test_top_agents_hides_team_private_agents_from_anonymous_callers():
+    db = _CaptureDb()
+
+    await top_agents(limit=6, db=db, current_user=None)
+
+    sql = _sql(db.statements[0])
+    assert "agents.is_private = false" in sql
+    assert "agents.is_private = true" not in sql
+    assert "team_memberships" not in sql
+
+
+async def test_top_agents_gates_team_private_agents_on_caller_membership():
+    caller = _caller()
+    outsider = _caller()
+    db = _CaptureDb()
+
+    await top_agents(limit=6, db=db, current_user=caller)
+
+    sql = _sql(db.statements[0])
+    assert _membership_predicate("agents", caller) in sql
+    assert outsider.id.hex not in sql
+
+
+async def test_top_agents_does_not_restrict_visibility_for_reviewers():
+    db = _CaptureDb()
+
+    await top_agents(limit=6, db=db, current_user=_caller(role=UserRole.reviewer))
+
+    sql = _sql(db.statements[0])
+    assert "agents.is_private =" not in sql
+    assert "team_memberships" not in sql
+
+
+async def test_agent_leaderboard_hides_team_private_agents_from_anonymous_callers():
+    db = _CaptureDb()
+
+    await agent_leaderboard(window="all", limit=20, user=None, db=db, current_user=None)
+
+    assert db.statements
+    for stmt in db.statements:
+        sql = _sql(stmt)
+        assert "agents.is_private = false" in sql
+        assert "team_memberships" not in sql
+
+
+async def test_agent_leaderboard_gates_team_private_agents_on_caller_membership():
+    caller = _caller()
+    outsider = _caller()
+    db = _CaptureDb()
+
+    await agent_leaderboard(window="all", limit=20, user=None, db=db, current_user=caller)
+
+    assert db.statements
+    for stmt in db.statements:
+        sql = _sql(stmt)
+        assert _membership_predicate("agents", caller) in sql
+        assert outsider.id.hex not in sql
+
+
+async def test_component_leaderboard_hides_team_private_rows_from_anonymous_callers():
+    db = _CaptureDb()
+
+    await component_leaderboard(window="all", limit=20, user=None, db=db, current_user=None)
+
+    assert all("team_memberships" not in _sql(stmt) for stmt in db.statements)
+    for table, stmt in zip(_LISTING_TABLES, _download_queries(db), strict=True):
+        sql = _sql(stmt)
+        assert "agents.is_private = false" in sql
+        assert f"{table}.is_private = false" in sql
+        assert f"{table}.is_private = true" not in sql
+
+
+async def test_component_leaderboard_gates_team_private_rows_on_caller_membership():
+    caller = _caller()
+    outsider = _caller()
+    db = _CaptureDb()
+
+    await component_leaderboard(window="all", limit=20, user=None, db=db, current_user=caller)
+
+    for table, stmt in zip(_LISTING_TABLES, _download_queries(db), strict=True):
+        sql = _sql(stmt)
+        assert _membership_predicate("agents", caller) in sql
+        assert _membership_predicate(table, caller) in sql
+        assert outsider.id.hex not in sql

--- a/tests/test_dashboard_leaderboard.py
+++ b/tests/test_dashboard_leaderboard.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import uuid
 from unittest.mock import MagicMock
 
+import pytest
+
 from api.routes.dashboard import agent_leaderboard, component_leaderboard, top_agents
 from models.user import User, UserRole
 
@@ -111,14 +113,29 @@ async def test_top_agents_gates_team_private_agents_on_caller_membership():
     assert outsider.id.hex not in sql
 
 
-async def test_top_agents_does_not_restrict_visibility_for_reviewers():
+@pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
+async def test_top_agents_does_not_restrict_visibility_for_admins(role):
     db = _CaptureDb()
 
-    await top_agents(limit=6, db=db, current_user=_caller(role=UserRole.reviewer))
+    await top_agents(limit=6, db=db, current_user=_caller(role=role))
 
     sql = _sql(db.statements[0])
     assert "agents.is_private =" not in sql
     assert "team_memberships" not in sql
+
+
+async def test_top_agents_gates_a_global_reviewer_on_membership_like_anyone_else():
+    """A leaderboard is a public ranking, so another team's private agents stay out.
+
+    The global reviewer role reviews the public catalog; team-private agents are
+    reviewed inside their own teamspace, so only admins skip the filter here.
+    """
+    reviewer = _caller(role=UserRole.reviewer)
+    db = _CaptureDb()
+
+    await top_agents(limit=6, db=db, current_user=reviewer)
+
+    assert _membership_predicate("agents", reviewer) in _sql(db.statements[0])
 
 
 async def test_agent_leaderboard_hides_team_private_agents_from_anonymous_callers():

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -25,6 +25,7 @@ from httpx import ASGITransport, AsyncClient
 from api.deps import get_current_user, get_db
 from api.routes.agent import router
 from models.agent import AgentStatus
+from models.team import TeamRole
 from models.user import User, UserRole
 
 # ── Helpers ──────────────────────────────────────────────
@@ -47,6 +48,26 @@ def _mock_db():
     db.refresh = AsyncMock()
     db.delete = MagicMock()
     db.flush = AsyncMock()
+    return db
+
+
+def _membership(role: TeamRole):
+    m = MagicMock()
+    m.role = role
+    return m
+
+
+def _db_with_membership(membership):
+    """Mock db whose only query, the teamspace membership lookup, yields *membership*.
+
+    A bare AsyncMock returns AsyncMock children, so `result.scalar_one_or_none()`
+    would hand back an un-awaited coroutine instead of a row. Wire `execute`
+    explicitly so the membership lookup behaves like a real AsyncSession.
+    """
+    db = _mock_db()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = membership
+    db.execute = AsyncMock(return_value=result)
     return db
 
 
@@ -79,6 +100,9 @@ def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
     m.unique_users = 0
     m.owner_org_id = None
     m.git_url = None
+    # team_id is the sole privacy axis: None means a personal listing.
+    m.team_id = extra.get("team_id")
+    m.is_private = extra.get("is_private", False)
     m.created_by = created_by or uuid.uuid4()
     m.created_at = datetime.now(UTC)
     m.deleted_at = None
@@ -89,6 +113,8 @@ def _agent_mock(status=AgentStatus.draft, created_by=None, **extra):
     m.latest_version.editing_by = None
     m.latest_version.editing_since = None
     m.latest_version.prompt = extra.get("prompt", "Test prompt")
+    m.latest_version.reviewed_by = None
+    m.latest_version.reviewed_at = None
     # Make __table__.columns iterable for _agent_to_response
     col_keys = [
         "id",
@@ -141,6 +167,49 @@ def _empty_result():
     r.scalars.return_value.all.return_value = []
     r.scalar_one_or_none.return_value = None
     return r
+
+
+def _component_mock(component_type="mcp", component_id=None):
+    """Return a MagicMock that looks like an AgentComponent row."""
+    c = MagicMock()
+    c.component_type = component_type
+    c.component_id = component_id or uuid.uuid4()
+    c.resolved_version = "1.0.0"
+    c.order_index = 0
+    c.config_override = None
+    return c
+
+
+def _scalar_result(value):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    return r
+
+
+def _rows_result(rows):
+    r = MagicMock()
+    r.all.return_value = rows
+    return r
+
+
+def _approved_listing(name="public-mcp"):
+    from models.mcp import ListingStatus
+
+    listing = MagicMock()
+    listing.status = ListingStatus.approved
+    listing.name = name
+    return listing
+
+
+def _sequenced_db(*results):
+    """Mock db whose successive `execute` calls yield *results* in order.
+
+    Anything beyond the listed calls raises StopIteration, so an unexpected
+    extra query fails the test instead of silently returning a MagicMock.
+    """
+    db = _mock_db()
+    db.execute = AsyncMock(side_effect=list(results))
+    return db
 
 
 def _result_with_agent(agent):
@@ -265,12 +334,270 @@ class TestDraftUpdate:
 
 
 # ═══════════════════════════════════════════════════════════
+# update_draft visibility changes (Feature 3 composition policy)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDraftVisibilityChange:
+    """A visibility flip revalidates the attached components and checks team role."""
+
+    @staticmethod
+    def _team_agent(user, *, is_private, components):
+        return _agent_mock(
+            status=AgentStatus.draft,
+            created_by=user.id,
+            team_id=uuid.uuid4(),
+            is_private=is_private,
+            components=components,
+        )
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_team_to_public_rejects_private_component(self, mock_load):
+        """Going public with a team-private component attached is a 409 naming it."""
+        user = _user()
+        component = _component_mock()
+        agent = self._team_agent(user, is_private=True, components=[component])
+        db = _sequenced_db(
+            _scalar_result(_membership(TeamRole.owner)),  # team role gate
+            _scalar_result(None),  # component is outside the public scope
+            _rows_result([(component.component_id, "secret-mcp")]),  # name lookup
+        )
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"visibility": "public"})
+
+        assert r.status_code == 409
+        assert "secret-mcp" in r.json()["detail"]
+        # The flip must not be applied when the composition check fails.
+        assert agent.is_private is True
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_team_to_public_allows_public_components(self, mock_load):
+        """Going public succeeds when every attached component is public."""
+        user = _user()
+        component = _component_mock()
+        agent = self._team_agent(user, is_private=True, components=[component])
+        db = _sequenced_db(
+            _scalar_result(_membership(TeamRole.owner)),
+            _scalar_result(_approved_listing()),
+        )
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"visibility": "public"})
+
+        assert r.status_code == 200
+        assert agent.is_private is False
+        assert r.json()["visibility"] == "public"
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_public_to_team_requires_teamspace(self, mock_load):
+        """Team visibility without a teamspace is a 422, with no component queries."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, is_private=False)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"visibility": "team"})
+
+        assert r.status_code == 422
+        assert r.json()["detail"] == "Team visibility requires a teamspace"
+        assert agent.is_private is False
+        db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_public_to_team_allowed_for_team_owner(self, mock_load):
+        """A team owner may take a public team agent private."""
+        user = _user()
+        component = _component_mock()
+        agent = self._team_agent(user, is_private=False, components=[component])
+        db = _sequenced_db(
+            _scalar_result(_membership(TeamRole.owner)),
+            _scalar_result(_approved_listing()),
+        )
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"visibility": "team"})
+
+        assert r.status_code == 200
+        assert agent.is_private is True
+        assert r.json()["visibility"] == "team"
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_plain_team_member_cannot_flip_visibility(self, mock_load):
+        """A plain team member is refused before any component work happens."""
+        user = _user()
+        agent = self._team_agent(user, is_private=True, components=[_component_mock()])
+        db = _sequenced_db(_scalar_result(_membership(TeamRole.member)))
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"visibility": "public"})
+
+        assert r.status_code == 403
+        assert r.json()["detail"] == "Only team owners and reviewers can change visibility"
+        assert agent.is_private is True
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_unchanged_visibility_skips_revalidation(self, mock_load):
+        """Echoing the current visibility back is a no-op, not a team-role check."""
+        user = _user()
+        agent = self._team_agent(user, is_private=True, components=[_component_mock()])
+        db = _sequenced_db()  # any query at all would raise StopIteration
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"visibility": "team"})
+
+        assert r.status_code == 200
+        assert agent.is_private is True
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_resent_components_are_validated_against_new_target(self, mock_load):
+        """When components are resent, they are checked against the new visibility."""
+        user = _user()
+        agent = self._team_agent(user, is_private=True, components=[_component_mock()])
+        new_component_id = uuid.uuid4()
+        db = _sequenced_db(
+            _scalar_result(_membership(TeamRole.owner)),
+            _scalar_result(None),  # the resent component is not public
+        )
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(
+                f"/api/v1/agents/{agent.id}/draft",
+                json={
+                    "visibility": "public",
+                    "components": [{"component_type": "mcp", "component_id": str(new_component_id)}],
+                },
+            )
+
+        assert r.status_code == 400
+        assert r.json()["detail"][0]["component_id"] == str(new_component_id)
+        db.commit.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════
+# update_draft fields that must never be silently dropped
+# ═══════════════════════════════════════════════════════════
+
+
+class TestDraftUpdateFieldHandling:
+    """Every accepted request field is either applied or refused explicitly."""
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_rejects_teamspace_move(self, mock_load):
+        """A different team_id is refused instead of being ignored."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, team_id=uuid.uuid4(), is_private=True)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"team_id": str(uuid.uuid4())})
+
+        assert r.status_code == 422
+        assert "Teamspace cannot be changed here" in r.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_accepts_unchanged_teamspace(self, mock_load):
+        """Resending the agent's own team_id is a no-op, not an error."""
+        user = _user()
+        team_id = uuid.uuid4()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, team_id=team_id, is_private=True)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"team_id": str(team_id)})
+
+        assert r.status_code == 200
+        assert agent.team_id == team_id
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_rejects_legacy_mcp_server_ids(self, mock_load):
+        """The draft route never wired mcp_server_ids up, so it refuses them."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"mcp_server_ids": [str(uuid.uuid4())]})
+
+        assert r.status_code == 422
+        assert "components" in r.json()["detail"]
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_applies_category(self, mock_load):
+        """category reaches the agent row instead of being dropped."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"category": "devops"})
+
+        assert r.status_code == 200
+        assert agent.category == "devops"
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_applies_version_bump_type(self, mock_load):
+        """version_bump_type bumps the draft version instead of being dropped."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, version="1.2.3")
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"version_bump_type": "minor"})
+
+        assert r.status_code == 200
+        assert agent.latest_version.version == "1.3.0"
+
+
+# ═══════════════════════════════════════════════════════════
 # submit_draft (POST /api/v1/agents/{id}/submit)
 # ═══════════════════════════════════════════════════════════
 
 
 class TestDraftSubmit:
-    """Test submitting a draft for review."""
+    """Test submitting a personal draft for review."""
 
     @pytest.mark.asyncio
     @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
@@ -278,7 +605,7 @@ class TestDraftSubmit:
     @patch("api.routes.agent.draft._resolve_component_names")
     @patch("api.routes.agent.draft._load_agent")
     async def test_transitions_to_pending(self, mock_load, mock_resolve, mock_emit):
-        """POST /agents/{id}/submit transitions a draft to pending status."""
+        """POST /agents/{id}/submit transitions a personal draft to pending status."""
         user = _user()
         app, db, _ = _app_with(user=user)
         agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, components=[])
@@ -311,6 +638,137 @@ class TestDraftSubmit:
 
         data = r.json()
         assert data["status"] == "pending"
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft.emit_registry_event")
+    @patch("api.routes.agent.draft._resolve_component_names")
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_personal_draft_never_auto_approves(self, mock_load, mock_resolve, mock_emit):
+        """A draft with no teamspace always goes to review, never straight to approved."""
+        user = _user()
+        app, db, _ = _app_with(user=user)
+        agent = _agent_mock(status=AgentStatus.draft, created_by=user.id, components=[])
+        mock_load.return_value = agent
+        mock_resolve.return_value = {}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 200
+        assert agent.status == AgentStatus.pending
+        assert agent.latest_version.reviewed_by is None
+        assert agent.latest_version.reviewed_at is None
+        # No teamspace means no membership lookup is needed at all.
+        db.execute.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════
+# Submit a team-owned draft (Feature 3 publishing rules)
+# ═══════════════════════════════════════════════════════════
+
+
+class TestTeamDraftSubmit:
+    """Team owners and team reviewers publish without review; members do not."""
+
+    @staticmethod
+    def _submit_team_draft(user, membership):
+        agent = _agent_mock(
+            status=AgentStatus.draft,
+            created_by=user.id,
+            components=[],
+            team_id=uuid.uuid4(),
+            is_private=True,
+        )
+        db = _db_with_membership(membership)
+        return agent, db
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft.emit_registry_event")
+    @patch("api.routes.agent.draft._resolve_component_names")
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_team_owner_auto_approves(self, mock_load, mock_resolve, mock_emit):
+        """A team owner submitting a team draft publishes it immediately."""
+        user = _user()
+        agent, db = self._submit_team_draft(user, _membership(TeamRole.owner))
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+        mock_resolve.return_value = {}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 200
+        assert r.json()["status"] == "approved"
+        assert agent.status == AgentStatus.approved
+        assert agent.latest_version.reviewed_by == user.id
+        assert isinstance(agent.latest_version.reviewed_at, datetime)
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft.emit_registry_event")
+    @patch("api.routes.agent.draft._resolve_component_names")
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_team_reviewer_auto_approves(self, mock_load, mock_resolve, mock_emit):
+        """A team reviewer submitting a team draft publishes it immediately."""
+        user = _user()
+        agent, db = self._submit_team_draft(user, _membership(TeamRole.reviewer))
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+        mock_resolve.return_value = {}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 200
+        assert r.json()["status"] == "approved"
+        assert agent.status == AgentStatus.approved
+        assert agent.latest_version.reviewed_by == user.id
+        assert isinstance(agent.latest_version.reviewed_at, datetime)
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft.emit_registry_event")
+    @patch("api.routes.agent.draft._resolve_component_names")
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_plain_team_member_goes_to_pending(self, mock_load, mock_resolve, mock_emit):
+        """A plain team member cannot self-publish; the draft waits for review."""
+        user = _user()
+        agent, db = self._submit_team_draft(user, _membership(TeamRole.member))
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+        mock_resolve.return_value = {}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 200
+        assert r.json()["status"] == "pending"
+        assert agent.status == AgentStatus.pending
+        assert agent.latest_version.reviewed_by is None
+        assert agent.latest_version.reviewed_at is None
+
+    @pytest.mark.asyncio
+    @patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot"))
+    @patch("api.routes.agent.draft.emit_registry_event")
+    @patch("api.routes.agent.draft._resolve_component_names")
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_global_reviewer_auto_approves_without_membership(self, mock_load, mock_resolve, mock_emit):
+        """A global reviewer publishes a team draft even with no membership row."""
+        user = _user(role=UserRole.reviewer)
+        agent, db = self._submit_team_draft(user, None)
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+        mock_resolve.return_value = {}
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(f"/api/v1/agents/{agent.id}/submit")
+
+        assert r.status_code == 200
+        assert r.json()["status"] == "approved"
+        assert agent.status == AgentStatus.approved
+        assert agent.latest_version.reviewed_by == user.id
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_insights_access.py
+++ b/tests/test_insights_access.py
@@ -361,10 +361,32 @@ async def test_admin_only_report_routes_allow_admins(route):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("route", REPORT_ROUTES)
 async def test_report_routes_reject_global_reviewer(route):
-    """Reviewers are privileged for visibility but not for session telemetry.
+    """Reviewers are privileged for review status but not for session telemetry.
 
-    check_listing_visibility_async lets a reviewer past gate 1 even on a
-    team-private agent, so the 403 here proves gate 2 is independent.
+    The agent here is PUBLIC, so gate 1 (visibility) admits the reviewer and the
+    403 comes from gate 2 (ownership) alone. That is what proves the two gates are
+    independent. A team-private agent would prove nothing, because gate 1 already
+    rejects a global reviewer who is not in the team.
+    """
+    from models.user import UserRole
+
+    agent = _agent(created_by=uuid.uuid4(), is_private=False)
+    report = _report(agent.id)
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_report_route(route, str(report.id), _report_db(report, agent), _user(role=UserRole.reviewer))
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", REPORT_ROUTES)
+async def test_report_routes_hide_a_team_private_agent_from_a_global_reviewer(route):
+    """Gate 1 answers first, and it no longer admits a global reviewer.
+
+    Team-private content is reviewed inside its own teamspace, so an outside
+    reviewer gets "not found" rather than the 403 that would confirm the report
+    exists.
     """
     from models.user import UserRole
 
@@ -374,7 +396,7 @@ async def test_report_routes_reject_global_reviewer(route):
     with pytest.raises(HTTPException) as exc:
         await _call_report_route(route, str(report.id), _report_db(report, agent), _user(role=UserRole.reviewer))
 
-    assert exc.value.status_code == 403
+    assert exc.value.status_code == 404
 
 
 def test_no_route_bypasses_the_permission_gate():

--- a/tests/test_insights_access.py
+++ b/tests/test_insights_access.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorization matrix for the insights routes.
+
+Insight reports are derived from an agent's private session telemetry, so every
+insights route needs two independent gates:
+
+1. visibility (`check_listing_visibility_async` / `apply_visibility_filter`),
+   which answers "does this agent exist for you" and produces 404.
+2. permission (`_require_agent_edit_access`), which answers "do you own it" and
+   produces 403. Only the creator, a co-author, or an admin passes.
+
+Team membership feeds gate 1 only. A team member who is not the creator, a
+co-author, or an admin therefore resolves a team-private agent and is refused
+with 403. A global reviewer is privileged for gate 1 and refused by gate 2 for
+the same reason: reviewing a registry submission never requires reading the
+session transcripts of everyone who ran the agent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _result(value):
+    """Mock a SQLAlchemy Result whose scalar_one_or_none yields *value*."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    result.scalars.return_value.all.return_value = [value] if value is not None else []
+    return result
+
+
+def _user(role=None, user_id: uuid.UUID | None = None):
+    from models.user import UserRole
+
+    return SimpleNamespace(id=user_id or uuid.uuid4(), role=role or UserRole.user)
+
+
+def _agent(*, created_by: uuid.UUID, is_private: bool = False, team_id=None, co_authors=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name="ultra-pi",
+        created_by=created_by,
+        is_private=is_private,
+        team_id=team_id,
+        co_authors=co_authors or [],
+    )
+
+
+def _report(agent_id: uuid.UUID):
+    from models.insight_report import InsightReportStatus
+
+    now = datetime.now(UTC)
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        agent_id=agent_id,
+        agent_version_id=None,
+        agent_version="1.0.0",
+        version_scope="canonical_and_dirty",
+        comparison_agent_version_id=None,
+        comparison_agent_version=None,
+        triggered_by=None,
+        status=InsightReportStatus.completed,
+        period_start=now,
+        period_end=now,
+        metrics={},
+        narrative={},
+        sessions_analyzed=3,
+        llm_model_used=None,
+        error_message=None,
+        started_at=now,
+        completed_at=now,
+        created_at=now,
+    )
+
+
+def _agent_db(agent, *, membership=None):
+    """DB mock for routes that resolve an agent by id."""
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(agent))
+    db.scalar = AsyncMock(return_value=membership)
+    return db
+
+
+def _report_db(report, agent, *, membership=None):
+    """DB mock for report routes: they load the report, then its agent."""
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_result(report), _result(agent)])
+    db.scalar = AsyncMock(return_value=membership)
+    return db
+
+
+# Routes reached through _resolve_insights_agent.
+AGENT_ROUTES = ("agent_session_count", "generate_insight", "list_reports", "clear_agent_reports")
+
+# Routes reached through _authorize_report_agent.
+REPORT_ROUTES = ("get_report", "export_report_html", "delete_report", "apply_report_suggestions")
+
+
+async def _call_agent_route(name: str, agent_id: str, db, user):
+    import api.routes.insights as insights
+
+    if name == "agent_session_count":
+        return await insights.agent_session_count(agent_id, None, db, user)
+    if name == "generate_insight":
+        return await insights.generate_insight(agent_id, None, db, user)
+    return await getattr(insights, name)(agent_id, db, user)
+
+
+async def _call_report_route(name: str, report_id: str, db, user):
+    import api.routes.insights as insights
+
+    if name == "apply_report_suggestions":
+        with (
+            patch("services.dynamic_settings.get_bool", new=AsyncMock(return_value=True)),
+            patch("services.insights.self_learn.apply_insight_suggestions", new=AsyncMock(return_value={})),
+        ):
+            return await insights.apply_report_suggestions(report_id, None, db, user)
+    if name == "export_report_html":
+        with patch("api.routes.insights.render_report_html", return_value="<html></html>"):
+            return await insights.export_report_html(report_id, db, user)
+    return await getattr(insights, name)(report_id, db, user)
+
+
+# ---------------------------------------------------------------------------
+# _require_agent_edit_access: the helper the regression neutered
+# ---------------------------------------------------------------------------
+
+
+def test_effective_agent_permission_never_returns_none():
+    """The regression compared against 'none', which this helper never returns.
+
+    Any insights gate written as `== "none"` is therefore dead code. This test
+    pins the helper's real return set so that shape cannot come back unnoticed.
+    """
+    from api.deps import get_effective_agent_permission
+    from models.user import UserRole
+
+    creator_id = uuid.uuid4()
+    agent = _agent(created_by=creator_id)
+
+    assert get_effective_agent_permission(agent, _user(user_id=creator_id)) == "owner"
+    assert get_effective_agent_permission(agent, _user(role=UserRole.admin)) == "owner"
+    assert get_effective_agent_permission(agent, _user(role=UserRole.reviewer)) == "view"
+    assert get_effective_agent_permission(agent, _user()) == "view"
+
+
+@pytest.mark.parametrize("role_name", ["user", "reviewer"])
+def test_require_agent_edit_access_rejects_non_owners(role_name):
+    """A stranger and a global reviewer are both refused, whatever the agent."""
+    from api.routes.insights import _require_agent_edit_access
+    from models.user import UserRole
+
+    agent = _agent(created_by=uuid.uuid4())
+
+    with pytest.raises(HTTPException) as exc:
+        _require_agent_edit_access(agent, _user(role=getattr(UserRole, role_name)))
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Insufficient permissions for this agent"
+
+
+def test_require_agent_edit_access_allows_creator_co_author_and_admin():
+    from api.routes.insights import _require_agent_edit_access
+    from models.user import UserRole
+
+    creator_id = uuid.uuid4()
+    co_author_id = uuid.uuid4()
+    agent = _agent(created_by=creator_id, co_authors=[co_author_id])
+
+    _require_agent_edit_access(agent, _user(user_id=creator_id))
+    _require_agent_edit_access(agent, _user(user_id=co_author_id))
+    _require_agent_edit_access(agent, _user(role=UserRole.admin))
+    _require_agent_edit_access(agent, _user(role=UserRole.super_admin))
+
+
+# ---------------------------------------------------------------------------
+# Agent-scoped routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", AGENT_ROUTES)
+async def test_agent_routes_reject_unrelated_user_on_public_agent(route):
+    """REGRESSION: any authenticated user could read insights for any public agent."""
+    agent = _agent(created_by=uuid.uuid4(), is_private=False)
+    stranger = _user()
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_agent_route(route, str(agent.id), _agent_db(agent), stranger)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Insufficient permissions for this agent"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", AGENT_ROUTES)
+async def test_agent_routes_hide_team_private_agent_from_non_member(route):
+    """Visibility, not permission: an outsider must not learn the agent exists."""
+    agent = _agent(created_by=uuid.uuid4(), is_private=True, team_id=uuid.uuid4())
+    outsider = _user()
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_agent_route(route, str(agent.id), _agent_db(agent, membership=None), outsider)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Agent not found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", AGENT_ROUTES)
+async def test_agent_routes_reject_team_member_who_does_not_own_the_agent(route):
+    """Documented answer: a member sees the agent (no 404) but cannot read insights."""
+    agent = _agent(created_by=uuid.uuid4(), is_private=True, team_id=uuid.uuid4())
+    member = _user()
+    db = _agent_db(agent, membership=uuid.uuid4())
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_agent_route(route, str(agent.id), db, member)
+
+    assert exc.value.status_code == 403
+    db.scalar.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("actor", ["creator", "co_author", "admin"])
+async def test_list_reports_allows_owners_and_admins(actor):
+    from api.routes.insights import list_reports
+    from models.user import UserRole
+
+    creator_id = uuid.uuid4()
+    co_author_id = uuid.uuid4()
+    agent = _agent(created_by=creator_id, co_authors=[co_author_id])
+    users = {
+        "creator": _user(user_id=creator_id),
+        "co_author": _user(user_id=co_author_id),
+        "admin": _user(role=UserRole.admin),
+    }
+
+    empty_reports = MagicMock()
+    empty_reports.scalars.return_value.all.return_value = []
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_result(agent), empty_reports])
+    db.scalar = AsyncMock(return_value=None)
+
+    assert await list_reports(str(agent.id), db, users[actor]) == []
+
+
+# ---------------------------------------------------------------------------
+# Report-scoped routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", REPORT_ROUTES)
+async def test_report_routes_reject_unrelated_user_on_public_agent(route):
+    """REGRESSION: read, export, delete and apply must all gate on ownership.
+
+    delete and apply additionally sit behind require_role(admin) at the routing
+    layer; the in-function gate is asserted here as defense in depth so a future
+    change to the role dependency cannot silently open them.
+    """
+    agent = _agent(created_by=uuid.uuid4(), is_private=False)
+    report = _report(agent.id)
+    stranger = _user()
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_report_route(route, str(report.id), _report_db(report, agent), stranger)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Insufficient permissions for this agent"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", REPORT_ROUTES)
+async def test_report_routes_hide_team_private_agent_from_non_member(route):
+    agent = _agent(created_by=uuid.uuid4(), is_private=True, team_id=uuid.uuid4())
+    report = _report(agent.id)
+    outsider = _user()
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_report_route(route, str(report.id), _report_db(report, agent, membership=None), outsider)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Report not found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", REPORT_ROUTES)
+async def test_report_routes_reject_team_member_who_does_not_own_the_agent(route):
+    agent = _agent(created_by=uuid.uuid4(), is_private=True, team_id=uuid.uuid4())
+    report = _report(agent.id)
+    db = _report_db(report, agent, membership=uuid.uuid4())
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_report_route(route, str(report.id), db, _user())
+
+    assert exc.value.status_code == 403
+    db.scalar.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", REPORT_ROUTES)
+async def test_report_routes_fail_loudly_when_the_agent_row_is_missing(route):
+    """A report whose agent row is gone is unreachable, never an unchecked pass.
+
+    delete and apply previously skipped every check in that case because the
+    guard read `if agent and ...`.
+    """
+    agent_id = uuid.uuid4()
+    report = _report(agent_id)
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_report_route(route, str(report.id), _report_db(report, None), _user())
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Report not found"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["get_report", "export_report_html"])
+@pytest.mark.parametrize("actor", ["creator", "co_author", "admin"])
+async def test_report_routes_allow_owners_and_admins(route, actor):
+    from models.user import UserRole
+
+    creator_id = uuid.uuid4()
+    co_author_id = uuid.uuid4()
+    agent = _agent(created_by=creator_id, co_authors=[co_author_id])
+    report = _report(agent.id)
+    users = {
+        "creator": _user(user_id=creator_id),
+        "co_author": _user(user_id=co_author_id),
+        "admin": _user(role=UserRole.admin),
+    }
+
+    response = await _call_report_route(route, str(report.id), _report_db(report, agent), users[actor])
+
+    assert response is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["delete_report", "apply_report_suggestions"])
+async def test_admin_only_report_routes_allow_admins(route):
+    from models.user import UserRole
+
+    agent = _agent(created_by=uuid.uuid4())
+    report = _report(agent.id)
+
+    result = await _call_report_route(route, str(report.id), _report_db(report, agent), _user(role=UserRole.admin))
+
+    assert result is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", REPORT_ROUTES)
+async def test_report_routes_reject_global_reviewer(route):
+    """Reviewers are privileged for visibility but not for session telemetry.
+
+    check_listing_visibility_async lets a reviewer past gate 1 even on a
+    team-private agent, so the 403 here proves gate 2 is independent.
+    """
+    from models.user import UserRole
+
+    agent = _agent(created_by=uuid.uuid4(), is_private=True, team_id=uuid.uuid4())
+    report = _report(agent.id)
+
+    with pytest.raises(HTTPException) as exc:
+        await _call_report_route(route, str(report.id), _report_db(report, agent), _user(role=UserRole.reviewer))
+
+    assert exc.value.status_code == 403
+
+
+def test_no_route_bypasses_the_permission_gate():
+    """Every agent-touching route in insights.py routes through one of the gates.
+
+    A new handler that loads an agent without calling _resolve_insights_agent or
+    _authorize_report_agent fails here rather than shipping unguarded.
+    """
+    import ast
+    import inspect
+
+    import api.routes.insights as insights
+
+    source = inspect.getsource(insights)
+    tree = ast.parse(source)
+    gates = {"_resolve_insights_agent", "_authorize_report_agent", "_require_agent_edit_access"}
+    exempt = {"insights_status"} | gates
+
+    unguarded = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name.startswith("_"):
+            continue
+        if node.name in exempt:
+            continue
+        called = {
+            child.func.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+        }
+        if not called & gates:
+            unguarded.append(node.name)
+
+    assert unguarded == [], f"insights routes missing an authorization gate: {unguarded}"
+
+
+def test_module_imports_do_not_reference_org_scoping():
+    """Feature 3 removed org scoping. It must not creep back into this module."""
+    import inspect
+
+    import api.routes.insights as insights
+
+    source = inspect.getsource(insights)
+    assert "org_id" not in source
+    assert "owner_org_id" not in source

--- a/tests/test_insights_agent_lookup.py
+++ b/tests/test_insights_agent_lookup.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 
 import uuid
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+
+
+def _result(value):
+    """Mock a SQLAlchemy Result whose scalar_one_or_none yields *value*."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    result.scalars.return_value.all.return_value = [value] if value is not None else []
+    return result
 
 
 @pytest.mark.asyncio
@@ -16,23 +24,119 @@ async def test_resolve_insights_agent_accepts_agent_name():
     from api.routes.insights import _resolve_insights_agent
     from models.user import UserRole
 
-    org_id = uuid.uuid4()
     user_id = uuid.uuid4()
-    user = SimpleNamespace(id=user_id, org_id=org_id, role=UserRole.user)
-    agent = SimpleNamespace(id=uuid.uuid4(), name="ultra-pi", created_by=user_id, owner_org_id=org_id, co_authors=[])
+    user = SimpleNamespace(id=user_id, role=UserRole.user)
+    agent = SimpleNamespace(id=uuid.uuid4(), name="ultra-pi", created_by=user_id, is_private=False, co_authors=[])
     db = AsyncMock()
 
     with patch("api.routes.insights._load_agent", new=AsyncMock(return_value=agent)) as load_agent:
         resolved = await _resolve_insights_agent("ultra-pi", db, user)
 
     assert resolved is agent
+    # The loader evaluates team membership itself, so it takes the caller, not an
+    # organization id. Organization scoping is not part of registry visibility.
     load_agent.assert_awaited_once_with(
         db,
         "ultra-pi",
         prefer_user_id=user_id,
-        org_id=org_id,
+        current_user=user,
         include_all_statuses=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_resolve_insights_agent_hides_team_private_agent_from_non_member():
+    """A non-member gets the not-found path, never a leak, for a team-private agent."""
+    from api.routes.insights import _resolve_insights_agent
+    from models.user import UserRole
+
+    agent_id = uuid.uuid4()
+    agent = SimpleNamespace(
+        id=agent_id,
+        name="team-only",
+        created_by=uuid.uuid4(),
+        is_private=True,
+        team_id=uuid.uuid4(),
+        co_authors=[],
+    )
+    outsider = SimpleNamespace(id=uuid.uuid4(), role=UserRole.user)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(agent))
+    db.scalar = AsyncMock(return_value=None)  # no team membership row
+
+    with pytest.raises(HTTPException) as exc:
+        await _resolve_insights_agent(str(agent_id), db, outsider)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Agent not found"
+    db.scalar.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_insights_agent_denies_team_member_who_does_not_own_the_agent():
+    """A team member clears visibility but is still refused insights on someone else's agent.
+
+    Team membership decides whether the agent is visible (404 versus found). It is
+    not an ownership axis, so the member gets 403 here and not 404: that split is
+    the documented behaviour, and it proves the membership lookup actually ran.
+    """
+    from api.routes.insights import _resolve_insights_agent
+    from models.user import UserRole
+
+    agent_id = uuid.uuid4()
+    agent = SimpleNamespace(
+        id=agent_id,
+        name="team-only",
+        created_by=uuid.uuid4(),
+        is_private=True,
+        team_id=uuid.uuid4(),
+        co_authors=[],
+    )
+    member = SimpleNamespace(id=uuid.uuid4(), role=UserRole.user)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(agent))
+    db.scalar = AsyncMock(return_value=uuid.uuid4())  # membership row exists
+
+    with pytest.raises(HTTPException) as exc:
+        await _resolve_insights_agent(str(agent_id), db, member)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Insufficient permissions for this agent"
+    db.scalar.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_insights_agent_allows_creator_of_team_private_agent():
+    """The creator of a team-private agent resolves it through both gates.
+
+    Membership still has to be present: check_listing_visibility_async treats a
+    team-private item as reachable through the teamspace only, so authorship alone
+    does not survive removal from the team.
+    """
+    from api.routes.insights import _resolve_insights_agent
+    from models.user import UserRole
+
+    agent_id = uuid.uuid4()
+    creator_id = uuid.uuid4()
+    agent = SimpleNamespace(
+        id=agent_id,
+        name="team-only",
+        created_by=creator_id,
+        is_private=True,
+        team_id=uuid.uuid4(),
+        co_authors=[],
+    )
+    creator = SimpleNamespace(id=creator_id, role=UserRole.user)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_result(agent))
+    db.scalar = AsyncMock(return_value=uuid.uuid4())  # creator is a member of the teamspace
+
+    resolved = await _resolve_insights_agent(str(agent_id), db, creator)
+
+    assert resolved is agent
 
 
 @pytest.mark.asyncio
@@ -40,7 +144,7 @@ async def test_resolve_insights_agent_raises_404_for_missing_name():
     from api.routes.insights import _resolve_insights_agent
     from models.user import UserRole
 
-    user = SimpleNamespace(id=uuid.uuid4(), org_id=None, role=UserRole.user)
+    user = SimpleNamespace(id=uuid.uuid4(), role=UserRole.user)
     db = AsyncMock()
 
     with (

--- a/tests/test_listing_detail_access.py
+++ b/tests/test_listing_detail_access.py
@@ -59,7 +59,7 @@ def _app_with(router, user=None):
     return app
 
 
-def _listing_mock(status=ListingStatus.approved, submitted_by=None):
+def _listing_mock(status=ListingStatus.approved, submitted_by=None, is_private=False, team_id=None):
     m = MagicMock()
     m.id = uuid.uuid4()
     m.name = "test-listing"
@@ -72,7 +72,13 @@ def _listing_mock(status=ListingStatus.approved, submitted_by=None):
     m.status = status
     m.rejection_reason = None
     m.submitted_by = submitted_by or uuid.uuid4()
-    m.owner_org_id = None
+    m.co_authors = []
+    # Privacy is a separate axis from status: set it explicitly so these tests
+    # exercise status gating only. A bare MagicMock attribute is truthy, which
+    # would silently make every listing look team-private.
+    m.is_private = is_private
+    m.team_id = team_id
+    m.visibility = "team" if is_private else "public"
     m.supported_harnesses = []
     m.created_at = datetime(2025, 1, 1, tzinfo=UTC)
     m.updated_at = datetime(2025, 1, 1, tzinfo=UTC)
@@ -132,12 +138,18 @@ def _listing_mock(status=ListingStatus.approved, submitted_by=None):
 # ── Endpoint configs for parametrization ─────────────────
 
 ENDPOINTS = [
-    ("mcp", "/api/v1/mcps", "api.routes.mcp"),
-    ("prompt", "/api/v1/prompts", "api.routes.prompt"),
-    ("skill", "/api/v1/skills", "api.routes.skill"),
-    ("hook", "/api/v1/hooks", "api.routes.hook"),
-    ("sandbox", "/api/v1/sandboxes", "api.routes.sandbox"),
+    ("mcp", "/api/v1/mcps"),
+    ("prompt", "/api/v1/prompts"),
+    ("skill", "/api/v1/skills"),
+    ("hook", "/api/v1/hooks"),
+    ("sandbox", "/api/v1/sandboxes"),
 ]
+
+# The route modules resolve listings through api.deps.resolve_visible_listing,
+# which calls the module-global resolve_listing inside api.deps. That is the only
+# seam a patch can intercept; patching api.routes.<type>.resolve_listing rebinds a
+# name the detail handlers never call.
+RESOLVE_SEAM = "api.deps.resolve_listing"
 
 
 def _get_router(route_type):
@@ -159,17 +171,17 @@ def _get_router(route_type):
 # ── Tests ────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize("route_type,base_path,module_path", ENDPOINTS)
+@pytest.mark.parametrize("route_type,base_path", ENDPOINTS)
 class TestUnauthenticatedAccess:
     """Unauthenticated users can only see approved listings."""
 
     @pytest.mark.asyncio
-    async def test_sees_approved(self, route_type, base_path, module_path):
+    async def test_sees_approved(self, route_type, base_path):
         router = _get_router(route_type)
         listing = _listing_mock(status=ListingStatus.approved)
         app = _app_with(router, user=None)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.return_value = listing
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
@@ -180,30 +192,30 @@ class TestUnauthenticatedAccess:
         "status",
         [ListingStatus.draft, ListingStatus.pending, ListingStatus.rejected, ListingStatus.archived],
     )
-    async def test_blocked_from_non_approved(self, route_type, base_path, module_path, status):
+    async def test_blocked_from_non_approved(self, route_type, base_path, status):
         router = _get_router(route_type)
         listing = _listing_mock(status=status)
         app = _app_with(router, user=None)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.side_effect = [None, listing]
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
             assert r.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_nonexistent_returns_404(self, route_type, base_path, module_path):
+    async def test_nonexistent_returns_404(self, route_type, base_path):
         router = _get_router(route_type)
         app = _app_with(router, user=None)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.side_effect = [None, None]
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{uuid.uuid4()}")
             assert r.status_code == 404
 
 
-@pytest.mark.parametrize("route_type,base_path,module_path", ENDPOINTS)
+@pytest.mark.parametrize("route_type,base_path", ENDPOINTS)
 class TestOwnerAccess:
     """Listing owners can see their own listings in any status."""
 
@@ -212,20 +224,20 @@ class TestOwnerAccess:
         "status",
         [ListingStatus.draft, ListingStatus.pending, ListingStatus.rejected],
     )
-    async def test_owner_sees_own_non_approved(self, route_type, base_path, module_path, status):
+    async def test_owner_sees_own_non_approved(self, route_type, base_path, status):
         owner = _user()
         router = _get_router(route_type)
         listing = _listing_mock(status=status, submitted_by=owner.id)
         app = _app_with(router, user=owner)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.side_effect = [None, listing]
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
             assert r.status_code == 200
 
 
-@pytest.mark.parametrize("route_type,base_path,module_path", ENDPOINTS)
+@pytest.mark.parametrize("route_type,base_path", ENDPOINTS)
 class TestNonOwnerRegularUser:
     """Non-owner regular users cannot see non-approved listings."""
 
@@ -234,57 +246,57 @@ class TestNonOwnerRegularUser:
         "status",
         [ListingStatus.draft, ListingStatus.pending],
     )
-    async def test_blocked_from_others_non_approved(self, route_type, base_path, module_path, status):
+    async def test_blocked_from_others_non_approved(self, route_type, base_path, status):
         other_user = _user()
         router = _get_router(route_type)
         listing = _listing_mock(status=status)
         app = _app_with(router, user=other_user)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.side_effect = [None, listing]
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
             assert r.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_sees_approved(self, route_type, base_path, module_path):
+    async def test_sees_approved(self, route_type, base_path):
         other_user = _user()
         router = _get_router(route_type)
         listing = _listing_mock(status=ListingStatus.approved)
         app = _app_with(router, user=other_user)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.return_value = listing
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
             assert r.status_code == 200
 
 
-@pytest.mark.parametrize("route_type,base_path,module_path", ENDPOINTS)
+@pytest.mark.parametrize("route_type,base_path", ENDPOINTS)
 class TestPrivilegedAccess:
     """Admins and reviewers can see any listing in any status."""
 
     @pytest.mark.asyncio
-    async def test_reviewer_sees_pending(self, route_type, base_path, module_path):
+    async def test_reviewer_sees_pending(self, route_type, base_path):
         reviewer = _user(role=UserRole.reviewer)
         router = _get_router(route_type)
         listing = _listing_mock(status=ListingStatus.pending)
         app = _app_with(router, user=reviewer)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.side_effect = [None, listing]
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
             assert r.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_admin_sees_draft(self, route_type, base_path, module_path):
+    async def test_admin_sees_draft(self, route_type, base_path):
         admin = _user(role=UserRole.admin)
         router = _get_router(route_type)
         listing = _listing_mock(status=ListingStatus.draft)
         app = _app_with(router, user=admin)
 
-        with patch(f"{module_path}.resolve_listing", new_callable=AsyncMock) as mock_resolve:
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
             mock_resolve.side_effect = [None, listing]
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")

--- a/tests/test_listing_detail_access.py
+++ b/tests/test_listing_detail_access.py
@@ -38,17 +38,21 @@ def _user(role=UserRole.user, user_id=None, **kw):
     return u
 
 
-def _mock_db():
+def _mock_db(membership=None):
     db = AsyncMock()
     db.add = MagicMock()
     db.commit = AsyncMock()
     db.refresh = AsyncMock()
     db.delete = AsyncMock()
+    # check_listing_visibility_async resolves team membership with db.scalar.
+    # A bare AsyncMock returns a truthy sentinel, which would make every caller
+    # look like a team member, so the membership row is always explicit here.
+    db.scalar = AsyncMock(return_value=membership)
     return db
 
 
-def _app_with(router, user=None):
-    db = _mock_db()
+def _app_with(router, user=None, membership=None):
+    db = _mock_db(membership)
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[get_db] = lambda: db
@@ -301,3 +305,86 @@ class TestPrivilegedAccess:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
                 r = await ac.get(f"{base_path}/{listing.id}")
             assert r.status_code == 200
+
+
+# ── Privacy is a different axis from status ──────────────
+#
+# Status decides whether an item is ready to be shown; privacy decides who the
+# item belongs to. The detail routes run both gates, and only the status one
+# admits a global reviewer. A reviewer reviews the PUBLIC catalog, so a
+# team-private listing has to answer the membership question for them exactly as
+# it does for any other user.
+
+
+@pytest.mark.parametrize("route_type,base_path", ENDPOINTS)
+class TestTeamPrivateAccess:
+    """A team-private listing is readable through membership or an admin role only."""
+
+    @staticmethod
+    async def _get(route_type, base_path, user, *, membership, status=ListingStatus.approved):
+        router = _get_router(route_type)
+        listing = _listing_mock(status=status, is_private=True, team_id=uuid.uuid4())
+        app = _app_with(router, user=user, membership=membership)
+
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = listing
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                return await ac.get(f"{base_path}/{listing.id}")
+
+    @pytest.mark.asyncio
+    async def test_global_reviewer_outside_the_team_is_denied(self, route_type, base_path):
+        reviewer = _user(role=UserRole.reviewer)
+
+        r = await self._get(route_type, base_path, reviewer, membership=None)
+
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_global_reviewer_outside_the_team_is_denied_for_pending_too(self, route_type, base_path):
+        """The status gate must not hand a reviewer a private item it cannot own.
+
+        ``may_view_unapproved`` says yes to a reviewer for any pending item, so the
+        404 here proves the privacy gate runs first and independently.
+        """
+        reviewer = _user(role=UserRole.reviewer)
+
+        r = await self._get(route_type, base_path, reviewer, membership=None, status=ListingStatus.pending)
+
+        assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
+    async def test_admins_still_read_it(self, route_type, base_path, role):
+        r = await self._get(route_type, base_path, _user(role=role), membership=None)
+
+        assert r.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_team_member_reads_it(self, route_type, base_path):
+        r = await self._get(route_type, base_path, _user(), membership=uuid.uuid4())
+
+        assert r.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_reviewer_who_is_a_team_member_reads_it(self, route_type, base_path):
+        """Membership admits the reviewer; the global role never did."""
+        reviewer = _user(role=UserRole.reviewer)
+
+        r = await self._get(route_type, base_path, reviewer, membership=uuid.uuid4())
+
+        assert r.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_reviewer_still_reads_a_pending_public_listing(self, route_type, base_path):
+        """The mirror case: narrowing privacy must leave the review queue working."""
+        reviewer = _user(role=UserRole.reviewer)
+        router = _get_router(route_type)
+        listing = _listing_mock(status=ListingStatus.pending)
+        app = _app_with(router, user=reviewer, membership=None)
+
+        with patch(RESOLVE_SEAM, new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.side_effect = [None, listing]
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+                r = await ac.get(f"{base_path}/{listing.id}")
+
+        assert r.status_code == 200

--- a/tests/test_listing_version_flush.py
+++ b/tests/test_listing_version_flush.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Every listing model must survive a flush that touches its version too.
+
+Each listing pairs a one-to-many ``versions`` with a many-to-one ``latest_version``
+pointing back into the same table. Without ``post_update=True`` on that
+many-to-one, SQLAlchemy cannot order a unit of work containing both a dirty
+listing and a dirty version, and raises CircularDependencyError.
+
+Two real endpoints hit this:
+
+* ``POST /api/v1/{type}/submit`` deletes a non-approved listing of the same
+  identity before recreating it, which deletes the listing and its versions in
+  one flush. That returned a 500 on any resubmit of a pending or rejected name.
+* ``PATCH /api/v1/registry/{type}/{id}/visibility`` writes ``is_private`` on the
+  listing and, when a team-private listing goes public, ``status`` on its version.
+
+Agent already declared post_update=True. These tests pin the five component
+listing models to the same behaviour so the two shapes cannot regress.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from models.base import Base
+from models.hook import HookListing, HookVersion
+from models.mcp import ListingStatus, McpListing, McpVersion
+from models.prompt import PromptListing, PromptVersion
+from models.sandbox import SandboxListing, SandboxVersion
+from models.skill import SkillListing, SkillVersion
+
+# (listing model, version model, non-null listing columns, non-null version columns)
+LISTING_MODELS = [
+    (McpListing, McpVersion, {"category": "general"}, {}),
+    (SkillListing, SkillVersion, {}, {"task_type": "testing"}),
+    (HookListing, HookVersion, {}, {"event": "PreToolUse", "handler_type": "command"}),
+    (PromptListing, PromptVersion, {}, {"category": "testing", "template": "hi"}),
+    (SandboxListing, SandboxVersion, {}, {"runtime_type": "docker", "image": "python:3.11"}),
+]
+IDS = [m.__name__ for m, _, _, _ in LISTING_MODELS]
+
+
+@asynccontextmanager
+async def _sessions(listing_model, version_model):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            # Create every table: the listings cascade into download and
+            # validation tables that a delete has to reach.
+            await conn.run_sync(Base.metadata.create_all)
+        yield async_sessionmaker(engine, expire_on_commit=False)
+    finally:
+        await engine.dispose()
+
+
+async def _seed(sessions, listing_model, version_model, extra, version_extra, status=ListingStatus.pending):
+    owner_id = uuid.uuid4()
+    listing = listing_model(
+        id=uuid.uuid4(),
+        name="thing",
+        namespace="alice",
+        slug="thing",
+        owner="alice",
+        submitted_by=owner_id,
+        is_private=True,
+        co_authors=[],
+        **extra,
+    )
+    version = version_model(
+        id=uuid.uuid4(),
+        listing_id=listing.id,
+        version="1.0.0",
+        description="seed",
+        released_by=owner_id,
+        released_at=datetime(2026, 1, 1, tzinfo=UTC),
+        status=status,
+        **version_extra,
+    )
+    async with sessions() as session:
+        session.add(listing)
+        await session.flush()
+        session.add(version)
+        await session.flush()
+        listing.latest_version_id = version.id
+        await session.commit()
+    return listing.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("listing_model", "version_model", "extra", "version_extra"), LISTING_MODELS, ids=IDS)
+async def test_deleting_a_listing_and_its_version_flushes(listing_model, version_model, extra, version_extra):
+    """The resubmit path: submit deletes a non-approved listing of the same name."""
+    async with _sessions(listing_model, version_model) as sessions:
+        listing_id = await _seed(sessions, listing_model, version_model, extra, version_extra)
+        async with sessions() as session:
+            listing = await session.get(listing_model, listing_id)
+            await session.delete(listing)
+            await session.flush()
+            await session.commit()
+        async with sessions() as session:
+            assert await session.get(listing_model, listing_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("listing_model", "version_model", "extra", "version_extra"), LISTING_MODELS, ids=IDS)
+async def test_listing_and_version_fields_change_in_one_flush(listing_model, version_model, extra, version_extra):
+    """The visibility path: is_private on the listing, status on its version."""
+    async with _sessions(listing_model, version_model) as sessions:
+        listing_id = await _seed(
+            sessions, listing_model, version_model, extra, version_extra, status=ListingStatus.approved
+        )
+        async with sessions() as session:
+            listing = await session.get(listing_model, listing_id)
+            listing.is_private = False
+            listing.status = ListingStatus.pending
+            await session.commit()
+        async with sessions() as session:
+            listing = await session.get(listing_model, listing_id)
+            assert listing.is_private is False
+            assert listing.status == ListingStatus.pending
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("listing_model", "version_model", "extra", "version_extra"), LISTING_MODELS, ids=IDS)
+async def test_latest_version_relationship_uses_post_update(listing_model, version_model, extra, version_extra):
+    """Pin the mapper setting, so the fix cannot be removed without a failure."""
+    relationship = listing_model.__mapper__.relationships["latest_version"]
+    assert relationship.post_update is True

--- a/tests/test_preview_config.py
+++ b/tests/test_preview_config.py
@@ -196,3 +196,105 @@ class TestPreviewConfigNoComponents:
             )
 
         assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestPreviewConfigVisibility:
+    """Preview renders real component content, so it must apply the same
+    visibility rules as every other read path.
+
+    A team-private MCP command, hook handler, prompt template, or SKILL.md must
+    never reach a caller who is not a member of the owning teamspace. Selecting a
+    component in the builder UI is not an authorization boundary: the endpoint
+    takes raw component ids from the request body.
+    """
+
+    @staticmethod
+    def _db_returning(rows):
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = rows
+        db.execute = AsyncMock(return_value=result)
+        return db
+
+    async def test_invisible_component_returns_404(self):
+        """A component the caller cannot see is reported as not found."""
+        hidden_id = str(uuid.uuid4())
+        app, _db, _u = _app_with(db=self._db_returning([]))
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            res = await client.post(
+                "/api/v1/agents/preview-config",
+                json={
+                    "name": "probe",
+                    "description": "",
+                    "prompt": "",
+                    "model_name": "",
+                    "components": [{"component_type": "skill", "component_id": hidden_id}],
+                },
+            )
+
+        assert res.status_code == 404
+        # Same wording a genuinely nonexistent id would produce, so the response is
+        # not an existence oracle for team-private listings.
+        assert res.json()["detail"] == f"Component not found: {hidden_id}"
+
+    async def test_visibility_filter_applied_to_every_component_query(self):
+        """Every component lookup is scoped to the requesting user."""
+        from unittest.mock import patch
+
+        seen = []
+
+        def _spy(stmt, model, current_user):
+            seen.append((model.__name__, current_user))
+            return stmt
+
+        user = _user()
+        app, _db, _u = _app_with(user=user, db=self._db_returning([]))
+
+        with patch("api.routes.preview.apply_visibility_filter", side_effect=_spy):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                res = await client.post(
+                    "/api/v1/agents/preview-config",
+                    json={
+                        "name": "probe",
+                        "description": "",
+                        "prompt": "",
+                        "model_name": "",
+                        "components": [
+                            {"component_type": "mcp", "component_id": str(uuid.uuid4())},
+                            {"component_type": "skill", "component_id": str(uuid.uuid4())},
+                            {"component_type": "hook", "component_id": str(uuid.uuid4())},
+                            {"component_type": "prompt", "component_id": str(uuid.uuid4())},
+                        ],
+                    },
+                )
+
+        assert res.status_code == 404
+        assert {m for m, _ in seen} == {"McpListing", "SkillListing", "HookListing", "PromptListing"}
+        assert all(u is user for _, u in seen)
+
+    async def test_no_component_lookup_without_visibility_filter(self):
+        """The endpoint issues no unfiltered component query."""
+        from unittest.mock import patch
+
+        db = self._db_returning([])
+        app, _db, _u = _app_with(db=db)
+
+        with patch("api.routes.preview.apply_visibility_filter", side_effect=lambda s, m, u: s) as spy:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                await client.post(
+                    "/api/v1/agents/preview-config",
+                    json={
+                        "name": "probe",
+                        "description": "",
+                        "prompt": "",
+                        "model_name": "",
+                        "components": [{"component_type": "mcp", "component_id": str(uuid.uuid4())}],
+                    },
+                )
+
+        assert db.execute.await_count == spy.call_count == 1

--- a/tests/test_pull_and_agent_cli.py
+++ b/tests/test_pull_and_agent_cli.py
@@ -859,27 +859,72 @@ class TestAgentAdd:
         assert "not found" in result.output
 
 
+_TEAM_UUID = "6f3c4b1a-9d2e-4f5a-8c7b-1e2d3f4a5b6c"
+
+
+def _validate_call(mock_post_fn):
+    """Return the payload the CLI sent to the agent composition validator."""
+    for call in mock_post_fn.call_args_list:
+        if call[0][0] == "/api/v1/agents/validate":
+            return call[0][1]
+    raise AssertionError(f"composition validation was never called: {mock_post_fn.call_args_list}")
+
+
 class TestAgentBuild:
     def test_validates_components_against_server(self, tmp_path: Path):
-        """Components are validated via GET calls; output shows results."""
-        _make_agent_yaml(
-            tmp_path,
-            components=[
-                {"component_type": "mcp", "component_id": "id-1"},
-                {"component_type": "skill", "component_id": "id-2"},
-            ],
-        )
+        """Components are validated via GET calls, then scope-checked on the server."""
+        components = [
+            {"component_type": "mcp", "component_id": "id-1"},
+            {"component_type": "skill", "component_id": "id-2"},
+        ]
+        _make_agent_yaml(tmp_path, components=components)
 
         def mock_get(path, **kwargs):
             return {"id": "id-1", "name": "test"}
 
-        with _patch_config(), patch("observal_cli.client.get", side_effect=mock_get):
+        with (
+            _patch_config(),
+            patch("observal_cli.client.get", side_effect=mock_get),
+            _patch_post({"valid": True, "issues": []}) as mock_post_fn,
+        ):
             result = runner.invoke(
                 cli_app,
                 ["agent", "build", "--dir", str(tmp_path)],
             )
         assert result.exit_code == 0, result.output
         assert "All components valid" in result.output
+
+        payload = _validate_call(mock_post_fn)
+        assert payload["components"] == components
+        assert payload["visibility"] == "public"
+        assert "team_id" not in payload
+
+    def test_sends_publish_target_to_composition_validation(self, tmp_path: Path):
+        """--team/--visibility are resolved and sent to the composition validator."""
+        _make_agent_yaml(
+            tmp_path,
+            components=[{"component_type": "skill", "component_id": "id-1"}],
+        )
+
+        def mock_get(path, **kwargs):
+            if path == "/api/v1/teams/all":
+                return [{"id": _TEAM_UUID, "handle": "platform"}]
+            return {"id": "id-1", "name": "test"}
+
+        with (
+            _patch_config(),
+            patch("observal_cli.client.get", side_effect=mock_get),
+            _patch_post({"valid": True, "issues": []}) as mock_post_fn,
+        ):
+            result = runner.invoke(
+                cli_app,
+                ["agent", "build", "--dir", str(tmp_path), "--team", "@platform", "--visibility", "team"],
+            )
+        assert result.exit_code == 0, result.output
+
+        payload = _validate_call(mock_post_fn)
+        assert payload["visibility"] == "team"
+        assert payload["team_id"] == _TEAM_UUID
 
     def test_reports_invalid_components(self, tmp_path: Path):
         """Components that fail GET show as errors."""
@@ -893,13 +938,52 @@ class TestAgentBuild:
         def mock_get(path, **kwargs):
             raise typer.Exit(code=1)
 
-        with _patch_config(), patch("observal_cli.client.get", side_effect=mock_get):
+        with (
+            _patch_config(),
+            patch("observal_cli.client.get", side_effect=mock_get),
+            _patch_post({"valid": True, "issues": []}),
+        ):
             result = runner.invoke(
                 cli_app,
                 ["agent", "build", "--dir", str(tmp_path)],
             )
         assert result.exit_code != 0
         assert "failed validation" in result.output
+        assert "mcp:bad-id" in result.output
+
+    def test_reports_server_scope_issues(self, tmp_path: Path):
+        """A scope issue from the server fails the build and is shown to the user."""
+        _make_agent_yaml(
+            tmp_path,
+            components=[{"component_type": "skill", "component_id": "id-1"}],
+        )
+
+        def mock_get(path, **kwargs):
+            return {"id": "id-1", "name": "test"}
+
+        scope_result = {
+            "valid": False,
+            "issues": [
+                {
+                    "severity": "error",
+                    "component_type": "skill",
+                    "component_id": "id-1",
+                    "message": "Component belongs to another teamspace",
+                }
+            ],
+        }
+        with (
+            _patch_config(),
+            patch("observal_cli.client.get", side_effect=mock_get),
+            _patch_post(scope_result),
+        ):
+            result = runner.invoke(
+                cli_app,
+                ["agent", "build", "--dir", str(tmp_path)],
+            )
+        assert result.exit_code != 0
+        assert "failed validation" in result.output
+        assert "Component belongs to another teamspace" in result.output
 
     def test_fails_if_no_yaml(self, tmp_path: Path):
         """Fails if observal-agent.yaml does not exist."""
@@ -913,9 +997,14 @@ class TestAgentBuild:
 
 class TestAgentPublish:
     def test_creates_agent_via_post(self, tmp_path: Path):
-        """publish sends correct payload via POST."""
+        """publish sends correct payload via POST and reports the pending status."""
         _make_agent_yaml(tmp_path)
-        mock_result = {"id": "new-agent-uuid", "name": "test-agent"}
+        mock_result = {
+            "id": "new-agent-uuid",
+            "name": "test-agent",
+            "qualified_name": "tester/test-agent",
+            "status": "pending",
+        }
 
         with _patch_config(), _patch_post(mock_result) as mock_post_fn:
             result = runner.invoke(
@@ -923,8 +1012,11 @@ class TestAgentPublish:
                 ["agent", "publish", "--dir", str(tmp_path)],
             )
         assert result.exit_code == 0, result.output
-        assert "Agent submitted for review" in result.output
+        assert "Agent submitted!" in result.output
         assert "new-agent-uuid" in result.output
+        assert "observal pull tester/test-agent" in result.output
+        # A public publish stays in the review queue, so the CLI must say so.
+        assert "an admin must approve it" in result.output
 
         # Verify the POST payload
         call_args = mock_post_fn.call_args
@@ -932,6 +1024,35 @@ class TestAgentPublish:
         assert payload["name"] == "test-agent"
         assert payload["version"] == "1.0.0"
         assert payload["model_name"] == "claude-sonnet-4"
+        assert payload["visibility"] == "public"
+
+    def test_team_publish_reports_auto_approval(self, tmp_path: Path):
+        """A team publish auto-approves, so no review warning is printed."""
+        _make_agent_yaml(tmp_path)
+        mock_result = {
+            "id": "new-agent-uuid",
+            "name": "test-agent",
+            "qualified_name": "platform/test-agent",
+            "status": "approved",
+        }
+
+        with (
+            _patch_config(),
+            _patch_get([{"id": _TEAM_UUID, "handle": "platform"}]),
+            _patch_post(mock_result) as mock_post_fn,
+        ):
+            result = runner.invoke(
+                cli_app,
+                ["agent", "publish", "--dir", str(tmp_path), "--team", "@platform", "--visibility", "team"],
+            )
+        assert result.exit_code == 0, result.output
+        assert "Agent submitted!" in result.output
+        assert "observal pull platform/test-agent" in result.output
+        assert "must approve" not in result.output
+
+        payload = mock_post_fn.call_args[0][1]
+        assert payload["visibility"] == "team"
+        assert payload["team_id"] == _TEAM_UUID
 
     def test_updates_existing_agent_with_update_flag(self, tmp_path: Path):
         """--update finds agent by name then PUTs."""

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -688,45 +688,107 @@ class TestFeedbackExtension:
 # ═══════════════════════════════════════════════════════════
 
 
-@pytest.mark.asyncio
-async def test_component_lists_apply_namespace_and_type_filters():
-    from fastapi import Response
-
+def _list_endpoint_cases():
+    """Every registry list route with its listing table, type filter, and expected filter value."""
     from api.routes.hook import list_hooks
     from api.routes.mcp import list_mcps
     from api.routes.prompt import list_prompts
     from api.routes.sandbox import list_sandboxes
     from api.routes.skill import list_skills
 
-    cases = [
-        (list_mcps.__wrapped__, {"category": "developer-tools"}, "developer-tools"),
-        (list_skills.__wrapped__, {"task_type": "testing", "target_agent": None}, "testing"),
-        (list_hooks.__wrapped__, {"event": "Stop", "scope": None}, "Stop"),
-        (list_prompts.__wrapped__, {"category": "testing"}, "testing"),
-        (list_sandboxes.__wrapped__, {"runtime_type": "docker"}, "docker"),
+    return [
+        (list_mcps, "mcp_listings", {"category": "developer-tools"}, "developer-tools"),
+        (list_skills, "skill_listings", {"task_type": "testing", "target_agent": None, "harness": None}, "testing"),
+        (list_hooks, "hook_listings", {"event": "Stop", "scope": None}, "Stop"),
+        (list_prompts, "prompt_listings", {"category": "testing"}, "testing"),
+        (list_sandboxes, "sandbox_listings", {"runtime_type": "docker"}, "docker"),
     ]
 
-    for list_items, filters, expected in cases:
-        db = _mock_db()
-        result = MagicMock()
-        result.scalars.return_value.all.return_value = []
-        db.execute.return_value = result
-        db.scalar.return_value = 0
-        await list_items(
-            response=Response(),
-            namespace="Alice",
-            search=None,
-            limit=50,
-            offset=0,
-            db=db,
-            current_user=None,
-            **filters,
-        )
-        statement = db.execute.await_args.args[0]
+
+async def _run_list(list_items, filters, *, current_user, namespace="Alice"):
+    """Call a registry list route directly and return the SELECT it executed.
+
+    The routes carry no response cache, so every argument is passed explicitly:
+    unset FastAPI ``Query`` defaults are sentinel objects, not ``None``.
+    """
+    from fastapi import Response
+
+    db = _mock_db()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    db.execute.return_value = result
+    db.scalar.return_value = 0
+    await list_items(
+        response=Response(),
+        namespace=namespace,
+        search=None,
+        team_id=None,
+        public_only=False,
+        limit=50,
+        offset=0,
+        db=db,
+        current_user=current_user,
+        **filters,
+    )
+    return db.execute.await_args.args[0]
+
+
+def _inline_sql(statement) -> str:
+    """Compile a statement to a single-line SQL string with bind values inlined."""
+    return " ".join(str(statement.compile(compile_kwargs={"literal_binds": True})).split())
+
+
+def _membership_predicate(table: str, user) -> str:
+    """The correlated EXISTS that gates team-private listings on the caller's own membership."""
+    return (
+        f"{table}.is_private = true AND {table}.team_id IS NOT NULL "
+        "AND (EXISTS (SELECT team_memberships.id FROM team_memberships "
+        f"WHERE team_memberships.team_id = {table}.team_id "
+        f"AND team_memberships.user_id = '{user.id.hex}'))"
+    )
+
+
+@pytest.mark.asyncio
+async def test_component_lists_apply_namespace_and_type_filters():
+    for list_items, _table, filters, expected in _list_endpoint_cases():
+        statement = await _run_list(list_items, filters, current_user=None)
         sql = str(statement)
         params = set(statement.compile().params.values())
         assert ".namespace" in sql
         assert {"alice", expected}.issubset(params)
+
+
+@pytest.mark.asyncio
+async def test_component_lists_hide_team_private_listings_from_anonymous_callers():
+    for list_items, table, filters, _expected in _list_endpoint_cases():
+        sql = _inline_sql(await _run_list(list_items, filters, current_user=None))
+        assert f"{table}.is_private = false" in sql
+        assert f"{table}.is_private = true" not in sql
+        assert "team_memberships" not in sql
+
+
+@pytest.mark.asyncio
+async def test_component_lists_gate_team_private_listings_on_caller_membership():
+    """A team-private listing is reachable only through a membership row for the caller.
+
+    The same predicate both excludes non-members and includes members, and it is
+    bound to the calling user's id, so no other user's rows can leak in.
+    """
+    caller = _user(role=UserRole.user)
+    outsider = _user(role=UserRole.user)
+    for list_items, table, filters, _expected in _list_endpoint_cases():
+        sql = _inline_sql(await _run_list(list_items, filters, current_user=caller))
+        assert _membership_predicate(table, caller) in sql
+        assert outsider.id.hex not in sql
+
+
+@pytest.mark.asyncio
+async def test_component_lists_do_not_restrict_visibility_for_reviewers():
+    reviewer = _user(role=UserRole.reviewer)
+    for list_items, table, filters, _expected in _list_endpoint_cases():
+        sql = _inline_sql(await _run_list(list_items, filters, current_user=reviewer))
+        assert f"{table}.is_private =" not in sql
+        assert "team_memberships" not in sql
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -723,6 +723,7 @@ async def _run_list(list_items, filters, *, current_user, namespace="Alice"):
         namespace=namespace,
         search=None,
         team_id=None,
+        composable_for_team_id=None,
         public_only=False,
         limit=50,
         offset=0,

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -783,12 +783,26 @@ async def test_component_lists_gate_team_private_listings_on_caller_membership()
 
 
 @pytest.mark.asyncio
-async def test_component_lists_do_not_restrict_visibility_for_reviewers():
+@pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
+async def test_component_lists_do_not_restrict_visibility_for_admins(role):
+    admin = _user(role=role)
+    for list_items, table, filters, _expected in _list_endpoint_cases():
+        sql = _inline_sql(await _run_list(list_items, filters, current_user=admin))
+        assert f"{table}.is_private =" not in sql
+        assert "team_memberships" not in sql
+
+
+@pytest.mark.asyncio
+async def test_component_lists_gate_a_global_reviewer_on_membership_like_anyone_else():
+    """The global reviewer role reviews the public catalog, not other teams' rows.
+
+    Team-private items are reviewed inside their own teamspace, so a reviewer gets
+    the same membership predicate as a plain user and only admins skip it.
+    """
     reviewer = _user(role=UserRole.reviewer)
     for list_items, table, filters, _expected in _list_endpoint_cases():
         sql = _inline_sql(await _run_list(list_items, filters, current_user=reviewer))
-        assert f"{table}.is_private =" not in sql
-        assert "team_memberships" not in sql
+        assert _membership_predicate(table, reviewer) in sql
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_registry_visibility.py
+++ b/tests/test_registry_visibility.py
@@ -1,0 +1,666 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for /api/v1/registry visibility enforcement.
+
+Two holes are covered here:
+
+1. GET /api/v1/registry/resolve returned the canonical identity of any listing
+   whose latest version was not approved, to anyone. The endpoint resolves with
+   ``require_status=approved`` first and falls back to an unfiltered lookup, and
+   that fallback had no status gate. Resolution now matches the component detail
+   handlers: non-approved items resolve only for owners, co-authors, admins and
+   reviewers.
+
+2. PATCH /api/v1/registry/{type}/{id}/visibility only inspected the latest
+   version of each public agent before letting a component go team-private.
+   Installs can pin any approved version (``POST /agents/{id}/install`` with a
+   ``version``), so an older approved version of a public agent kept a dangling
+   reference that fails the install-time component scope check. The guard now
+   covers every approved version of a public agent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api.deps import get_db, optional_current_user
+
+# api.routes.registry is imported eagerly on purpose: it binds resolve_listing at
+# import time, so a first import that happened inside a patch() block would
+# capture the mock for the rest of the session.
+from api.routes.registry import (
+    VisibilityUpdateRequest,
+    update_registry_visibility,
+)
+from api.routes.registry import router as registry_router
+from models.agent import Agent, AgentStatus, AgentVersion
+from models.agent_component import AgentComponent
+from models.base import Base
+from models.mcp import ListingStatus, McpListing, McpValidationResult, McpVersion
+from models.team import Team, TeamMembership, TeamRole
+from models.user import UserRole
+
+# resolve_visible_listing calls the module-global resolve_listing inside
+# api.deps, so that is the only seam a patch can intercept.
+RESOLVE_SEAM = "api.deps.resolve_listing"
+
+NON_APPROVED = [
+    ListingStatus.draft,
+    ListingStatus.pending,
+    ListingStatus.rejected,
+    ListingStatus.archived,
+]
+
+
+def _user(role=UserRole.user, user_id=None):
+    return SimpleNamespace(id=user_id or uuid.uuid4(), role=role, email="u@example.com", username="u")
+
+
+def _component(status, submitted_by=None, co_authors=None):
+    listing = MagicMock()
+    listing.id = uuid.uuid4()
+    listing.namespace = "alice"
+    listing.slug = "tool"
+    listing.qualified_name = "alice/tool"
+    listing.status = status
+    listing.submitted_by = submitted_by or uuid.uuid4()
+    listing.co_authors = co_authors or []
+    # Privacy is a separate axis from status. A bare MagicMock attribute is
+    # truthy, which would make every listing look team-private.
+    listing.is_private = False
+    listing.team_id = None
+    return listing
+
+
+def _agent(status, created_by=None, co_authors=None):
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.namespace = "alice"
+    agent.slug = "reviewer"
+    agent.qualified_name = "alice/reviewer"
+    agent.status = status
+    agent.created_by = created_by or uuid.uuid4()
+    agent.co_authors = co_authors or []
+    agent.is_private = False
+    agent.team_id = None
+    return agent
+
+
+def _app(user):
+    app = FastAPI()
+    app.include_router(registry_router)
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    app.dependency_overrides[optional_current_user] = lambda: user
+    return app
+
+
+async def _resolve(app, item_type: str, identifier: str = "alice/tool"):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.get(
+            "/api/v1/registry/resolve",
+            params={"type": item_type, "identifier": identifier},
+        )
+
+
+# ── /resolve: component branch ───────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", NON_APPROVED)
+async def test_anonymous_cannot_resolve_non_approved_component(status):
+    listing = _component(status)
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.side_effect = [None, listing]
+        response = await _resolve(_app(None), "mcp")
+    assert response.status_code == 404
+    assert "alice/tool" not in response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", NON_APPROVED)
+async def test_non_owner_cannot_resolve_non_approved_component(status):
+    listing = _component(status)
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.side_effect = [None, listing]
+        response = await _resolve(_app(_user()), "mcp")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", NON_APPROVED)
+async def test_owner_resolves_own_non_approved_component(status):
+    owner = _user()
+    listing = _component(status, submitted_by=owner.id)
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.side_effect = [None, listing]
+        response = await _resolve(_app(owner), "mcp")
+    assert response.status_code == 200
+    assert response.json()["qualified_name"] == "alice/tool"
+
+
+@pytest.mark.asyncio
+async def test_co_author_resolves_non_approved_component():
+    co_author = _user()
+    listing = _component(ListingStatus.pending, co_authors=[str(co_author.id)])
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.side_effect = [None, listing]
+        response = await _resolve(_app(co_author), "mcp")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
+async def test_privileged_roles_resolve_non_approved_component(role):
+    listing = _component(ListingStatus.draft)
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.side_effect = [None, listing]
+        response = await _resolve(_app(_user(role=role)), "mcp")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("item_type", ["mcp", "skill", "hook", "prompt", "sandbox"])
+async def test_anonymous_resolves_approved_component(item_type):
+    listing = _component(ListingStatus.approved)
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.return_value = listing
+        response = await _resolve(_app(None), item_type)
+    assert response.status_code == 200
+    assert response.json()["type"] == item_type
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("item_type", ["mcp", "skill", "hook", "prompt", "sandbox"])
+async def test_every_component_type_gates_non_approved(item_type):
+    listing = _component(ListingStatus.draft)
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.side_effect = [None, listing]
+        response = await _resolve(_app(None), item_type)
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_missing_component_returns_404():
+    with patch(RESOLVE_SEAM, new_callable=AsyncMock) as resolve:
+        resolve.side_effect = [None, None]
+        response = await _resolve(_app(None), "mcp")
+    assert response.status_code == 404
+
+
+# ── /resolve: agent branch ───────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status",
+    [AgentStatus.draft, AgentStatus.pending, AgentStatus.rejected, AgentStatus.archived],
+)
+async def test_anonymous_cannot_resolve_non_approved_agent(status):
+    """_load_agent skips the status filter on UUID and prefix lookups."""
+    agent = _agent(status)
+    with patch("api.routes.registry._load_agent", new_callable=AsyncMock) as load:
+        load.return_value = agent
+        response = await _resolve(_app(None), "agent", identifier=str(agent.id))
+    assert response.status_code == 404
+    assert "alice/reviewer" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_resolve_non_approved_agent():
+    agent = _agent(AgentStatus.draft)
+    with patch("api.routes.registry._load_agent", new_callable=AsyncMock) as load:
+        load.return_value = agent
+        response = await _resolve(_app(_user()), "agent", identifier=str(agent.id))
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_owner_resolves_own_non_approved_agent():
+    owner = _user()
+    agent = _agent(AgentStatus.draft, created_by=owner.id)
+    with patch("api.routes.registry._load_agent", new_callable=AsyncMock) as load:
+        load.return_value = agent
+        response = await _resolve(_app(owner), "agent", identifier=str(agent.id))
+    assert response.status_code == 200
+    assert response.json()["qualified_name"] == "alice/reviewer"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
+async def test_privileged_roles_resolve_non_approved_agent(role):
+    agent = _agent(AgentStatus.pending)
+    with patch("api.routes.registry._load_agent", new_callable=AsyncMock) as load:
+        load.return_value = agent
+        response = await _resolve(_app(_user(role=role)), "agent", identifier=str(agent.id))
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_anonymous_resolves_approved_agent():
+    agent = _agent(AgentStatus.approved)
+    with patch("api.routes.registry._load_agent", new_callable=AsyncMock) as load:
+        load.return_value = agent
+        response = await _resolve(_app(None), "agent", identifier=str(agent.id))
+    assert response.status_code == 200
+
+
+# ── PATCH visibility: every approved public agent version ──
+
+_TABLES = [
+    Agent.__table__,
+    AgentVersion.__table__,
+    AgentComponent.__table__,
+    McpListing.__table__,
+    McpVersion.__table__,
+    McpValidationResult.__table__,
+    Team.__table__,
+    TeamMembership.__table__,
+]
+
+
+@asynccontextmanager
+async def _sessions():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all, tables=_TABLES)
+        yield async_sessionmaker(engine, expire_on_commit=False)
+    finally:
+        await engine.dispose()
+
+
+async def _seed_component_used_by_older_version(
+    sessions,
+    *,
+    agent_is_private: bool,
+    old_status: AgentStatus,
+    link_to_latest: bool = False,
+):
+    """Seed an agent with two versions, only one of which references the component."""
+    owner_id = uuid.uuid4()
+    team = Team(id=uuid.uuid4(), name="Platform", handle="platform", created_by=owner_id)
+    membership = TeamMembership(team_id=team.id, user_id=owner_id, role=TeamRole.owner)
+    listing = McpListing(
+        id=uuid.uuid4(),
+        name="Search",
+        namespace="platform",
+        slug="search",
+        category="general",
+        owner="platform",
+        submitted_by=owner_id,
+        team_id=team.id,
+        is_private=False,
+        co_authors=[],
+    )
+    agent = Agent(
+        id=uuid.uuid4(),
+        name="Reviewer",
+        namespace="alice",
+        slug="reviewer",
+        owner="alice",
+        created_by=owner_id,
+        is_private=agent_is_private,
+        co_authors=[],
+    )
+    old = AgentVersion(
+        id=uuid.uuid4(),
+        agent_id=agent.id,
+        version="1.0.0",
+        model_name="claude-sonnet-4-5",
+        released_by=owner_id,
+        status=old_status,
+    )
+    latest = AgentVersion(
+        id=uuid.uuid4(),
+        agent_id=agent.id,
+        version="2.0.0",
+        model_name="claude-sonnet-4-5",
+        released_by=owner_id,
+        status=AgentStatus.approved,
+    )
+    link = AgentComponent(
+        agent_version_id=latest.id if link_to_latest else old.id,
+        component_type="mcp",
+        component_id=listing.id,
+        component_name="Search",
+        resolved_version="1.0.0",
+    )
+    async with sessions() as session:
+        session.add_all([team, membership, listing, agent, old, latest])
+        await session.flush()
+        agent.latest_version_id = latest.id
+        session.add(link)
+        await session.commit()
+    return SimpleNamespace(listing_id=listing.id, user=SimpleNamespace(id=owner_id, role=UserRole.user))
+
+
+async def _patch_visibility(session, listing_id, user, visibility="team"):
+    return await update_registry_visibility(
+        "mcp",
+        str(listing_id),
+        VisibilityUpdateRequest(visibility=visibility),
+        SimpleNamespace(state=SimpleNamespace()),
+        session,
+        user,
+    )
+
+
+@pytest.mark.asyncio
+async def test_component_cannot_go_private_for_latest_approved_public_agent_version():
+    """The guard the widened query has to keep: the latest version still counts."""
+    async with _sessions() as sessions:
+        seed = await _seed_component_used_by_older_version(
+            sessions,
+            agent_is_private=False,
+            old_status=AgentStatus.approved,
+            link_to_latest=True,
+        )
+        async with sessions() as session:
+            with pytest.raises(HTTPException) as exc:
+                await _patch_visibility(session, seed.listing_id, seed.user)
+        assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_component_cannot_go_private_for_older_approved_public_agent_version():
+    """Only the superseded version references the component, and installs can pin it."""
+    async with _sessions() as sessions:
+        seed = await _seed_component_used_by_older_version(
+            sessions, agent_is_private=False, old_status=AgentStatus.approved
+        )
+        async with sessions() as session:
+            with pytest.raises(HTTPException) as exc:
+                await _patch_visibility(session, seed.listing_id, seed.user)
+        assert exc.value.status_code == 409
+        assert "approved public agent version" in exc.value.detail
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.listing_id)
+            assert listing.is_private is False
+
+
+@pytest.mark.asyncio
+async def test_component_goes_private_when_older_public_agent_version_is_not_approved():
+    async with _sessions() as sessions:
+        seed = await _seed_component_used_by_older_version(
+            sessions, agent_is_private=False, old_status=AgentStatus.rejected
+        )
+        async with sessions() as session:
+            result = await _patch_visibility(session, seed.listing_id, seed.user)
+        assert result["visibility"] == "team"
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.listing_id)
+            assert listing.is_private is True
+
+
+@pytest.mark.asyncio
+async def test_component_goes_private_when_the_dependent_agent_is_team_private():
+    async with _sessions() as sessions:
+        seed = await _seed_component_used_by_older_version(
+            sessions, agent_is_private=True, old_status=AgentStatus.approved
+        )
+        async with sessions() as session:
+            result = await _patch_visibility(session, seed.listing_id, seed.user)
+        assert result["visibility"] == "team"
+
+
+@pytest.mark.asyncio
+async def test_component_returns_to_public_without_the_dependency_check():
+    async with _sessions() as sessions:
+        seed = await _seed_component_used_by_older_version(
+            sessions, agent_is_private=False, old_status=AgentStatus.approved
+        )
+        async with sessions() as session:
+            result = await _patch_visibility(session, seed.listing_id, seed.user, visibility="public")
+        assert result["visibility"] == "public"
+
+
+# ── Making a team-private listing public re-enters review ───────────────────
+#
+# Team owners and team reviewers approve their own team-visibility publications,
+# because only their own teamspace can see the result. Without a review step on
+# the visibility transition that self-approval becomes a two-step route into the
+# public catalog: publish as team visibility, self-approve, then flip the same
+# approved row to public and reach every user without a reviewer ever seeing it.
+# The web registry UI exposes the flip as a single toggle, so the bypass is one
+# click, not a theoretical API sequence.
+
+
+async def _seed_team_private_component(sessions, *, status=ListingStatus.approved):
+    """Seed an approved team-private MCP owned by a plain user who owns the team."""
+    owner_id = uuid.uuid4()
+    team = Team(id=uuid.uuid4(), name="Acme", handle="acme", created_by=owner_id)
+    membership = TeamMembership(team_id=team.id, user_id=owner_id, role=TeamRole.owner)
+    listing = McpListing(
+        id=uuid.uuid4(),
+        name="Internal",
+        namespace="acme",
+        slug="internal",
+        category="general",
+        owner="acme",
+        submitted_by=owner_id,
+        team_id=team.id,
+        is_private=True,
+        co_authors=[],
+    )
+    version = McpVersion(
+        id=uuid.uuid4(),
+        listing_id=listing.id,
+        version="1.0.0",
+        description="internal tool",
+        released_by=owner_id,
+        released_at=datetime(2026, 1, 1, tzinfo=UTC),
+        status=status,
+        reviewed_by=owner_id,
+        reviewed_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    async with sessions() as session:
+        # Insert the listing before the version: McpListing.versions and
+        # McpListing.latest_version point at each other, so flushing both in one
+        # unit of work makes SQLAlchemy see a circular dependency.
+        session.add_all([team, membership, listing])
+        await session.flush()
+        session.add(version)
+        await session.flush()
+        listing.latest_version_id = version.id
+        await session.commit()
+    return SimpleNamespace(
+        listing_id=listing.id,
+        team_id=team.id,
+        owner=SimpleNamespace(id=owner_id, role=UserRole.user),
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_owner_making_a_listing_public_sends_it_back_to_review():
+    """The bypass: a plain user who owns the team must not self-publish publicly."""
+    async with _sessions() as sessions:
+        seed = await _seed_team_private_component(sessions)
+        async with sessions() as session:
+            result = await _patch_visibility(session, seed.listing_id, seed.owner, visibility="public")
+
+        assert result["visibility"] == "public"
+        assert result["returned_to_review"] is True
+        assert result["status"] == ListingStatus.pending.value
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.listing_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            assert version.status == ListingStatus.pending
+            # The previous team-level approval must not be presented as a global one.
+            assert version.reviewed_by is None
+            assert version.reviewed_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
+async def test_privileged_actor_making_a_listing_public_keeps_it_approved(role):
+    """A global reviewer already holds the authority the queue represents."""
+    async with _sessions() as sessions:
+        seed = await _seed_team_private_component(sessions)
+        actor = SimpleNamespace(id=uuid.uuid4(), role=role)
+        async with sessions() as session:
+            result = await _patch_visibility(session, seed.listing_id, actor, visibility="public")
+
+        assert result["visibility"] == "public"
+        assert result["returned_to_review"] is False
+        assert result["status"] == ListingStatus.approved.value
+
+
+@pytest.mark.asyncio
+async def test_restricting_a_public_listing_to_the_team_does_not_re_enter_review():
+    """Narrowing visibility is not a publication, so it needs no review."""
+    async with _sessions() as sessions:
+        seed = await _seed_team_private_component(sessions)
+        async with sessions() as session:
+            await _patch_visibility(session, seed.listing_id, seed.owner, visibility="public")
+        # Approve it globally, then narrow it back to the team.
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.listing_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            version.status = ListingStatus.approved
+            await session.commit()
+        async with sessions() as session:
+            result = await _patch_visibility(session, seed.listing_id, seed.owner, visibility="team")
+
+        assert result["visibility"] == "team"
+        assert result["returned_to_review"] is False
+        assert result["status"] == ListingStatus.approved.value
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [ListingStatus.draft, ListingStatus.pending, ListingStatus.rejected])
+async def test_never_approved_listing_is_not_moved_when_it_becomes_public(status):
+    """A listing that was never approved has no approval to revoke."""
+    async with _sessions() as sessions:
+        seed = await _seed_team_private_component(sessions, status=status)
+        async with sessions() as session:
+            result = await _patch_visibility(session, seed.listing_id, seed.owner, visibility="public")
+
+        assert result["returned_to_review"] is False
+        assert result["status"] == status.value
+
+
+# ── Legacy bare names resolve against the caller, not against anonymous ─────
+#
+# resolve_listing filters a bare-name collision through the caller's visibility
+# before it builds the 409, so it needs the caller. A call site that omits it
+# evaluates the collision as anonymous: the team-private half of the collision
+# drops out, one candidate is left, and the name resolves silently to the public
+# row instead of raising. These go through update_registry_visibility, a real
+# call site, rather than through resolve_listing directly, because the omission
+# lives at the call sites and not in the helper.
+
+
+async def _seed_colliding_bare_name(sessions):
+    """Seed a public alice/tool and a team-private platform/tool, both on slug 'tool'."""
+    alice_id = uuid.uuid4()
+    bob_id = uuid.uuid4()
+    team = Team(id=uuid.uuid4(), name="Platform", handle="platform", created_by=bob_id)
+    membership = TeamMembership(team_id=team.id, user_id=bob_id, role=TeamRole.owner)
+    public = McpListing(
+        id=uuid.uuid4(),
+        name="Tool",
+        namespace="alice",
+        slug="tool",
+        category="general",
+        owner="alice",
+        submitted_by=alice_id,
+        team_id=None,
+        is_private=False,
+        co_authors=[],
+    )
+    private = McpListing(
+        id=uuid.uuid4(),
+        name="Tool",
+        namespace="platform",
+        slug="tool",
+        category="general",
+        owner="platform",
+        submitted_by=bob_id,
+        team_id=team.id,
+        is_private=True,
+        co_authors=[],
+    )
+    async with sessions() as session:
+        session.add_all([team, membership, public, private])
+        await session.flush()
+        for listing in (public, private):
+            version = McpVersion(
+                id=uuid.uuid4(),
+                listing_id=listing.id,
+                version="1.0.0",
+                description="tool",
+                released_by=listing.submitted_by,
+                released_at=datetime(2026, 1, 1, tzinfo=UTC),
+                status=ListingStatus.approved,
+            )
+            session.add(version)
+            await session.flush()
+            listing.latest_version_id = version.id
+        await session.commit()
+    return SimpleNamespace(
+        member=SimpleNamespace(id=bob_id, role=UserRole.user),
+        non_member=SimpleNamespace(id=alice_id, role=UserRole.user),
+        public_name=public.qualified_name,
+        private_name=private.qualified_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_bare_name_colliding_with_a_visible_team_listing_is_ambiguous_for_a_member():
+    """Bob can see both rows, so 'tool' is ambiguous and must not pick one for him."""
+    async with _sessions() as sessions:
+        seed = await _seed_colliding_bare_name(sessions)
+        async with sessions() as session:
+            with pytest.raises(HTTPException) as exc:
+                await _patch_visibility(session, "tool", seed.member, visibility="public")
+
+        assert exc.value.status_code == 409
+        assert seed.public_name in exc.value.detail
+        assert seed.private_name in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_same_bare_name_resolves_to_the_public_row_for_a_non_member():
+    """Alice sees one candidate, so the name is unambiguous and the other stays secret."""
+    async with _sessions() as sessions:
+        seed = await _seed_colliding_bare_name(sessions)
+        async with sessions() as session:
+            result = await _patch_visibility(session, "tool", seed.non_member, visibility="public")
+
+        assert result["qualified_name"] == seed.public_name
+        assert seed.private_name not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_public_listing_is_not_visible_to_anonymous_callers_while_pending():
+    """The flipped listing leaves the approved catalog until a reviewer accepts it."""
+    from sqlalchemy import select
+
+    from api.deps import apply_visibility_filter
+
+    async with _sessions() as sessions:
+        seed = await _seed_team_private_component(sessions)
+        async with sessions() as session:
+            await _patch_visibility(session, seed.listing_id, seed.owner, visibility="public")
+
+        async with sessions() as session:
+            stmt = (
+                select(McpListing)
+                .join(McpVersion, McpListing.latest_version_id == McpVersion.id)
+                .where(McpVersion.status == ListingStatus.approved)
+            )
+            rows = (await session.execute(apply_visibility_filter(stmt, McpListing, None))).scalars().all()
+            assert [r.id for r in rows] == []

--- a/tests/test_registry_visibility.py
+++ b/tests/test_registry_visibility.py
@@ -504,9 +504,9 @@ async def test_team_owner_making_a_listing_public_sends_it_back_to_review():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
+@pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
 async def test_privileged_actor_making_a_listing_public_keeps_it_approved(role):
-    """A global reviewer already holds the authority the queue represents."""
+    """An admin already holds the authority the queue represents."""
     async with _sessions() as sessions:
         seed = await _seed_team_private_component(sessions)
         actor = SimpleNamespace(id=uuid.uuid4(), role=role)
@@ -516,6 +516,25 @@ async def test_privileged_actor_making_a_listing_public_keeps_it_approved(role):
         assert result["visibility"] == "public"
         assert result["returned_to_review"] is False
         assert result["status"] == ListingStatus.approved.value
+
+
+@pytest.mark.asyncio
+async def test_global_reviewer_outside_the_team_cannot_flip_a_team_private_listing():
+    """A global reviewer cannot read the listing, so it cannot flip it either.
+
+    Team-private content is reviewed inside its own teamspace. A reviewer who is
+    not in the team gets the same answer as any other outsider: the listing does
+    not exist. Publishing it into the public catalog stays a team owner or team
+    reviewer action, followed by the global review queue.
+    """
+    async with _sessions() as sessions:
+        seed = await _seed_team_private_component(sessions)
+        reviewer = SimpleNamespace(id=uuid.uuid4(), role=UserRole.reviewer)
+        async with sessions() as session:
+            with pytest.raises(HTTPException) as exc:
+                await _patch_visibility(session, seed.listing_id, reviewer, visibility="public")
+
+        assert exc.value.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/test_sec009_component_source_ownership.py
+++ b/tests/test_sec009_component_source_ownership.py
@@ -1,17 +1,36 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for component source org ownership enforcement.
+"""Tests for teamspace visibility enforcement on component sources.
+
+Component sources have exactly two visibilities: public (everyone) and team
+(members of the owning teamspace, plus global reviewers and admins). There is no
+organization axis.
 
 Verifies that:
-- add_source derives owner_org_id from the authenticated user, not the request body
-- list_sources returns only public sources and the caller's own org sources
-- get_source returns 404 for private sources owned by a different org
+- add_source derives the teamspace and visibility from the authenticated user's
+  membership, never from unvalidated request-body input
+- list_sources returns public sources plus team-private sources of teams the
+  caller belongs to, and nothing else
+- get_source answers 404 (not 403) for a team-private source the caller cannot
+  see, so existence is never leaked
+
+The routes run against a real in-memory SQLite session so the visibility SQL is
+actually executed rather than merely inspected.
 """
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from contextlib import asynccontextmanager
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from models.base import Base
+from models.component_source import ComponentSource
+from models.team import Team, TeamMembership, TeamRole
+from models.user import User, UserRole
+
+_TABLES = [ComponentSource.__table__, Team.__table__, TeamMembership.__table__]
 
 
 def _make_client():
@@ -27,264 +46,336 @@ def _make_client():
     )
 
 
-def _user(role="user", org_id=None):
-    from models.user import User, UserRole
-
-    u = MagicMock(spec=User)
-    u.id = uuid.uuid4()
-    u.role = getattr(UserRole, role)
-    u.org_id = org_id if org_id is not None else uuid.uuid4()
-    return u
-
-
-def _source(is_public=True, owner_org_id=None):
-    s = MagicMock()
-    s.id = uuid.uuid4()
-    s.url = "https://github.com/example/repo"
-    s.provider = "github"
-    s.component_type = "mcp"
-    s.is_public = is_public
-    s.owner_org_id = owner_org_id or uuid.uuid4()
-    s.auto_sync_interval = None
-    s.last_synced_at = None
-    s.sync_status = None
-    s.sync_error = None
-    from datetime import UTC, datetime
-
-    s.created_at = datetime.now(UTC)
-    return s
-
-
-# ── add_source: owner_org_id derived from user, not request ──────────────────
-
-
-@pytest.mark.asyncio
-async def test_add_source_ignores_client_owner_org_id():
-    """owner_org_id in the request body is ignored; user's org is used."""
+@asynccontextmanager
+async def _api(user: User | None):
+    """Bind the app to a fresh database and authenticate as ``user`` (None = anonymous)."""
     from api.deps import get_current_user, get_db
     from main import app
 
-    org = uuid.uuid4()
-    user = _user(org_id=org)
-    foreign_org = uuid.uuid4()
-
-    from datetime import UTC, datetime
-
-    created_source = _source(owner_org_id=org)
-    captured = {}
-
-    db = AsyncMock()
-
-    def capturing_add(obj):
-        captured["source"] = obj
-        # Copy required fields onto the object so pydantic serialisation works
-        obj.id = created_source.id
-        obj.provider = created_source.provider
-        obj.created_at = datetime.now(UTC)
-        obj.auto_sync_interval = None
-        obj.last_synced_at = None
-        obj.sync_status = None
-        obj.sync_error = None
-
-    db.add = MagicMock(side_effect=capturing_add)
-    db.commit = AsyncMock()
-    db.refresh = AsyncMock()
-
-    async def fake_db():
-        yield db
-
-    app.dependency_overrides[get_db] = fake_db
-    app.dependency_overrides[get_current_user] = lambda: user
-
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     try:
-        async with _make_client() as client:
-            r = await client.post(
-                "/api/v1/component-sources",
-                json={
-                    "url": "https://github.com/example/repo",
-                    "component_type": "mcp",
-                    "is_public": True,
-                    "owner_org_id": str(foreign_org),  # attacker supplies foreign org
-                },
-            )
-        assert r.status_code in (201, 409)
-        # The source added to DB must use the user's org, not the foreign one
-        if "source" in captured:
-            assert captured["source"].owner_org_id == org
-            assert captured["source"].owner_org_id != foreign_org
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all, tables=_TABLES)
+        sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+        async def _db():
+            async with sessions() as session:
+                yield session
+
+        app.dependency_overrides[get_db] = _db
+        if user is not None:
+            app.dependency_overrides[get_current_user] = lambda: user
+        try:
+            async with _make_client() as client:
+                yield client, sessions
+        finally:
+            app.dependency_overrides.clear()
     finally:
-        app.dependency_overrides.clear()
+        await engine.dispose()
 
 
-# ── list_sources: scoped to public + caller's org ─────────────────────────────
+async def _seed(sessions, *rows):
+    async with sessions() as session:
+        session.add_all(rows)
+        await session.commit()
+
+
+async def _sources(sessions) -> list[ComponentSource]:
+    async with sessions() as session:
+        return list((await session.execute(select(ComponentSource))).scalars().all())
+
+
+def _user(username: str = "alice", role: UserRole = UserRole.user) -> User:
+    return User(
+        id=uuid.uuid4(),
+        email=f"{username}@example.com",
+        username=username,
+        name=username.title(),
+        role=role,
+    )
+
+
+def _team(handle: str) -> Team:
+    return Team(id=uuid.uuid4(), name=handle.title(), handle=handle, created_by=uuid.uuid4())
+
+
+def _member(team: Team, user: User, role: TeamRole = TeamRole.member) -> TeamMembership:
+    return TeamMembership(id=uuid.uuid4(), team_id=team.id, user_id=user.id, role=role)
+
+
+def _source(url: str, *, is_public: bool = True, team_id: uuid.UUID | None = None) -> ComponentSource:
+    return ComponentSource(
+        id=uuid.uuid4(),
+        url=url,
+        provider="github",
+        component_type="mcp",
+        is_public=is_public,
+        team_id=team_id,
+    )
+
+
+# ── add_source: teamspace derived from membership, not from the request body ──
 
 
 @pytest.mark.asyncio
-async def test_list_sources_excludes_other_org_private_sources():
-    """Private sources from a different org are not returned."""
-    from api.deps import get_current_user, get_db
-    from main import app
-
-    my_org = uuid.uuid4()
-    other_org = uuid.uuid4()
-    user = _user(org_id=my_org)
-
-    public_source = _source(is_public=True, owner_org_id=other_org)
-    private_mine = _source(is_public=False, owner_org_id=my_org)
-    private_other = _source(is_public=False, owner_org_id=other_org)
-
-    db = AsyncMock()
-    result = MagicMock()
-
-    # Simulate DB filtering: only return sources that pass the WHERE clause
-    # We test by checking what WHERE conditions are applied via the stmt
-    executed_stmts = []
-    orig_execute = db.execute
-
-    async def capturing_execute(stmt, *a, **kw):
-        executed_stmts.append(stmt)
-        r = MagicMock()
-        r.scalars.return_value.all.return_value = [public_source, private_mine]
-        return r
-
-    db.execute = capturing_execute
-
-    async def fake_db():
-        yield db
-
-    app.dependency_overrides[get_db] = fake_db
-    app.dependency_overrides[get_current_user] = lambda: user
-
-    try:
-        async with _make_client() as client:
-            r = await client.get("/api/v1/component-sources")
-        assert r.status_code == 200
-        # The WHERE clause on the stmt should include org scoping
-        assert len(executed_stmts) == 1
-        stmt_str = str(executed_stmts[0])
-        assert str(my_org) in stmt_str or "owner_org_id" in stmt_str
-    finally:
-        app.dependency_overrides.clear()
-
-
-@pytest.mark.asyncio
-async def test_list_sources_no_org_user_sees_only_public():
-    """User with no org_id sees only public sources."""
-    from api.deps import get_current_user, get_db
-    from main import app
-
+async def test_add_source_rejects_team_id_the_caller_is_not_a_member_of():
+    """A client-supplied team_id cannot attach a source to a foreign teamspace."""
     user = _user()
-    user.org_id = None
+    foreign_team = _team("platform")
 
-    db = AsyncMock()
-    executed_stmts = []
-
-    async def capturing_execute(stmt, *a, **kw):
-        executed_stmts.append(stmt)
-        r = MagicMock()
-        r.scalars.return_value.all.return_value = []
-        return r
-
-    db.execute = capturing_execute
-
-    async def fake_db():
-        yield db
-
-    app.dependency_overrides[get_db] = fake_db
-    app.dependency_overrides[get_current_user] = lambda: user
-
-    try:
-        async with _make_client() as client:
-            r = await client.get("/api/v1/component-sources")
-        assert r.status_code == 200
-        assert len(executed_stmts) == 1
-        # Query must filter to is_public = true only
-        stmt_str = str(executed_stmts[0])
-        assert "is_public" in stmt_str
-    finally:
-        app.dependency_overrides.clear()
-
-
-# ── get_source: private source from another org returns 404 ──────────────────
+    async with _api(user) as (client, sessions):
+        await _seed(sessions, foreign_team)
+        r = await client.post(
+            "/api/v1/component-sources",
+            json={
+                "url": "https://github.com/example/repo",
+                "component_type": "mcp",
+                "team_id": str(foreign_team.id),
+                "visibility": "team",
+            },
+        )
+        assert r.status_code == 403
+        assert await _sources(sessions) == []
 
 
 @pytest.mark.asyncio
-async def test_get_source_private_other_org_returns_404():
-    """Fetching a private source owned by a different org returns 404."""
-    from api.deps import get_current_user, get_db
-    from main import app
+async def test_add_source_rejects_foreign_team_even_for_public_visibility():
+    """Membership is checked on team_id itself, not only when visibility is 'team'."""
+    user = _user()
+    foreign_team = _team("platform")
 
-    my_org = uuid.uuid4()
-    other_org = uuid.uuid4()
-    user = _user(org_id=my_org)
+    async with _api(user) as (client, sessions):
+        await _seed(sessions, foreign_team)
+        r = await client.post(
+            "/api/v1/component-sources",
+            json={
+                "url": "https://github.com/example/repo",
+                "component_type": "mcp",
+                "team_id": str(foreign_team.id),
+                "visibility": "public",
+            },
+        )
+        assert r.status_code == 403
+        assert await _sources(sessions) == []
 
-    private_source = _source(is_public=False, owner_org_id=other_org)
 
-    db = AsyncMock()
-    db.get = AsyncMock(return_value=private_source)
+@pytest.mark.asyncio
+async def test_add_source_rejects_team_visibility_without_a_teamspace():
+    """Team visibility with no teamspace has no membership to authorize against."""
+    async with _api(_user()) as (client, sessions):
+        r = await client.post(
+            "/api/v1/component-sources",
+            json={
+                "url": "https://github.com/example/repo",
+                "component_type": "mcp",
+                "visibility": "team",
+            },
+        )
+        assert r.status_code == 422
+        assert await _sources(sessions) == []
 
-    async def fake_db():
-        yield db
 
-    app.dependency_overrides[get_db] = fake_db
-    app.dependency_overrides[get_current_user] = lambda: user
+@pytest.mark.asyncio
+async def test_add_source_stores_team_visibility_for_a_member():
+    """A member publishing to their own teamspace gets a team-private source."""
+    user = _user()
+    team = _team("platform")
 
-    try:
-        async with _make_client() as client:
-            r = await client.get(f"/api/v1/component-sources/{private_source.id}")
+    async with _api(user) as (client, sessions):
+        await _seed(sessions, team, _member(team, user))
+        r = await client.post(
+            "/api/v1/component-sources",
+            json={
+                "url": "https://github.com/example/repo",
+                "component_type": "mcp",
+                "team_id": str(team.id),
+                "visibility": "team",
+            },
+        )
+        assert r.status_code == 201
+        assert r.json()["visibility"] == "team"
+        assert r.json()["team_id"] == str(team.id)
+
+        stored = await _sources(sessions)
+        assert len(stored) == 1
+        assert stored[0].is_public is False
+        assert stored[0].team_id == team.id
+
+
+@pytest.mark.asyncio
+async def test_add_source_without_a_team_is_public():
+    """No teamspace means no private scope to hide the source in."""
+    async with _api(_user()) as (client, sessions):
+        r = await client.post(
+            "/api/v1/component-sources",
+            json={"url": "https://github.com/example/repo", "component_type": "mcp"},
+        )
+        assert r.status_code == 201
+        assert r.json()["visibility"] == "public"
+        assert r.json()["team_id"] is None
+
+        stored = await _sources(sessions)
+        assert len(stored) == 1
+        assert stored[0].is_public is True
+        assert stored[0].team_id is None
+
+
+# ── list_sources: public plus the caller's own teamspaces ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_sources_excludes_team_private_sources_of_other_teams():
+    """Team-private sources of a teamspace the caller is not in are never listed."""
+    user = _user()
+    mine, theirs = _team("mine"), _team("theirs")
+
+    async with _api(user) as (client, sessions):
+        await _seed(
+            sessions,
+            mine,
+            theirs,
+            _member(mine, user),
+            _source("https://github.com/example/public", is_public=True),
+            _source("https://github.com/example/mine", is_public=False, team_id=mine.id),
+            _source("https://github.com/example/theirs", is_public=False, team_id=theirs.id),
+        )
+        r = await client.get("/api/v1/component-sources")
+        assert r.status_code == 200
+        assert {s["url"] for s in r.json()} == {
+            "https://github.com/example/public",
+            "https://github.com/example/mine",
+        }
+
+
+@pytest.mark.asyncio
+async def test_list_sources_includes_team_private_sources_for_a_member():
+    """Membership is what admits a team-private source into the listing."""
+    user = _user()
+    team = _team("platform")
+
+    async with _api(user) as (client, sessions):
+        await _seed(
+            sessions,
+            team,
+            _member(team, user),
+            _source("https://github.com/example/private", is_public=False, team_id=team.id),
+        )
+        r = await client.get("/api/v1/component-sources")
+        assert r.status_code == 200
+        assert [s["url"] for s in r.json()] == ["https://github.com/example/private"]
+        assert r.json()[0]["visibility"] == "team"
+
+
+@pytest.mark.asyncio
+async def test_list_sources_hides_private_sources_with_no_teamspace():
+    """A private source with no teamspace has no membership that can admit it."""
+    async with _api(_user()) as (client, sessions):
+        await _seed(
+            sessions,
+            _source("https://github.com/example/orphan", is_public=False, team_id=None),
+            _source("https://github.com/example/public", is_public=True),
+        )
+        r = await client.get("/api/v1/component-sources")
+        assert r.status_code == 200
+        assert [s["url"] for s in r.json()] == ["https://github.com/example/public"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
+async def test_list_sources_returns_every_team_private_source_to_global_reviewers(role):
+    """Global reviewers and admins moderate the whole registry, so they see all of it."""
+    team = _team("platform")
+
+    async with _api(_user(role=role)) as (client, sessions):
+        await _seed(
+            sessions,
+            team,
+            _source("https://github.com/example/private", is_public=False, team_id=team.id),
+            _source("https://github.com/example/public", is_public=True),
+        )
+        r = await client.get("/api/v1/component-sources")
+        assert r.status_code == 200
+        assert {s["url"] for s in r.json()} == {
+            "https://github.com/example/private",
+            "https://github.com/example/public",
+        }
+
+
+# ── get_source: non-members get 404 so existence is not leaked ───────────────
+
+
+@pytest.mark.asyncio
+async def test_get_team_private_source_as_non_member_returns_404():
+    """A non-member gets the same answer as for an id that does not exist."""
+    team = _team("platform")
+    private = _source("https://github.com/example/private", is_public=False, team_id=team.id)
+
+    async with _api(_user()) as (client, sessions):
+        await _seed(sessions, team, private)
+        hidden = await client.get(f"/api/v1/component-sources/{private.id}")
+        missing = await client.get(f"/api/v1/component-sources/{uuid.uuid4()}")
+        assert hidden.status_code == 404
+        assert hidden.json() == missing.json()
+
+
+@pytest.mark.asyncio
+async def test_get_private_source_with_no_teamspace_returns_404():
+    """No teamspace means no membership can grant access, so it stays hidden."""
+    orphan = _source("https://github.com/example/orphan", is_public=False, team_id=None)
+
+    async with _api(_user()) as (client, sessions):
+        await _seed(sessions, orphan)
+        r = await client.get(f"/api/v1/component-sources/{orphan.id}")
         assert r.status_code == 404
-    finally:
-        app.dependency_overrides.clear()
 
 
 @pytest.mark.asyncio
-async def test_get_source_private_same_org_returns_200():
-    """Fetching a private source owned by the caller's org returns 200."""
-    from api.deps import get_current_user, get_db
-    from main import app
+async def test_get_team_private_source_as_member_returns_200():
+    """Members of the owning teamspace can read the source."""
+    user = _user()
+    team = _team("platform")
+    private = _source("https://github.com/example/private", is_public=False, team_id=team.id)
 
-    org = uuid.uuid4()
-    user = _user(org_id=org)
-    private_source = _source(is_public=False, owner_org_id=org)
-
-    db = AsyncMock()
-    db.get = AsyncMock(return_value=private_source)
-
-    async def fake_db():
-        yield db
-
-    app.dependency_overrides[get_db] = fake_db
-    app.dependency_overrides[get_current_user] = lambda: user
-
-    try:
-        async with _make_client() as client:
-            r = await client.get(f"/api/v1/component-sources/{private_source.id}")
+    async with _api(user) as (client, sessions):
+        await _seed(sessions, team, _member(team, user), private)
+        r = await client.get(f"/api/v1/component-sources/{private.id}")
         assert r.status_code == 200
-    finally:
-        app.dependency_overrides.clear()
+        assert r.json()["visibility"] == "team"
+        assert r.json()["team_id"] == str(team.id)
 
 
 @pytest.mark.asyncio
-async def test_get_source_public_any_org_returns_200():
-    """Public sources are accessible to any authenticated user."""
-    from api.deps import get_current_user, get_db
-    from main import app
+@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
+async def test_get_team_private_source_as_global_reviewer_returns_200(role):
+    """Global reviewers and admins can read team-private sources."""
+    team = _team("platform")
+    private = _source("https://github.com/example/private", is_public=False, team_id=team.id)
 
-    user = _user(org_id=uuid.uuid4())
-    public_source = _source(is_public=True, owner_org_id=uuid.uuid4())
-
-    db = AsyncMock()
-    db.get = AsyncMock(return_value=public_source)
-
-    async def fake_db():
-        yield db
-
-    app.dependency_overrides[get_db] = fake_db
-    app.dependency_overrides[get_current_user] = lambda: user
-
-    try:
-        async with _make_client() as client:
-            r = await client.get(f"/api/v1/component-sources/{public_source.id}")
+    async with _api(_user(role=role)) as (client, sessions):
+        await _seed(sessions, team, private)
+        r = await client.get(f"/api/v1/component-sources/{private.id}")
         assert r.status_code == 200
-    finally:
-        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_get_public_source_returns_200_for_any_authenticated_caller():
+    """Public sources carry no teamspace restriction."""
+    public = _source("https://github.com/example/public", is_public=True)
+
+    async with _api(_user(username="nobody")) as (client, sessions):
+        await _seed(sessions, public)
+        r = await client.get(f"/api/v1/component-sources/{public.id}")
+        assert r.status_code == 200
+        assert r.json()["visibility"] == "public"
+        assert r.json()["team_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_component_sources_require_authentication():
+    """The whole surface is authenticated, so anonymous callers never reach visibility."""
+    public = _source("https://github.com/example/public", is_public=True)
+
+    async with _api(None) as (client, sessions):
+        await _seed(sessions, public)
+        assert (await client.get("/api/v1/component-sources")).status_code == 401
+        assert (await client.get(f"/api/v1/component-sources/{public.id}")).status_code == 401

--- a/tests/test_sec009_component_source_ownership.py
+++ b/tests/test_sec009_component_source_ownership.py
@@ -371,6 +371,19 @@ async def test_get_public_source_returns_200_for_any_authenticated_caller():
 
 
 @pytest.mark.asyncio
+async def test_team_owner_can_delete_a_team_source():
+    owner = _user()
+    team = _team("platform")
+    source = _source("https://github.com/example/private", is_public=False, team_id=team.id)
+
+    async with _api(owner) as (client, sessions):
+        await _seed(sessions, team, _member(team, owner, TeamRole.owner), source)
+        response = await client.delete(f"/api/v1/component-sources/{source.id}")
+        assert response.status_code == 200
+        assert await _sources(sessions) == []
+
+
+@pytest.mark.asyncio
 async def test_component_sources_require_authentication():
     """The whole surface is authenticated, so anonymous callers never reach visibility."""
     public = _source("https://github.com/example/public", is_public=True)

--- a/tests/test_sec009_org_scoping.py
+++ b/tests/test_sec009_org_scoping.py
@@ -74,6 +74,27 @@ class TestApplyVisibilityFilter:
         stmt.where.assert_not_called()
         assert result is stmt
 
+    def test_super_admin_sees_all(self):
+        from models.mcp import McpListing
+
+        stmt = self._stmt()
+        result = apply_visibility_filter(stmt, McpListing, _user(role="super_admin"))
+        stmt.where.assert_not_called()
+        assert result is stmt
+
+    def test_global_reviewer_is_filtered_like_a_regular_user(self):
+        """A global reviewer reviews the public catalog, not other teams' private rows.
+
+        Team-private items are reviewed inside their own teamspace by a team owner
+        or team reviewer, so the global reviewer role carries no cross-team read.
+        Only admins and super_admins skip the filter.
+        """
+        from models.mcp import McpListing
+
+        stmt = self._stmt()
+        apply_visibility_filter(stmt, McpListing, _user(role="reviewer"))
+        stmt.where.assert_called_once()
+
     def test_regular_user_filter_applied(self):
         from models.mcp import McpListing
 
@@ -203,10 +224,86 @@ class TestCheckListingVisibilityAsync:
         db.scalar.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_private_visible_to_reviewer_and_admin(self):
+    async def test_private_visible_to_admin_and_super_admin(self):
         listing = _listing(is_private=True, team_id=uuid.uuid4())
-        assert await check_listing_visibility_async(listing, _user(role="reviewer"), self._db(None)) is True
         assert await check_listing_visibility_async(listing, _user(role="admin"), self._db(None)) is True
+        assert await check_listing_visibility_async(listing, _user(role="super_admin"), self._db(None)) is True
+
+    @pytest.mark.asyncio
+    async def test_private_hidden_from_a_global_reviewer_who_is_not_a_member(self):
+        """The global reviewer role is not a cross-team read grant.
+
+        Team-private items are reviewed inside their own teamspace, so a global
+        reviewer falls back to the same membership query as any other user.
+        """
+        listing = _listing(is_private=True, team_id=uuid.uuid4())
+        db = self._db(None)
+
+        assert await check_listing_visibility_async(listing, _user(role="reviewer"), db) is False
+        db.scalar.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_private_visible_to_a_global_reviewer_who_is_a_member(self):
+        """Membership, not the global role, is what admits the reviewer."""
+        listing = _listing(is_private=True, team_id=uuid.uuid4())
+        assert await check_listing_visibility_async(listing, _user(role="reviewer"), self._db(uuid.uuid4())) is True
+
+
+@asynccontextmanager
+async def _seeded_team_private_listing(*, membership: bool):
+    """Yield (session, listing, submitter) for a team-private listing the submitter published."""
+    from models.base import Base
+    from models.mcp import McpListing, McpValidationResult, McpVersion
+    from models.team import Team, TeamMembership, TeamRole
+
+    tables = [
+        McpListing.__table__,
+        McpVersion.__table__,
+        McpValidationResult.__table__,
+        Team.__table__,
+        TeamMembership.__table__,
+    ]
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all, tables=tables)
+        sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+        submitter = _user()
+        team = Team(id=uuid.uuid4(), name="Platform", handle="platform", created_by=submitter.id)
+        listing = McpListing(
+            id=uuid.uuid4(),
+            name="internal-mcp",
+            namespace=team.handle,
+            slug="internal-mcp",
+            category="developer-tools",
+            owner=team.handle,
+            is_private=True,
+            team_id=team.id,
+            submitted_by=submitter.id,
+            co_authors=[],
+        )
+        async with sessions() as session:
+            session.add_all([team, listing])
+            if membership:
+                session.add(
+                    TeamMembership(id=uuid.uuid4(), team_id=team.id, user_id=submitter.id, role=TeamRole.member)
+                )
+            await session.commit()
+
+        async with sessions() as session:
+            yield session, listing, submitter
+    finally:
+        await engine.dispose()
+
+
+async def _visible_ids(session, caller):
+    from sqlalchemy import select
+
+    from models.mcp import McpListing
+
+    stmt = apply_visibility_filter(select(McpListing.id), McpListing, caller)
+    return set((await session.execute(stmt)).scalars().all())
 
 
 class TestExMemberSubmitterAgainstARealDatabase:
@@ -217,75 +314,70 @@ class TestExMemberSubmitterAgainstARealDatabase:
     ``check_listing_visibility_async`` fails here rather than in production.
     """
 
-    @staticmethod
-    @asynccontextmanager
-    async def _seeded(*, membership: bool):
-        """Yield (session, listing, submitter) for a team-private listing the submitter published."""
-        from models.base import Base
-        from models.mcp import McpListing, McpValidationResult, McpVersion
-        from models.team import Team, TeamMembership, TeamRole
-
-        tables = [
-            McpListing.__table__,
-            McpVersion.__table__,
-            McpValidationResult.__table__,
-            Team.__table__,
-            TeamMembership.__table__,
-        ]
-        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-        try:
-            async with engine.begin() as conn:
-                await conn.run_sync(Base.metadata.create_all, tables=tables)
-            sessions = async_sessionmaker(engine, expire_on_commit=False)
-
-            submitter = _user()
-            team = Team(id=uuid.uuid4(), name="Platform", handle="platform", created_by=submitter.id)
-            listing = McpListing(
-                id=uuid.uuid4(),
-                name="internal-mcp",
-                namespace=team.handle,
-                slug="internal-mcp",
-                category="developer-tools",
-                owner=team.handle,
-                is_private=True,
-                team_id=team.id,
-                submitted_by=submitter.id,
-                co_authors=[],
-            )
-            async with sessions() as session:
-                session.add_all([team, listing])
-                if membership:
-                    session.add(
-                        TeamMembership(id=uuid.uuid4(), team_id=team.id, user_id=submitter.id, role=TeamRole.member)
-                    )
-                await session.commit()
-
-            async with sessions() as session:
-                yield session, listing, submitter
-        finally:
-            await engine.dispose()
-
-    @staticmethod
-    async def _visible_ids(session, caller):
-        from sqlalchemy import select
-
-        from models.mcp import McpListing
-
-        stmt = apply_visibility_filter(select(McpListing.id), McpListing, caller)
-        return set((await session.execute(stmt)).scalars().all())
-
     @pytest.mark.asyncio
     async def test_current_member_sees_the_listing_in_both_gates(self):
-        async with self._seeded(membership=True) as (session, listing, submitter):
-            assert listing.id in await self._visible_ids(session, submitter)
+        async with _seeded_team_private_listing(membership=True) as (session, listing, submitter):
+            assert listing.id in await _visible_ids(session, submitter)
             assert await check_listing_visibility_async(listing, submitter, session) is True
 
     @pytest.mark.asyncio
     async def test_ex_member_submitter_is_denied_by_the_list_filter_and_the_detail_helper(self):
         """Removing the submitter from the teamspace revokes both list and by-id reads."""
-        async with self._seeded(membership=False) as (session, listing, submitter):
-            assert await self._visible_ids(session, submitter) == set()
+        async with _seeded_team_private_listing(membership=False) as (session, listing, submitter):
+            assert await _visible_ids(session, submitter) == set()
             assert await check_listing_visibility_async(listing, submitter, session) is False
+
+
+class TestGlobalReviewerAgainstARealDatabase:
+    """Only admins hold a cross-team read of team-private listings.
+
+    A global reviewer reviews the PUBLIC catalog. Team-private items are reviewed
+    inside their own teamspace by a team owner or team reviewer, so routing another
+    team's private titles past a reviewer who is not in that team buys nothing and
+    discloses everything. Both gates are asserted together because the detail helper
+    is the row-level twin of the list filter, and a fix applied to only one of them
+    leaves a by-id read open.
+    """
+
+    @pytest.mark.asyncio
+    async def test_global_reviewer_outside_the_team_is_denied_by_both_gates(self):
+        async with _seeded_team_private_listing(membership=True) as (session, listing, _submitter):
+            reviewer = _user(role="reviewer")
+
+            assert await _visible_ids(session, reviewer) == set()
+            assert await check_listing_visibility_async(listing, reviewer, session) is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", ["admin", "super_admin"])
+    async def test_admins_still_see_the_listing_in_both_gates(self, role):
+        async with _seeded_team_private_listing(membership=True) as (session, listing, _submitter):
+            caller = _user(role=role)
+
+            assert listing.id in await _visible_ids(session, caller)
+            assert await check_listing_visibility_async(listing, caller, session) is True
+
+    @pytest.mark.asyncio
+    async def test_a_plain_team_member_still_sees_the_listing_in_both_gates(self):
+        async with _seeded_team_private_listing(membership=True) as (session, listing, member):
+            assert listing.id in await _visible_ids(session, member)
+            assert await check_listing_visibility_async(listing, member, session) is True
+
+    @pytest.mark.asyncio
+    async def test_a_public_listing_stays_readable_by_the_reviewer(self):
+        """The mirror case: narrowing privacy must not touch the public catalog.
+
+        Status gating is a separate axis handled by ``may_view_unapproved``, so a
+        reviewer keeps reading public rows here whatever their review state.
+        """
+        async with _seeded_team_private_listing(membership=True) as (session, listing, _submitter):
+            listing.is_private = False
+            listing.team_id = None
+            session.add(listing)
+            await session.commit()
+            reviewer = _user(role="reviewer")
+
+            assert listing.id in await _visible_ids(session, reviewer)
+            assert await check_listing_visibility_async(listing, reviewer, session) is True
 
 
 class _Result:
@@ -381,15 +473,32 @@ class TestResolveListingAmbiguity:
         assert resolved is rows[0]
 
     @pytest.mark.asyncio
-    async def test_reviewer_sees_every_colliding_listing(self):
+    @pytest.mark.parametrize("role", ["admin", "super_admin"])
+    async def test_admin_sees_every_colliding_listing(self, role):
         from models.mcp import McpListing
 
         rows = [_row("alice", "tool"), _row("secretteam", "tool", is_private=True, team_id=uuid.uuid4())]
         with pytest.raises(HTTPException) as exc:
-            await resolve_listing(McpListing, "tool", self._db(rows), current_user=_user(role="reviewer"))
+            await resolve_listing(McpListing, "tool", self._db(rows), current_user=_user(role=role))
 
         assert exc.value.status_code == 409
         assert "secretteam/tool" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_global_reviewer_is_not_told_about_a_team_private_collision(self):
+        """The 409 is built from what the caller may see, and a reviewer may not see this.
+
+        A collision report that named the teamspace listing would leak the private
+        canonical name to every global reviewer, which is exactly the disclosure the
+        admin-only read closes.
+        """
+        from models.mcp import McpListing
+
+        rows = [_row("alice", "tool"), _row("secretteam", "tool", is_private=True, team_id=uuid.uuid4())]
+
+        resolved = await resolve_listing(McpListing, "tool", self._db(rows), current_user=_user(role="reviewer"))
+
+        assert resolved is rows[0]
 
     @pytest.mark.asyncio
     async def test_qualified_name_is_never_treated_as_ambiguous(self):

--- a/tests/test_sec009_org_scoping.py
+++ b/tests/test_sec009_org_scoping.py
@@ -153,9 +153,7 @@ class TestApplyRegistryScope:
 
         team_id = uuid.uuid4()
         sql = _inline_sql(
-            apply_registry_scope(
-                select(McpListing.id), McpListing, _user(role="admin"), composable_for_team_id=team_id
-            )
+            apply_registry_scope(select(McpListing.id), McpListing, _user(role="admin"), composable_for_team_id=team_id)
         )
 
         assert "mcp_listings.is_private = false" in sql

--- a/tests/test_sec009_org_scoping.py
+++ b/tests/test_sec009_org_scoping.py
@@ -128,13 +128,35 @@ class TestApplyRegistryScope:
     two share an implementation. Narrowing to a single teamspace is ``?namespace=``.
     """
 
-    def test_team_filter_keeps_public_rows(self):
+    def test_team_filter_returns_only_that_teamspace_s_listings(self):
+        """?team_id= means ownership, so another namespace's public rows are out.
+
+        This used to reuse the publish-scope predicate, which kept every public
+        row in the registry. A teamspace page then listed other teams' listings
+        under its own tabs.
+        """
         from sqlalchemy import select
 
         from models.mcp import McpListing
 
         team_id = uuid.uuid4()
         sql = _inline_sql(apply_registry_scope(select(McpListing.id), McpListing, _user(role="admin"), team_id=team_id))
+
+        assert f"mcp_listings.team_id = '{team_id.hex}'" in sql
+        assert "is_private = false" not in sql
+
+    def test_composable_scope_keeps_public_rows(self):
+        """Agent composition still needs public plus the target team's private rows."""
+        from sqlalchemy import select
+
+        from models.mcp import McpListing
+
+        team_id = uuid.uuid4()
+        sql = _inline_sql(
+            apply_registry_scope(
+                select(McpListing.id), McpListing, _user(role="admin"), composable_for_team_id=team_id
+            )
+        )
 
         assert "mcp_listings.is_private = false" in sql
         assert f"mcp_listings.team_id = '{team_id.hex}'" in sql

--- a/tests/test_sec009_org_scoping.py
+++ b/tests/test_sec009_org_scoping.py
@@ -1,72 +1,49 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for org-scoped visibility on registry list and detail endpoints.
+"""Tests for public and teamspace visibility on registry listings."""
 
-Verifies that private listings are hidden from users in other organisations,
-visible to users in the same organisation, and always visible to admins.
-The same rules apply to MCP, skill, hook, prompt, and sandbox routes.
-"""
-
+import ast
 import uuid
-from unittest.mock import MagicMock
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
-from api.deps import apply_visibility_filter, check_listing_visibility
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import api.deps
+from api.deps import (
+    apply_registry_scope,
+    apply_visibility_filter,
+    check_listing_visibility_async,
+    resolve_listing,
+)
 
 # ── Unit tests for the shared helpers ─────────────────────────────────────────
 
 
-def _user(role="user", org_id=None):
+def _user(role="user"):
     from models.user import User, UserRole
 
     u = MagicMock(spec=User)
     u.id = uuid.uuid4()
     u.role = getattr(UserRole, role)
-    u.org_id = org_id or uuid.uuid4()
     return u
 
 
-def _listing(is_private=False, owner_org_id=None, submitted_by=None):
+def _listing(is_private=False, team_id=None, submitted_by=None):
     m = MagicMock()
     m.is_private = is_private
-    m.owner_org_id = owner_org_id or uuid.uuid4()
+    m.team_id = team_id
     m.submitted_by = submitted_by or uuid.uuid4()
     return m
 
 
-class TestCheckListingVisibility:
-    def test_public_listing_always_visible(self):
-        assert check_listing_visibility(_listing(is_private=False), None) is True
-        assert check_listing_visibility(_listing(is_private=False), _user()) is True
-
-    def test_private_hidden_from_anonymous(self):
-        assert check_listing_visibility(_listing(is_private=True), None) is False
-
-    def test_private_hidden_from_other_org(self):
-        org_a = uuid.uuid4()
-        org_b = uuid.uuid4()
-        listing = _listing(is_private=True, owner_org_id=org_a)
-        user = _user(org_id=org_b)
-        assert check_listing_visibility(listing, user) is False
-
-    def test_private_visible_to_same_org(self):
-        org = uuid.uuid4()
-        listing = _listing(is_private=True, owner_org_id=org)
-        user = _user(org_id=org)
-        assert check_listing_visibility(listing, user) is True
-
-    def test_private_visible_to_submitter(self):
-        user = _user()
-        listing = _listing(is_private=True, submitted_by=user.id)
-        assert check_listing_visibility(listing, user) is True
-
-    def test_private_visible_to_admin(self):
-        listing = _listing(is_private=True)
-        assert check_listing_visibility(listing, _user(role="admin")) is True
-        assert check_listing_visibility(listing, _user(role="reviewer")) is True
-
-    def test_no_is_private_attr_is_visible(self):
-        m = MagicMock(spec=[])  # no is_private attribute
-        assert check_listing_visibility(m, None) is True
+def _inline_sql(statement) -> str:
+    """Compile a statement to a single-line SQL string with bind values inlined."""
+    return " ".join(str(statement.compile(compile_kwargs={"literal_binds": True})).split())
 
 
 class TestApplyVisibilityFilter:
@@ -74,11 +51,6 @@ class TestApplyVisibilityFilter:
         s = MagicMock()
         s.where = MagicMock(return_value=s)
         return s
-
-    def _model(self):
-        from models.mcp import McpListing
-
-        return McpListing
 
     def test_no_is_private_attr_passes_through(self):
         model = MagicMock(spec=[])
@@ -108,3 +80,360 @@ class TestApplyVisibilityFilter:
         stmt = self._stmt()
         apply_visibility_filter(stmt, McpListing, _user(role="user"))
         stmt.where.assert_called_once()
+
+    def test_submitter_clause_is_restricted_to_listings_without_a_teamspace(self):
+        """The own-listing shortcut never admits a team-private row.
+
+        Team-private rows are admitted only by the membership EXISTS, so an
+        ex-member who submitted the listing no longer sees it in any list.
+        """
+        from sqlalchemy import select
+
+        from models.mcp import McpListing
+
+        caller = _user()
+        sql = _inline_sql(apply_visibility_filter(select(McpListing.id), McpListing, caller))
+
+        assert f"mcp_listings.team_id IS NULL AND mcp_listings.submitted_by = '{caller.id.hex}'" in sql
+        # The only other path to a private row is the correlated membership EXISTS.
+        assert "mcp_listings.is_private = true AND mcp_listings.team_id IS NOT NULL AND (EXISTS" in sql
+
+
+class TestApplyRegistryScope:
+    """``team_id`` on a list route means "public plus this teamspace", not "only this teamspace".
+
+    ``apply_publish_scope`` answers a different question (what an agent published
+    for a target may contain) but resolves to the same predicate, which is why the
+    two share an implementation. Narrowing to a single teamspace is ``?namespace=``.
+    """
+
+    def test_team_filter_keeps_public_rows(self):
+        from sqlalchemy import select
+
+        from models.mcp import McpListing
+
+        team_id = uuid.uuid4()
+        sql = _inline_sql(apply_registry_scope(select(McpListing.id), McpListing, _user(role="admin"), team_id=team_id))
+
+        assert "mcp_listings.is_private = false" in sql
+        assert f"mcp_listings.team_id = '{team_id.hex}'" in sql
+
+    def test_team_filter_still_hides_other_teams_private_rows_from_non_members(self):
+        from sqlalchemy import select
+
+        from models.mcp import McpListing
+
+        caller = _user()
+        team_id = uuid.uuid4()
+        sql = _inline_sql(apply_registry_scope(select(McpListing.id), McpListing, caller, team_id=team_id))
+
+        # Caller visibility is applied before the teamspace filter, so the
+        # membership EXISTS still gates every team-private row.
+        assert "team_memberships" in sql
+        assert f"team_memberships.user_id = '{caller.id.hex}'" in sql
+
+    def test_public_only_drops_the_team_filter(self):
+        from sqlalchemy import select
+
+        from models.mcp import McpListing
+
+        sql = _inline_sql(
+            apply_registry_scope(
+                select(McpListing.id), McpListing, _user(role="admin"), team_id=uuid.uuid4(), public_only=True
+            )
+        )
+
+        assert "mcp_listings.is_private = false" in sql
+        assert "mcp_listings.team_id =" not in sql
+
+
+class TestCheckListingVisibilityAsync:
+    """Detail and install routes resolve membership with a query instead of a cached list."""
+
+    def _db(self, membership_id=None):
+        db = MagicMock()
+        db.scalar = AsyncMock(return_value=membership_id)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_public_listing_needs_no_membership_query(self):
+        db = self._db()
+        assert await check_listing_visibility_async(_listing(is_private=False), _user(), db) is True
+        db.scalar.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_private_hidden_from_anonymous(self):
+        db = self._db(membership_id=uuid.uuid4())
+        assert await check_listing_visibility_async(_listing(is_private=True), None, db) is False
+        db.scalar.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_private_visible_to_team_member(self):
+        listing = _listing(is_private=True, team_id=uuid.uuid4())
+        assert await check_listing_visibility_async(listing, _user(), self._db(uuid.uuid4())) is True
+
+    @pytest.mark.asyncio
+    async def test_private_hidden_from_non_member(self):
+        listing = _listing(is_private=True, team_id=uuid.uuid4())
+        assert await check_listing_visibility_async(listing, _user(), self._db(None)) is False
+
+    @pytest.mark.asyncio
+    async def test_private_hidden_when_no_team_and_not_submitter(self):
+        listing = _listing(is_private=True, team_id=None)
+        assert await check_listing_visibility_async(listing, _user(), self._db(uuid.uuid4())) is False
+
+    @pytest.mark.asyncio
+    async def test_private_visible_to_submitter_when_there_is_no_teamspace(self):
+        user = _user()
+        listing = _listing(is_private=True, team_id=None, submitted_by=user.id)
+        assert await check_listing_visibility_async(listing, user, self._db(None)) is True
+
+    @pytest.mark.asyncio
+    async def test_submitter_removed_from_the_teamspace_loses_detail_access(self):
+        """Publishing into a teamspace hands the item to the team, not to the submitter.
+
+        Membership is the only grant, so this matches ``apply_visibility_filter``:
+        an ex-member cannot read by id something that no longer appears in any list.
+        """
+        user = _user()
+        listing = _listing(is_private=True, team_id=uuid.uuid4(), submitted_by=user.id)
+        db = self._db(None)  # membership row was deleted
+
+        assert await check_listing_visibility_async(listing, user, db) is False
+        db.scalar.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_private_visible_to_reviewer_and_admin(self):
+        listing = _listing(is_private=True, team_id=uuid.uuid4())
+        assert await check_listing_visibility_async(listing, _user(role="reviewer"), self._db(None)) is True
+        assert await check_listing_visibility_async(listing, _user(role="admin"), self._db(None)) is True
+
+
+class TestExMemberSubmitterAgainstARealDatabase:
+    """The list filter and the detail helper must agree on the same row.
+
+    These run the visibility SQL against in-memory SQLite instead of inspecting
+    it, so a divergence between ``apply_visibility_filter`` and
+    ``check_listing_visibility_async`` fails here rather than in production.
+    """
+
+    @staticmethod
+    @asynccontextmanager
+    async def _seeded(*, membership: bool):
+        """Yield (session, listing, submitter) for a team-private listing the submitter published."""
+        from models.base import Base
+        from models.mcp import McpListing, McpValidationResult, McpVersion
+        from models.team import Team, TeamMembership, TeamRole
+
+        tables = [
+            McpListing.__table__,
+            McpVersion.__table__,
+            McpValidationResult.__table__,
+            Team.__table__,
+            TeamMembership.__table__,
+        ]
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all, tables=tables)
+            sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+            submitter = _user()
+            team = Team(id=uuid.uuid4(), name="Platform", handle="platform", created_by=submitter.id)
+            listing = McpListing(
+                id=uuid.uuid4(),
+                name="internal-mcp",
+                namespace=team.handle,
+                slug="internal-mcp",
+                category="developer-tools",
+                owner=team.handle,
+                is_private=True,
+                team_id=team.id,
+                submitted_by=submitter.id,
+                co_authors=[],
+            )
+            async with sessions() as session:
+                session.add_all([team, listing])
+                if membership:
+                    session.add(
+                        TeamMembership(id=uuid.uuid4(), team_id=team.id, user_id=submitter.id, role=TeamRole.member)
+                    )
+                await session.commit()
+
+            async with sessions() as session:
+                yield session, listing, submitter
+        finally:
+            await engine.dispose()
+
+    @staticmethod
+    async def _visible_ids(session, caller):
+        from sqlalchemy import select
+
+        from models.mcp import McpListing
+
+        stmt = apply_visibility_filter(select(McpListing.id), McpListing, caller)
+        return set((await session.execute(stmt)).scalars().all())
+
+    @pytest.mark.asyncio
+    async def test_current_member_sees_the_listing_in_both_gates(self):
+        async with self._seeded(membership=True) as (session, listing, submitter):
+            assert listing.id in await self._visible_ids(session, submitter)
+            assert await check_listing_visibility_async(listing, submitter, session) is True
+
+    @pytest.mark.asyncio
+    async def test_ex_member_submitter_is_denied_by_the_list_filter_and_the_detail_helper(self):
+        """Removing the submitter from the teamspace revokes both list and by-id reads."""
+        async with self._seeded(membership=False) as (session, listing, submitter):
+            assert await self._visible_ids(session, submitter) == set()
+            assert await check_listing_visibility_async(listing, submitter, session) is False
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return SimpleNamespace(all=lambda: list(self._rows), first=lambda: self._rows[0] if self._rows else None)
+
+
+def _row(namespace, slug, *, is_private=False, team_id=None, submitted_by=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        namespace=namespace,
+        slug=slug,
+        qualified_name=f"{namespace}/{slug}",
+        is_private=is_private,
+        team_id=team_id,
+        submitted_by=submitted_by or uuid.uuid4(),
+    )
+
+
+class TestResolveListingAmbiguity:
+    """A legacy bare name must not disclose listings the caller cannot see."""
+
+    def _db(self, rows, membership_id=None):
+        return SimpleNamespace(
+            execute=AsyncMock(return_value=_Result(rows)),
+            scalar=AsyncMock(return_value=membership_id),
+        )
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_public_names_are_reported(self):
+        from models.mcp import McpListing
+
+        rows = [_row("alice", "tool"), _row("bob", "tool")]
+        with pytest.raises(HTTPException) as exc:
+            await resolve_listing(McpListing, "tool", self._db(rows), current_user=_user())
+
+        assert exc.value.status_code == 409
+        assert "alice/tool" in exc.value.detail
+        assert "bob/tool" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_ambiguity_message_omits_team_private_listings(self):
+        """A non-member learns nothing about the colliding teamspace listing."""
+        from models.mcp import McpListing
+
+        rows = [
+            _row("alice", "tool"),
+            _row("secretteam", "tool", is_private=True, team_id=uuid.uuid4()),
+            _row("otherteam", "tool", is_private=True, team_id=uuid.uuid4()),
+        ]
+        db = self._db(rows, membership_id=None)
+
+        resolved = await resolve_listing(McpListing, "tool", db, current_user=_user())
+
+        # Only one visible candidate remains, so the name is not ambiguous here.
+        assert resolved is rows[0]
+
+    @pytest.mark.asyncio
+    async def test_ambiguity_between_hidden_listings_is_not_disclosed(self):
+        from models.mcp import McpListing
+
+        rows = [
+            _row("secretteam", "tool", is_private=True, team_id=uuid.uuid4()),
+            _row("otherteam", "tool", is_private=True, team_id=uuid.uuid4()),
+        ]
+
+        assert await resolve_listing(McpListing, "tool", self._db(rows), current_user=_user()) is None
+
+    @pytest.mark.asyncio
+    async def test_anonymous_caller_never_sees_private_choices(self):
+        from models.mcp import McpListing
+
+        rows = [_row("alice", "tool"), _row("secretteam", "tool", is_private=True, team_id=uuid.uuid4())]
+
+        assert await resolve_listing(McpListing, "tool", self._db(rows), current_user=None) is rows[0]
+
+    @pytest.mark.asyncio
+    async def test_submitter_of_a_team_listing_is_not_told_about_it_after_removal(self):
+        from models.mcp import McpListing
+
+        user = _user()
+        rows = [
+            _row("alice", "tool"),
+            _row("exteam", "tool", is_private=True, team_id=uuid.uuid4(), submitted_by=user.id),
+        ]
+        db = self._db(rows, membership_id=None)
+
+        resolved = await resolve_listing(McpListing, "tool", db, current_user=user)
+
+        assert resolved is rows[0]
+
+    @pytest.mark.asyncio
+    async def test_reviewer_sees_every_colliding_listing(self):
+        from models.mcp import McpListing
+
+        rows = [_row("alice", "tool"), _row("secretteam", "tool", is_private=True, team_id=uuid.uuid4())]
+        with pytest.raises(HTTPException) as exc:
+            await resolve_listing(McpListing, "tool", self._db(rows), current_user=_user(role="reviewer"))
+
+        assert exc.value.status_code == 409
+        assert "secretteam/tool" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_qualified_name_is_never_treated_as_ambiguous(self):
+        from models.mcp import McpListing
+
+        rows = [_row("alice", "tool")]
+        assert await resolve_listing(McpListing, "alice/tool", self._db(rows), current_user=None) is rows[0]
+
+
+class TestEveryCallSitePassesTheCaller:
+    """``current_user`` on ``resolve_listing`` means "anonymous", never "unset".
+
+    A route that leaves it off evaluates a legacy bare-name collision as an
+    anonymous caller, so the team-private half of the collision drops out and a
+    name that must raise 409 for a team member silently resolves to the single
+    public row. No behavioural test catches that, because every test in this file
+    passes the caller explicitly, so this walks the shipped source instead.
+
+    The parameter keeps a default because ``None`` is a real value that the
+    anonymous detail routes pass on purpose. This scan is what makes omitting it
+    a build failure rather than a silent downgrade.
+    """
+
+    @staticmethod
+    def _call_sites():
+        """Yield (label, keyword names) for every ``resolve_listing`` call under api/."""
+        api_root = Path(api.deps.__file__).resolve().parent
+        for path in sorted(api_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+                if called != "resolve_listing":
+                    continue
+                label = f"{path.relative_to(api_root.parent)}:{node.lineno}"
+                yield label, {keyword.arg for keyword in node.keywords}
+
+    def test_no_call_site_resolves_a_bare_name_as_an_anonymous_caller(self):
+        offenders = [label for label, keywords in self._call_sites() if "current_user" not in keywords]
+        assert offenders == [], "resolve_listing called without current_user at: " + ", ".join(offenders)
+
+    def test_the_scan_actually_reaches_the_call_sites(self):
+        """Guard the guard: a rename that silently empties the walk must fail here."""
+        sites = list(self._call_sites())
+        assert len(sites) >= 20, f"expected the api package to still hold the call sites, found {len(sites)}"

--- a/tests/test_team_publishing.py
+++ b/tests/test_team_publishing.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from api.deps import get_current_user, get_db
@@ -77,8 +77,8 @@ MATRIX = [
     ("team-reviewer-team", UserRole.user, TeamRole.reviewer, "team", True),
     ("team-member-public", UserRole.user, TeamRole.member, "public", False),
     ("team-member-team", UserRole.user, TeamRole.member, "team", False),
-    ("global-reviewer-public", UserRole.reviewer, None, "public", True),
-    ("global-reviewer-team", UserRole.reviewer, None, "team", True),
+    ("global-reviewer-member-public", UserRole.reviewer, TeamRole.member, "public", True),
+    ("global-reviewer-member-team", UserRole.reviewer, TeamRole.member, "team", True),
     ("admin-public", UserRole.admin, None, "public", True),
     ("admin-team", UserRole.admin, None, "team", True),
     ("super-admin-public", UserRole.super_admin, None, "public", True),
@@ -108,6 +108,35 @@ class TestResolvePublishTargetAutoApprove:
         assert target.namespace == "platform-tools"
         assert target.visibility == visibility
         assert target.auto_approve is expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("visibility", ["public", "team"])
+    async def test_global_reviewer_cannot_publish_into_a_team_they_are_not_in(self, visibility):
+        """Publishing cross-team is an admin capability, not a reviewer one.
+
+        A global reviewer cannot read another team's private listings, so allowing
+        one to publish here would create a listing its own author can no longer see.
+        """
+        team_id = uuid.uuid4()
+        db = _mock_db([_membership(None)])
+        db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve_publish_target(
+                db, _user(UserRole.reviewer), "Internal Tool", team_id=team_id, visibility=visibility
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
+    async def test_admin_may_publish_into_a_team_they_are_not_in(self, role):
+        """Admins keep the cross-team capability because they can still read the result."""
+        team_id = uuid.uuid4()
+        db = _mock_db([_membership(None)])
+        db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+
+        target = await resolve_publish_target(db, _user(role), "Internal Tool", team_id=team_id, visibility="team")
+        assert (target.namespace, target.visibility, target.auto_approve) == ("platform-tools", "team", True)
 
     @pytest.mark.asyncio
     async def test_personal_public_listing_never_auto_approves(self):
@@ -210,7 +239,7 @@ class TestSkillSubmitStatus:
 
     @pytest.mark.asyncio
     async def test_global_reviewer_public_is_approved(self):
-        _listing, version = await self._submit(_user(UserRole.reviewer), None, "public")
+        _listing, version = await self._submit(_user(UserRole.reviewer), TeamRole.member, "public")
         assert version.status == ListingStatus.approved
         assert version.reviewed_by is not None
 

--- a/tests/test_team_publishing.py
+++ b/tests/test_team_publishing.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Team publishing auto-approval rules (Feature 3).
+
+Team owners and team reviewers clear the review queue for TEAM-visibility listings
+only. Publishing a PUBLIC listing out of a team namespace still goes through global
+review, because team roles are self-service and would otherwise be a privilege
+escalation path into the global catalog. Global reviewers, admins and super_admins
+keep auto-approval for every visibility.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from api.deps import get_current_user, get_db
+from models.agent import AgentStatus
+from models.mcp import ListingStatus
+from models.team import TeamRole
+from models.user import User, UserRole
+from services.teamspace import publish_auto_approves_for_entity, resolve_publish_target
+
+# ── Helpers ──────────────────────────────────────────────
+
+
+def _user(role=UserRole.user, **kw):
+    u = MagicMock(spec=User)
+    u.id = kw.get("id", uuid.uuid4())
+    u.role = role
+    u.username = kw.get("username", "testuser")
+    u.email = kw.get("email", "test@example.com")
+    return u
+
+
+def _membership(role: TeamRole | None):
+    return SimpleNamespace(role=role) if role is not None else None
+
+
+def _result(value):
+    """Stand in for a SQLAlchemy Result whose scalar lookup yields *value*."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    return r
+
+
+def _mock_db(execute_values=()):
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.flush = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_result(v) for v in execute_values])
+    return db
+
+
+def _app_with(router, user, db):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+# (label, user role, team role or None, visibility, expected auto approval)
+MATRIX = [
+    ("team-owner-public", UserRole.user, TeamRole.owner, "public", False),
+    ("team-owner-team", UserRole.user, TeamRole.owner, "team", True),
+    ("team-reviewer-public", UserRole.user, TeamRole.reviewer, "public", False),
+    ("team-reviewer-team", UserRole.user, TeamRole.reviewer, "team", True),
+    ("team-member-public", UserRole.user, TeamRole.member, "public", False),
+    ("team-member-team", UserRole.user, TeamRole.member, "team", False),
+    ("global-reviewer-public", UserRole.reviewer, None, "public", True),
+    ("global-reviewer-team", UserRole.reviewer, None, "team", True),
+    ("admin-public", UserRole.admin, None, "public", True),
+    ("admin-team", UserRole.admin, None, "team", True),
+    ("super-admin-public", UserRole.super_admin, None, "public", True),
+    ("super-admin-team", UserRole.super_admin, None, "team", True),
+]
+
+MATRIX_PARAMS = [pytest.param(*row[1:], id=row[0]) for row in MATRIX]
+
+
+# ═══════════════════════════════════════════════════════════
+# resolve_publish_target: new listings
+# ═══════════════════════════════════════════════════════════
+
+
+class TestResolvePublishTargetAutoApprove:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("user_role", "team_role", "visibility", "expected"), MATRIX_PARAMS)
+    async def test_matrix(self, user_role, team_role, visibility, expected):
+        team_id = uuid.uuid4()
+        db = _mock_db([_membership(team_role)])
+        db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+
+        target = await resolve_publish_target(
+            db, _user(user_role), "Internal Tool", team_id=team_id, visibility=visibility
+        )
+
+        assert target.namespace == "platform-tools"
+        assert target.visibility == visibility
+        assert target.auto_approve is expected
+
+    @pytest.mark.asyncio
+    async def test_personal_public_listing_never_auto_approves(self):
+        target = await resolve_publish_target(_mock_db(), _user(UserRole.super_admin), "Internal Tool")
+        assert (target.team_id, target.visibility, target.auto_approve) == (None, "public", False)
+
+
+# ═══════════════════════════════════════════════════════════
+# publish_auto_approves_for_entity: saved drafts
+# ═══════════════════════════════════════════════════════════
+
+
+class TestEntityAutoApprove:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("user_role", "team_role", "visibility", "expected"), MATRIX_PARAMS)
+    async def test_matrix(self, user_role, team_role, visibility, expected):
+        entity = SimpleNamespace(team_id=uuid.uuid4(), is_private=visibility == "team")
+        db = _mock_db([_membership(team_role)])
+
+        assert await publish_auto_approves_for_entity(entity, _user(user_role), db) is expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("visibility", ["public", "team"])
+    async def test_non_member_never_auto_approves(self, visibility):
+        entity = SimpleNamespace(team_id=uuid.uuid4(), is_private=visibility == "team")
+        assert await publish_auto_approves_for_entity(entity, _user(), _mock_db([None])) is False
+
+    @pytest.mark.asyncio
+    async def test_personal_listing_skips_membership_lookup(self):
+        db = _mock_db()
+        entity = SimpleNamespace(team_id=None, is_private=False)
+        assert await publish_auto_approves_for_entity(entity, _user(UserRole.super_admin), db) is False
+        db.execute.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════
+# Route level: the auto-approval decision becomes a status
+# ═══════════════════════════════════════════════════════════
+
+
+class TestSkillSubmitStatus:
+    """POST /skills/submit resolves a publish target, so the status follows the matrix."""
+
+    @staticmethod
+    async def _submit(user, team_role, visibility):
+        from api.routes.skill import router
+        from models.skill import SkillListing, SkillVersion
+
+        team_id = uuid.uuid4()
+        # membership lookup, then the namespace/slug collision check.
+        db = _mock_db([_membership(team_role), None])
+        db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+
+        def _refresh(obj):
+            obj.id = uuid.uuid4()
+            obj.created_at = datetime.now(UTC)
+            obj.updated_at = datetime.now(UTC)
+
+        db.refresh = AsyncMock(side_effect=_refresh)
+        app = _app_with(router, user, db)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r = await ac.post(
+                "/api/v1/skills/submit",
+                json={
+                    "name": "s",
+                    "version": "1.0",
+                    "description": "d",
+                    "owner": "o",
+                    "task_type": "code-review",
+                    "team_id": str(team_id),
+                    "visibility": visibility,
+                },
+            )
+
+        assert r.status_code == 200, r.text
+        listing = next(c.args[0] for c in db.add.call_args_list if isinstance(c.args[0], SkillListing))
+        version = next(c.args[0] for c in db.add.call_args_list if isinstance(c.args[0], SkillVersion))
+        return listing, version
+
+    @pytest.mark.asyncio
+    async def test_team_owner_public_stays_pending(self):
+        listing, version = await self._submit(_user(), TeamRole.owner, "public")
+        assert listing.is_private is False
+        assert version.status == ListingStatus.pending
+        assert version.reviewed_by is None
+        assert version.reviewed_at is None
+
+    @pytest.mark.asyncio
+    async def test_team_owner_team_is_approved(self):
+        listing, version = await self._submit(_user(), TeamRole.owner, "team")
+        assert listing.is_private is True
+        assert version.status == ListingStatus.approved
+        assert version.reviewed_by is not None
+
+    @pytest.mark.asyncio
+    async def test_team_reviewer_public_stays_pending(self):
+        _listing, version = await self._submit(_user(), TeamRole.reviewer, "public")
+        assert version.status == ListingStatus.pending
+
+    @pytest.mark.asyncio
+    async def test_global_reviewer_public_is_approved(self):
+        _listing, version = await self._submit(_user(UserRole.reviewer), None, "public")
+        assert version.status == ListingStatus.approved
+        assert version.reviewed_by is not None
+
+
+class TestAgentSubmitStatus:
+    """POST /agents/{id}/submit reads the saved agent's own visibility."""
+
+    @staticmethod
+    def _agent(is_private):
+        m = MagicMock()
+        m.id = uuid.uuid4()
+        m.name = "test-agent"
+        m.status = AgentStatus.draft
+        m.team_id = uuid.uuid4()
+        m.is_private = is_private
+        m.components = []
+        m.description = "A test agent"
+        m.owner = "testowner"
+        m.rejection_reason = None
+        m.deleted_at = None
+        m.latest_version.prompt = "Test prompt"
+        m.latest_version.reviewed_by = None
+        m.latest_version.reviewed_at = None
+        return m
+
+    @staticmethod
+    async def _submit(user, team_role, is_private):
+        from api.routes.agent import draft as draft_routes
+
+        agent = TestAgentSubmitStatus._agent(is_private)
+        agent.created_by = user.id
+        db = _mock_db([_membership(team_role)])
+
+        with (
+            patch("services.agent_snapshot.build_yaml_snapshot", new=AsyncMock(return_value="snapshot")),
+            patch.object(draft_routes, "emit_registry_event"),
+            patch.object(draft_routes, "_resolve_component_names", new=AsyncMock(return_value={})),
+            patch.object(draft_routes, "_load_agent", new=AsyncMock(return_value=agent)),
+            patch.object(draft_routes, "_agent_to_response", new=MagicMock(return_value={"status": "ok"})),
+        ):
+            await draft_routes.submit_draft(str(agent.id), db, user)
+
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_team_owner_public_agent_stays_pending(self):
+        agent = await self._submit(_user(), TeamRole.owner, is_private=False)
+        assert agent.status == AgentStatus.pending
+        assert agent.latest_version.reviewed_by is None
+
+    @pytest.mark.asyncio
+    async def test_team_owner_team_agent_is_approved(self):
+        agent = await self._submit(_user(), TeamRole.owner, is_private=True)
+        assert agent.status == AgentStatus.approved
+        assert agent.latest_version.reviewed_by is not None
+
+    @pytest.mark.asyncio
+    async def test_team_reviewer_public_agent_stays_pending(self):
+        agent = await self._submit(_user(), TeamRole.reviewer, is_private=False)
+        assert agent.status == AgentStatus.pending
+
+    @pytest.mark.asyncio
+    async def test_team_member_team_agent_stays_pending(self):
+        agent = await self._submit(_user(), TeamRole.member, is_private=True)
+        assert agent.status == AgentStatus.pending
+
+    @pytest.mark.asyncio
+    async def test_admin_public_agent_is_approved(self):
+        agent = await self._submit(_user(UserRole.admin), None, is_private=False)
+        assert agent.status == AgentStatus.approved

--- a/tests/test_team_review.py
+++ b/tests/test_team_review.py
@@ -618,7 +618,8 @@ class TestTeamDeletionGuard:
         team = self._team()
         db = AsyncMock()
         # One skill left in the teamspace is enough to block the delete.
-        db.scalar = AsyncMock(side_effect=[0, 0, 1, 0, 0, 0])
+        # agents, mcp, skill, hook, prompt, sandbox, component_source
+        db.scalar = AsyncMock(side_effect=[0, 0, 1, 0, 0, 0, 0])
 
         with (
             patch("api.routes.teams._require_owner_or_admin", new=AsyncMock(return_value=team)),
@@ -652,7 +653,7 @@ class TestTeamDeletionGuard:
 
         team = self._team()
         db = AsyncMock()
-        db.scalar = AsyncMock(side_effect=[0, 0, 0, 0, 0, 2])
+        db.scalar = AsyncMock(side_effect=[0, 0, 0, 0, 0, 2, 0])
 
         with (
             patch("api.routes.teams._require_owner_or_admin", new=AsyncMock(return_value=team)),

--- a/tests/test_team_review.py
+++ b/tests/test_team_review.py
@@ -1,0 +1,589 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the team-scoped review queue at /api/v1/review.
+
+Every route in api/routes/review.py used to sit behind require_role(UserRole.reviewer),
+the GLOBAL role, which produced two defects at once:
+
+1. A team-private item published by a plain team member landed in the global queue,
+   where only a reviewer outside the team could approve it. Team-private titles were
+   routed to outsiders and the team stayed blocked until one of them acted.
+2. The "reviewer" team role granted no review capability whatsoever. A team owner and
+   a team reviewer both got 403 on the queue and on approve.
+
+Review is now capability scoped. The queue, the detail view, and the approve and
+reject actions all read one ReviewScope, so the list and the actions cannot drift
+apart: whatever a caller cannot see in the queue, they also cannot approve.
+
+The escalation this must not open is the mirror of the one team_role_self_publishes
+closes at publish time. Team roles are self-service, so a team owner who could approve
+a PUBLIC listing standing in their own team namespace would have a one-step route into
+the global catalog. Public items therefore stay with global reviewers, team roles or not.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from api.deps import get_current_user, get_db
+from api.routes.review import router as review_router
+from models.agent import Agent, AgentStatus, AgentVersion
+from models.agent_component import AgentComponent
+from models.base import Base
+from models.hook import HookListing, HookVersion
+from models.mcp import ListingStatus, McpListing, McpValidationResult, McpVersion
+from models.prompt import PromptListing, PromptVersion
+from models.sandbox import SandboxListing, SandboxVersion
+from models.skill import SkillListing, SkillVersion
+from models.team import Team, TeamMembership, TeamRole
+from models.user import User, UserRole
+
+# The default queue walks agents plus all five component types, so every one of
+# those tables has to exist even when a case only seeds MCPs.
+_TABLES = [
+    User.__table__,
+    Team.__table__,
+    TeamMembership.__table__,
+    McpListing.__table__,
+    McpVersion.__table__,
+    McpValidationResult.__table__,
+    SkillListing.__table__,
+    SkillVersion.__table__,
+    HookListing.__table__,
+    HookVersion.__table__,
+    PromptListing.__table__,
+    PromptVersion.__table__,
+    SandboxListing.__table__,
+    SandboxVersion.__table__,
+    Agent.__table__,
+    AgentVersion.__table__,
+    AgentComponent.__table__,
+]
+
+_EPOCH = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@asynccontextmanager
+async def _sessions():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all, tables=_TABLES)
+        yield async_sessionmaker(engine, expire_on_commit=False)
+    finally:
+        await engine.dispose()
+
+
+def _actor(user: User) -> SimpleNamespace:
+    """The request-scoped view of a seeded user, as get_current_user hands it over."""
+    return SimpleNamespace(id=user.id, role=user.role, email=user.email, username=user.username)
+
+
+def _user(handle: str, role: UserRole = UserRole.user) -> User:
+    return User(
+        id=uuid.uuid4(),
+        email=f"{handle}@example.com",
+        username=handle,
+        name=handle,
+        role=role,
+    )
+
+
+def _mcp(name: str, *, team_id, is_private: bool, submitted_by) -> McpListing:
+    return McpListing(
+        id=uuid.uuid4(),
+        name=name,
+        namespace="acme",
+        slug=name,
+        category="general",
+        owner="acme",
+        submitted_by=submitted_by,
+        team_id=team_id,
+        is_private=is_private,
+        co_authors=[],
+    )
+
+
+def _mcp_version(listing: McpListing, released_by) -> McpVersion:
+    return McpVersion(
+        id=uuid.uuid4(),
+        listing_id=listing.id,
+        version="1.0.0",
+        description=f"{listing.name} description",
+        released_by=released_by,
+        released_at=_EPOCH,
+        status=ListingStatus.pending,
+    )
+
+
+@asynccontextmanager
+async def _client(sessions, actor):
+    async with sessions() as session:
+        app = FastAPI()
+        app.include_router(review_router)
+        app.dependency_overrides[get_db] = lambda: session
+        app.dependency_overrides[get_current_user] = lambda: actor
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            yield client
+
+
+async def _seed(sessions):
+    """One teamspace holding a pending team-private MCP, a pending public MCP, and a pending team-private agent.
+
+    Every item is submitted by a plain team member, which is the case the whole
+    feature exists for: a member publishes, and someone has to clear the queue.
+    """
+    owner = _user("teamowner")
+    reviewer = _user("teamreviewer")
+    member = _user("teammember")
+    outsider = _user("outsider")
+    other_owner = _user("otherowner")
+    global_reviewer = _user("globalreviewer", role=UserRole.reviewer)
+    admin = _user("admin", role=UserRole.admin)
+
+    team = Team(id=uuid.uuid4(), name="Acme", handle="acme", created_by=owner.id)
+    other_team = Team(id=uuid.uuid4(), name="Other", handle="other", created_by=other_owner.id)
+    memberships = [
+        TeamMembership(team_id=team.id, user_id=owner.id, role=TeamRole.owner),
+        TeamMembership(team_id=team.id, user_id=reviewer.id, role=TeamRole.reviewer),
+        TeamMembership(team_id=team.id, user_id=member.id, role=TeamRole.member),
+        TeamMembership(team_id=other_team.id, user_id=other_owner.id, role=TeamRole.owner),
+    ]
+
+    private = _mcp("internal", team_id=team.id, is_private=True, submitted_by=member.id)
+    public = _mcp("shared", team_id=team.id, is_private=False, submitted_by=member.id)
+
+    agent = Agent(
+        id=uuid.uuid4(),
+        name="Triage",
+        namespace="acme",
+        slug="triage",
+        owner="acme",
+        created_by=member.id,
+        team_id=team.id,
+        is_private=True,
+        co_authors=[],
+    )
+    agent_version = AgentVersion(
+        id=uuid.uuid4(),
+        agent_id=agent.id,
+        version="1.0.0",
+        model_name="claude-sonnet-4-5",
+        released_by=member.id,
+        status=AgentStatus.pending,
+        created_at=_EPOCH,
+    )
+
+    async with sessions() as session:
+        session.add_all([owner, reviewer, member, outsider, other_owner, global_reviewer, admin])
+        session.add_all([team, other_team, *memberships])
+        # Listings go in before their versions: listing.versions and
+        # listing.latest_version point at each other, so flushing both in one unit
+        # of work makes SQLAlchemy see a circular dependency.
+        session.add_all([private, public, agent])
+        await session.flush()
+        for listing in (private, public):
+            version = _mcp_version(listing, member.id)
+            session.add(version)
+            await session.flush()
+            listing.latest_version_id = version.id
+        session.add(agent_version)
+        await session.flush()
+        agent.latest_version_id = agent_version.id
+        await session.commit()
+
+    return SimpleNamespace(
+        team_owner=_actor(owner),
+        team_reviewer=_actor(reviewer),
+        team_member=_actor(member),
+        outsider=_actor(outsider),
+        other_owner=_actor(other_owner),
+        global_reviewer=_actor(global_reviewer),
+        admin=_actor(admin),
+        team_id=team.id,
+        other_team_id=other_team.id,
+        private_id=private.id,
+        public_id=public.id,
+        agent_id=agent.id,
+    )
+
+
+async def _queue(sessions, actor, **params):
+    async with _client(sessions, actor) as client:
+        return await client.get("/api/v1/review", params=params)
+
+
+def _names(response) -> set[str]:
+    return {item["name"] for item in response.json()}
+
+
+# ── The queue: who may open it at all ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_owner", "team_reviewer", "global_reviewer", "admin"])
+async def test_review_capability_opens_the_queue(who):
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, getattr(seed, who))
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_member", "outsider"])
+async def test_no_review_capability_is_403_not_an_empty_queue(who):
+    """A plain member and a non-member keep the 'you have no business here' signal.
+
+    Answering 200 with [] would read as "nothing to review" and hide the fact that
+    the caller holds no review capability at all.
+    """
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, getattr(seed, who))
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Insufficient permissions"
+
+
+# ── The queue: what each capability contains ───────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_owner", "team_reviewer"])
+async def test_team_review_roles_see_their_teams_private_items(who):
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, getattr(seed, who))
+    assert response.status_code == 200
+    assert "internal" in _names(response)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_owner", "team_reviewer"])
+async def test_team_review_roles_do_not_see_their_teams_public_items(who):
+    """They cannot approve a public item, so listing it would only mislead them."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, getattr(seed, who))
+    assert "shared" not in _names(response)
+
+
+@pytest.mark.asyncio
+async def test_team_review_roles_see_their_teams_private_agents():
+    """Agents carry team_id and is_private too, so they scope the same way."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.team_owner)
+    assert "Triage" in _names(response)
+
+
+@pytest.mark.asyncio
+async def test_global_reviewer_sees_public_pending_items():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.global_reviewer)
+    assert response.status_code == 200
+    assert "shared" in _names(response)
+
+
+@pytest.mark.asyncio
+async def test_global_reviewer_never_sees_team_private_items():
+    """The privacy fix: private titles must not reach a reviewer outside the team."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.global_reviewer)
+    assert "internal" not in _names(response)
+    assert "Triage" not in _names(response)
+    assert "internal" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_admin_sees_public_and_private_items():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.admin)
+    assert {"internal", "shared", "Triage"} <= _names(response)
+
+
+@pytest.mark.asyncio
+async def test_a_team_owner_does_not_see_another_teams_private_items():
+    """The teamspace grants the item, not merely holding a team role somewhere."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.other_owner)
+    assert response.status_code == 200
+    assert _names(response) == set()
+
+
+@pytest.mark.asyncio
+async def test_another_teams_owner_cannot_approve_this_teams_private_item():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve(sessions, seed.other_owner, seed.private_id)
+    assert response.status_code == 403
+
+
+# ── The queue: ?team_id= narrowing ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_team_id_filter_narrows_to_that_teamspace():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.team_owner, team_id=str(seed.team_id))
+    assert response.status_code == 200
+    assert "internal" in _names(response)
+
+
+@pytest.mark.asyncio
+async def test_team_id_filter_for_a_teamspace_the_caller_does_not_review_for_is_403():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.team_owner, team_id=str(seed.other_team_id))
+    assert response.status_code == 403
+    assert response.json()["detail"] == "You do not review for this teamspace"
+
+
+@pytest.mark.asyncio
+async def test_team_id_filter_drops_items_from_other_teamspaces():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.admin, team_id=str(seed.other_team_id))
+    assert response.status_code == 200
+    assert _names(response) == set()
+
+
+@pytest.mark.asyncio
+async def test_team_id_filter_does_not_widen_a_global_reviewer():
+    """Narrowing to a teamspace still cannot surface that teamspace's private items."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _queue(sessions, seed.global_reviewer, team_id=str(seed.team_id))
+    assert response.status_code == 200
+    assert _names(response) == {"shared"}
+
+
+# ── Approving a team-private item ──────────────────────────────────────────
+
+
+async def _approve(sessions, actor, listing_id):
+    async with _client(sessions, actor) as client:
+        return await client.post(f"/api/v1/review/{listing_id}/approve")
+
+
+async def _reject(sessions, actor, listing_id, reason="not yet"):
+    async with _client(sessions, actor) as client:
+        return await client.post(f"/api/v1/review/{listing_id}/reject", json={"reason": reason})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_owner", "team_reviewer", "admin"])
+async def test_team_private_item_is_approved_inside_its_team(who):
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve(sessions, getattr(seed, who), seed.private_id)
+        assert response.status_code == 200
+        assert response.json()["status"] == ListingStatus.approved.value
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.private_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            assert version.status == ListingStatus.approved
+            assert version.reviewed_by == getattr(seed, who).id
+            assert version.reviewed_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_member", "outsider"])
+async def test_team_private_item_is_not_approved_without_a_review_role(who):
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve(sessions, getattr(seed, who), seed.private_id)
+        assert response.status_code == 403
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.private_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            assert version.status == ListingStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_global_reviewer_cannot_approve_a_team_private_item():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve(sessions, seed.global_reviewer, seed.private_id)
+        assert response.status_code == 403
+        assert "team" in response.json()["detail"].lower()
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.private_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            assert version.status == ListingStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_team_reviewer_rejects_a_team_private_item():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _reject(sessions, seed.team_reviewer, seed.private_id, reason="needs docs")
+        assert response.status_code == 200
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.private_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            assert version.status == ListingStatus.rejected
+            assert version.rejection_reason == "needs docs"
+
+
+@pytest.mark.asyncio
+async def test_global_reviewer_cannot_reject_a_team_private_item():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _reject(sessions, seed.global_reviewer, seed.private_id)
+        assert response.status_code == 403
+
+
+# ── Approving a public item ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["global_reviewer", "admin"])
+async def test_public_item_is_approved_by_a_global_role(who):
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve(sessions, getattr(seed, who), seed.public_id)
+        assert response.status_code == 200
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.public_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            assert version.status == ListingStatus.approved
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_owner", "team_reviewer"])
+async def test_team_role_cannot_approve_a_public_item_in_its_own_namespace(who):
+    """The escalation this closes: team roles are self-service, so a team owner who
+    could approve a public listing standing in their own namespace would promote
+    anything into the global catalog by first promoting themselves."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve(sessions, getattr(seed, who), seed.public_id)
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Public items are reviewed by global reviewers, not by teamspace roles"
+
+        async with sessions() as session:
+            listing = await session.get(McpListing, seed.public_id)
+            version = await session.get(McpVersion, listing.latest_version_id)
+            assert version.status == ListingStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_team_role_cannot_reject_a_public_item_in_its_own_namespace():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _reject(sessions, seed.team_owner, seed.public_id)
+        assert response.status_code == 403
+
+
+# ── Agents ─────────────────────────────────────────────────────────────────
+
+
+async def _approve_agent(sessions, actor, agent_id):
+    async with _client(sessions, actor) as client:
+        return await client.post(f"/api/v1/review/agents/{agent_id}/approve")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_owner", "team_reviewer", "admin"])
+async def test_team_private_agent_is_approved_inside_its_team(who):
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve_agent(sessions, getattr(seed, who), seed.agent_id)
+        assert response.status_code == 200
+        assert response.json()["status"] == "approved"
+
+        async with sessions() as session:
+            agent = await session.get(Agent, seed.agent_id)
+            version = await session.get(AgentVersion, agent.latest_version_id)
+            assert version.status == AgentStatus.approved
+
+
+@pytest.mark.asyncio
+async def test_global_reviewer_cannot_approve_a_team_private_agent():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _approve_agent(sessions, seed.global_reviewer, seed.agent_id)
+        assert response.status_code == 403
+
+        async with sessions() as session:
+            agent = await session.get(Agent, seed.agent_id)
+            version = await session.get(AgentVersion, agent.latest_version_id)
+            assert version.status == AgentStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_team_member_cannot_reject_a_team_private_agent():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        async with _client(sessions, seed.team_member) as client:
+            response = await client.post(
+                f"/api/v1/review/agents/{seed.agent_id}/reject",
+                json={"reason": "no"},
+            )
+    assert response.status_code == 403
+
+
+# ── The detail view follows the queue ──────────────────────────────────────
+
+
+async def _detail(sessions, actor, listing_id):
+    async with _client(sessions, actor) as client:
+        return await client.get(f"/api/v1/review/{listing_id}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("who", ["team_owner", "team_reviewer", "admin"])
+async def test_team_private_detail_opens_for_its_team(who):
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _detail(sessions, getattr(seed, who), seed.private_id)
+    assert response.status_code == 200
+    assert response.json()["name"] == "internal"
+
+
+@pytest.mark.asyncio
+async def test_team_private_detail_is_404_for_a_global_reviewer():
+    """404, not 403: a 403 would confirm the item exists to the reviewer the
+    scoping keeps away from it, and the queue already hides it."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _detail(sessions, seed.global_reviewer, seed.private_id)
+    assert response.status_code == 404
+    assert "internal" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_team_private_agent_detail_is_404_for_a_global_reviewer():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _detail(sessions, seed.global_reviewer, seed.agent_id)
+    assert response.status_code == 404
+    assert "Triage" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_public_detail_is_404_for_a_team_role_that_cannot_act_on_it():
+    """The detail view and the queue read one scope, so they cannot drift apart."""
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        response = await _detail(sessions, seed.team_owner, seed.public_id)
+    assert response.status_code == 404

--- a/tests/test_team_review.py
+++ b/tests/test_team_review.py
@@ -329,7 +329,7 @@ async def test_another_teams_owner_cannot_approve_this_teams_private_item():
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _approve(sessions, seed.other_owner, seed.private_id)
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
 # ── The queue: ?team_id= narrowing ─────────────────────────────────────────
@@ -421,8 +421,7 @@ async def test_global_reviewer_cannot_approve_a_team_private_item():
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _approve(sessions, seed.global_reviewer, seed.private_id)
-        assert response.status_code == 403
-        assert "team" in response.json()["detail"].lower()
+        assert response.status_code == 404
 
         async with sessions() as session:
             listing = await session.get(McpListing, seed.private_id)
@@ -449,7 +448,7 @@ async def test_global_reviewer_cannot_reject_a_team_private_item():
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _reject(sessions, seed.global_reviewer, seed.private_id)
-        assert response.status_code == 403
+        assert response.status_code == 404
 
 
 # ── Approving a public item ────────────────────────────────────────────────
@@ -523,7 +522,7 @@ async def test_global_reviewer_cannot_approve_a_team_private_agent():
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _approve_agent(sessions, seed.global_reviewer, seed.agent_id)
-        assert response.status_code == 403
+        assert response.status_code == 404
 
         async with sessions() as session:
             agent = await session.get(Agent, seed.agent_id)

--- a/tests/test_team_review.py
+++ b/tests/test_team_review.py
@@ -28,9 +28,10 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -587,3 +588,77 @@ async def test_public_detail_is_404_for_a_team_role_that_cannot_act_on_it():
         seed = await _seed(sessions)
         response = await _detail(sessions, seed.team_owner, seed.public_id)
     assert response.status_code == 404
+
+
+# ── Deleting a teamspace must not strip access from its listings ─────────────
+
+
+class TestTeamDeletionGuard:
+    """ON DELETE SET NULL turns a team-private listing into an orphan.
+
+    Reproduced against a live stack before the guard existed: deleting a team
+    returned 204, and the listing kept is_private=True with team_id=NULL. Its
+    submitter still reached it through the personal-private clause, but every
+    other member went from 200 to 404 with no warning, and the listing still
+    reported visibility "team" while belonging to no team. Freeing the handle
+    also lets the next registrant claim that namespace.
+    """
+
+    @staticmethod
+    def _team():
+        team = MagicMock()
+        team.id = uuid.uuid4()
+        team.handle = "platform-tools"
+        return team
+
+    @pytest.mark.asyncio
+    async def test_delete_is_refused_while_the_team_owns_listings(self):
+        from api.routes.teams import delete_team
+
+        team = self._team()
+        db = AsyncMock()
+        # One skill left in the teamspace is enough to block the delete.
+        db.scalar = AsyncMock(side_effect=[0, 0, 1, 0, 0, 0])
+
+        with (
+            patch("api.routes.teams._require_owner_or_admin", new=AsyncMock(return_value=team)),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await delete_team(team_id=team.id, db=db, current_user=MagicMock())
+
+        assert exc.value.status_code == 409
+        assert "1 skill" in exc.value.detail
+        assert "platform-tools" in exc.value.detail
+        db.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_proceeds_for_an_empty_teamspace(self):
+        from api.routes.teams import delete_team
+
+        team = self._team()
+        db = AsyncMock()
+        db.scalar = AsyncMock(return_value=0)
+
+        with patch("api.routes.teams._require_owner_or_admin", new=AsyncMock(return_value=team)):
+            await delete_team(team_id=team.id, db=db, current_user=MagicMock())
+
+        db.delete.assert_awaited_once_with(team)
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_every_listing_kind_is_counted(self):
+        """A teamspace holding only sandboxes must block too, not just skills."""
+        from api.routes.teams import delete_team
+
+        team = self._team()
+        db = AsyncMock()
+        db.scalar = AsyncMock(side_effect=[0, 0, 0, 0, 0, 2])
+
+        with (
+            patch("api.routes.teams._require_owner_or_admin", new=AsyncMock(return_value=team)),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await delete_team(team_id=team.id, db=db, current_user=MagicMock())
+
+        assert exc.value.status_code == 409
+        assert "2 sandboxes" in exc.value.detail

--- a/tests/test_team_visibility_migrations.py
+++ b/tests/test_team_visibility_migrations.py
@@ -81,6 +81,20 @@ def test_component_source_migration_has_no_data_mutation_sql():
     assert "is_public=True" not in source
 
 
+def test_team_foreign_keys_match_the_restrict_migration():
+    from models.agent import Agent
+    from models.component_source import ComponentSource
+    from models.hook import HookListing
+    from models.mcp import McpListing
+    from models.prompt import PromptListing
+    from models.sandbox import SandboxListing
+    from models.skill import SkillListing
+
+    for model in (Agent, McpListing, SkillListing, HookListing, PromptListing, SandboxListing, ComponentSource):
+        foreign_key = next(key for key in model.__table__.foreign_keys if key.target_fullname == "teams.id")
+        assert foreign_key.ondelete == "RESTRICT"
+
+
 class _FakeResult:
     def __init__(self, count: int) -> None:
         self._count = count

--- a/tests/test_team_visibility_migrations.py
+++ b/tests/test_team_visibility_migrations.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guards for the Feature 3 team visibility migration.
+
+Covers two things a migration review must never miss:
+1. 018_team_publishing must not mutate row visibility. A bulk publish of legacy
+   private rows is an irreversible data disclosure that fires on every upgrade.
+2. It must refuse to drop team_id while team-owned rows exist.
+"""
+
+import ast
+import importlib.util
+import re
+import types
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from api.deps import check_listing_visibility_async
+from models.user import UserRole
+
+VERSIONS_DIR = Path(__file__).resolve().parents[1] / "observal-server" / "alembic" / "versions"
+# Both halves of the original change now live in one migration, named to match the
+# repo convention of NNN_slug for the file and the revision id alike.
+TEAM_PUBLISHING_MIGRATION = VERSIONS_DIR / "018_team_publishing.py"
+COMPONENT_SOURCE_MIGRATION = TEAM_PUBLISHING_MIGRATION
+
+# Schema operations the migration is allowed to perform. alter_column is here
+# because agents.is_private is added with a false server default and then has that
+# default dropped, so new rows must state their own visibility. Every entry
+# changes structure only: none of them can touch row data.
+ALLOWED_SCHEMA_OPS = {"add_column", "alter_column", "create_index", "create_foreign_key"}
+
+
+def _load_migration(path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(f"_migration_{path.stem}", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _function_node(path: Path, name: str) -> ast.FunctionDef:
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{path.name} has no function {name}")
+
+
+def _called_op_methods(node: ast.AST) -> set[str]:
+    calls = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
+            value = child.func.value
+            if isinstance(value, ast.Name):
+                calls.add(f"{value.id}.{child.func.attr}")
+    return calls
+
+
+def test_component_source_migration_only_changes_schema():
+    """018_team_publishing must add columns and constraints and nothing else.
+
+    The removed backfill flipped every is_private listing and every non public
+    component source in one statement. downgrade() has no record of which rows it
+    touched, so the disclosure is permanent.
+    """
+    calls = _called_op_methods(_function_node(COMPONENT_SOURCE_MIGRATION, "upgrade"))
+    op_calls = {call for call in calls if call.startswith("op.")}
+    assert op_calls == {f"op.{name}" for name in ALLOWED_SCHEMA_OPS}
+    assert not any(call.startswith("sa.update") for call in calls)
+    assert "op.execute" not in op_calls
+
+
+def test_component_source_migration_has_no_data_mutation_sql():
+    source = COMPONENT_SOURCE_MIGRATION.read_text()
+    assert not re.search(r"\bUPDATE\b", source, re.IGNORECASE)
+    assert "is_private=False" not in source
+    assert "is_public=True" not in source
+
+
+class _FakeResult:
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def scalar_one(self) -> int:
+        return self._count
+
+
+class _FakeConnection:
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    def execute(self, clause):
+        sql = str(clause)
+        table = sql.split(" FROM ")[1].split(" ")[0]
+        return _FakeResult(self._counts.get(table, 0))
+
+
+@pytest.fixture
+def team_publishing_migration(monkeypatch):
+    module = _load_migration(TEAM_PUBLISHING_MIGRATION)
+
+    def _bind(counts: dict[str, int]):
+        monkeypatch.setattr(module.op, "get_bind", lambda: _FakeConnection(counts))
+
+    return module, _bind
+
+
+def test_downgrade_guard_allows_rollback_when_no_team_owns_rows(team_publishing_migration):
+    module, bind = team_publishing_migration
+    bind({})
+    assert module._assert_no_team_owned_rows() is None
+
+
+def test_downgrade_guard_blocks_rollback_while_team_owned_rows_exist(team_publishing_migration):
+    module, bind = team_publishing_migration
+    bind({"mcp_listings": 3, "agents": 1})
+    with pytest.raises(RuntimeError) as exc:
+        module._assert_no_team_owned_rows()
+    message = str(exc.value)
+    assert "agents=1" in message
+    assert "mcp_listings=3" in message
+
+
+def test_downgrade_runs_the_guard_before_dropping_anything(team_publishing_migration, monkeypatch):
+    module, bind = team_publishing_migration
+    bind({"skill_listings": 1})
+    dropped = []
+    for name in ("drop_constraint", "drop_index", "drop_column"):
+        monkeypatch.setattr(module.op, name, lambda *a, _n=name, **kw: dropped.append(_n))
+
+    with pytest.raises(RuntimeError):
+        module.downgrade()
+    assert dropped == []
+
+
+async def test_legacy_private_row_without_team_stays_creator_only():
+    """The reason 018_team_publishing needs no backfill.
+
+    A pre teamspace row (is_private=True, team_id=None) resolves to its creator
+    and to global reviewers only, so leaving it untouched discloses nothing.
+    """
+    creator_id = uuid.uuid4()
+    listing = SimpleNamespace(is_private=True, team_id=None, submitted_by=creator_id, co_authors=[])
+    creator = SimpleNamespace(id=creator_id, role=UserRole.user)
+    stranger = SimpleNamespace(id=uuid.uuid4(), role=UserRole.user)
+    reviewer = SimpleNamespace(id=uuid.uuid4(), role=UserRole.reviewer)
+
+    class _NoQueryDb:
+        async def scalar(self, *args, **kwargs):
+            raise AssertionError("a null team_id must not trigger a membership query")
+
+    db = _NoQueryDb()
+    assert await check_listing_visibility_async(listing, creator, db) is True
+    assert await check_listing_visibility_async(listing, stranger, db) is False
+    assert await check_listing_visibility_async(listing, reviewer, db) is True
+    assert await check_listing_visibility_async(listing, None, db) is False

--- a/tests/test_team_visibility_migrations.py
+++ b/tests/test_team_visibility_migrations.py
@@ -141,13 +141,16 @@ async def test_legacy_private_row_without_team_stays_creator_only():
     """The reason 018_team_publishing needs no backfill.
 
     A pre teamspace row (is_private=True, team_id=None) resolves to its creator
-    and to global reviewers only, so leaving it untouched discloses nothing.
+    and to admins only, so leaving it untouched discloses nothing. A global
+    reviewer is not on that list: nobody holds a team role over a personal
+    listing, so there is no team-scoped review to enable.
     """
     creator_id = uuid.uuid4()
     listing = SimpleNamespace(is_private=True, team_id=None, submitted_by=creator_id, co_authors=[])
     creator = SimpleNamespace(id=creator_id, role=UserRole.user)
     stranger = SimpleNamespace(id=uuid.uuid4(), role=UserRole.user)
     reviewer = SimpleNamespace(id=uuid.uuid4(), role=UserRole.reviewer)
+    admin = SimpleNamespace(id=uuid.uuid4(), role=UserRole.admin)
 
     class _NoQueryDb:
         async def scalar(self, *args, **kwargs):
@@ -156,5 +159,6 @@ async def test_legacy_private_row_without_team_stays_creator_only():
     db = _NoQueryDb()
     assert await check_listing_visibility_async(listing, creator, db) is True
     assert await check_listing_visibility_async(listing, stranger, db) is False
-    assert await check_listing_visibility_async(listing, reviewer, db) is True
+    assert await check_listing_visibility_async(listing, reviewer, db) is False
+    assert await check_listing_visibility_async(listing, admin, db) is True
     assert await check_listing_visibility_async(listing, None, db) is False

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.11.0"
+version = "1.10.7"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.10.7"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.10.7",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.11.0",
+  "version": "1.10.7",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",

--- a/web/src/components/registry/agent-edit-form.tsx
+++ b/web/src/components/registry/agent-edit-form.tsx
@@ -61,6 +61,8 @@ interface AgentDetail {
   status?: string;
   version?: string;
   owner?: string;
+  team_id?: string | null;
+  visibility?: "public" | "team";
   user_permission?: string;
   description?: string;
   prompt?: string;
@@ -234,7 +236,11 @@ export function AgentEditForm({
 
     validateTimerRef.current = setTimeout(() => {
       validation.mutate(
-        { components: allComponents },
+        {
+          components: allComponents,
+          team_id: agent.team_id ?? undefined,
+          visibility: agent.visibility ?? "public",
+        },
         {
           onSuccess: (result) => setValidationResult(result),
           onError: () =>
@@ -492,6 +498,7 @@ export function AgentEditForm({
                 type={ct.value}
                 selected={selectedIds}
                 onToggle={handleToggle(ct.value)}
+                targetTeamId={agent.visibility === "team" ? agent.team_id ?? undefined : undefined}
               />
 
               {(selectedComponents[ct.value] ?? []).length > 0 && (

--- a/web/src/components/registry/component-picker.tsx
+++ b/web/src/components/registry/component-picker.tsx
@@ -26,7 +26,9 @@ export function ComponentPicker({
 }) {
   const { data: items, isLoading } = useRegistryList(
     type,
-    targetTeamId ? { team_id: targetTeamId } : { public_only: "true" },
+    // Composition scope, not ownership: an agent published for this teamspace may
+    // contain any public component plus that teamspace's private ones.
+    targetTeamId ? { composable_for_team_id: targetTeamId } : { public_only: "true" },
   );
   const [search, setSearch] = useState("");
   const searchLabel = label ?? type;

--- a/web/src/components/registry/component-picker.tsx
+++ b/web/src/components/registry/component-picker.tsx
@@ -15,14 +15,19 @@ export function ComponentPicker({
   selected,
   onToggle,
   onCreateNew,
+  targetTeamId,
 }: {
   type: RegistryType;
   label?: string;
   selected: Set<string>;
   onToggle: (item: RegistryItem) => void;
   onCreateNew?: () => void;
+  targetTeamId?: string;
 }) {
-  const { data: items, isLoading } = useRegistryList(type);
+  const { data: items, isLoading } = useRegistryList(
+    type,
+    targetTeamId ? { team_id: targetTeamId } : { public_only: "true" },
+  );
   const [search, setSearch] = useState("");
   const searchLabel = label ?? type;
 
@@ -86,6 +91,10 @@ export function ComponentPicker({
               >
                 <span className="min-w-0 flex-1">
                   <span className="block truncate font-medium">{item.name}</span>
+                  <span className="block truncate text-[11px] text-muted-foreground">
+                    {item.qualified_name ?? item.name}
+                    {item.visibility === "team" ? " · team-only" : " · public"}
+                  </span>
                   {item.description && (
                     <span className="block truncate text-xs text-muted-foreground">
                       {item.description}

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -401,6 +401,12 @@ export function SubmitComponentDialog({
 		setName("");
 		setVersion("0.1.0");
 		setDescription("");
+		// The publication target has to reset with everything else. Leaving it means
+		// the next submission silently inherits the previous teamspace and
+		// visibility, so a component meant to be public is published team-private,
+		// or worse, one meant for a teamspace is published to the whole registry.
+		setTeamId("");
+		setVisibility("public");
 		setSupportedHarnesses([]);
 		setMcpMode("json");
 		setJsonInput("");

--- a/web/src/components/registry/submit-component-dialog.tsx
+++ b/web/src/components/registry/submit-component-dialog.tsx
@@ -26,7 +26,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Check, HelpCircle, Info, Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
 import type { RegistryType } from "@/lib/api";
-import { useWhoami } from "@/hooks/use-api";
+import { useTeams, useWhoami } from "@/hooks/use-api";
 import { useHarnesses } from "@/hooks/use-harnesses";
 import { parseMcpConfigJson, applyParsedConfig } from "@/lib/mcp-parser";
 import type { EnvVar } from "@/lib/mcp-parser";
@@ -139,6 +139,8 @@ interface SubmitComponentDialogProps {
 	isSubmitting: boolean;
 	isSavingDraft: boolean;
 	editItem?: Record<string, unknown> | null;
+	fixedTeamId?: string;
+	fixedVisibility?: "public" | "team";
 }
 
 export function SubmitComponentDialog({
@@ -151,10 +153,13 @@ export function SubmitComponentDialog({
 	isSubmitting,
 	isSavingDraft,
 	editItem,
+	fixedTeamId,
+	fixedVisibility,
 }: SubmitComponentDialogProps) {
 	const d = editItem as Record<string, unknown> | null;
 	const helpCtx = useHelp();
 	const { data: whoami } = useWhoami();
+	const { data: teams = [] } = useTeams();
 	const { data: harnessList } = useHarnesses();
 	const defaultOwner =
 		(d?.owner as string) ||
@@ -169,6 +174,10 @@ export function SubmitComponentDialog({
 		(d?.description as string) ?? "",
 	);
 	const owner = defaultOwner;
+	const [teamId, setTeamId] = useState<string>((d?.team_id as string) ?? "");
+	const [visibility, setVisibility] = useState<"public" | "team">(
+		(d?.visibility as "public" | "team") ?? "public",
+	);
 	const [supportedHarnesses, setSupportedHarnesses] = useState<string[]>(
 		Array.isArray(d?.supported_harnesses) ? (d.supported_harnesses as string[]) : [],
 	);
@@ -439,12 +448,16 @@ export function SubmitComponentDialog({
 	const isPendingEdit = isEditMode && d?.status === "pending";
 
 	function buildBody(): Record<string, unknown> {
+		const effectiveTeamId = fixedTeamId ?? teamId;
+		const effectiveVisibility = fixedVisibility ?? visibility;
 		const base: Record<string, unknown> = {
 			name,
 			version,
 			description,
 			owner,
+			visibility: effectiveVisibility,
 		};
+		if (effectiveTeamId) base.team_id = effectiveTeamId;
 		if (supportedHarnesses.length > 0) base.supported_harnesses = supportedHarnesses;
 
 		switch (type) {
@@ -703,6 +716,46 @@ export function SubmitComponentDialog({
 							rows={3}
 						/>
 					</div>
+
+					<div className="grid grid-cols-2 gap-3">
+						<div className="space-y-1.5">
+							<Label>Publish to</Label>
+							<PickerSelect
+								value={(fixedTeamId ?? teamId) || "personal"}
+								disabled={fixedTeamId !== undefined || fixedVisibility !== undefined}
+								onValueChange={(value) => {
+									const next = value === "personal" ? "" : value;
+									setTeamId(next);
+									if (!next) setVisibility("public");
+								}}
+								options={[
+									{ value: "personal", label: `Personal (${whoami?.username || whoami?.email || "me"})` },
+									...teams.map((team) => ({ value: team.id, label: `Team: ${team.name}` })),
+								]}
+							/>
+						</div>
+						<div className="space-y-1.5">
+							<Label>Visibility</Label>
+							<PickerSelect
+								value={fixedVisibility ?? visibility}
+								disabled={fixedVisibility !== undefined}
+								onValueChange={(value) => {
+									if (value === "team" && !teamId) {
+										toast.error("Team visibility requires a teamspace");
+										return;
+									}
+									setVisibility(value as "public" | "team");
+								}}
+								options={[
+									{ value: "public", label: "Public" },
+									{ value: "team", label: "Team members only" },
+								]}
+							/>
+						</div>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Public teamspace items are visible to everyone. Team-only items are limited to team members.
+					</p>
 
 					{/* ── MCP-specific ──────────────────────────────── */}
 					{type === "mcps" && (

--- a/web/src/hooks/use-api.ts
+++ b/web/src/hooks/use-api.ts
@@ -20,3 +20,4 @@ export * from "./use-sessions-api";
 export * from "./use-agents-api";
 export * from "./use-registry-api";
 export * from "./use-user-search";
+export * from "./use-teams-api";

--- a/web/src/hooks/use-registry-api.ts
+++ b/web/src/hooks/use-registry-api.ts
@@ -30,6 +30,20 @@ export function useMyComponents(type: RegistryType) {
   });
 }
 
+export function useUpdateRegistryVisibility() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ type, id, visibility }: { type: RegistryType; id: string; visibility: "public" | "team" }) =>
+      registry.updateVisibility(type, id, visibility),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ["registry", variables.type] });
+      qc.invalidateQueries({ queryKey: ["registry", variables.type, variables.id] });
+      toast.success("Visibility updated");
+    },
+    onError: (err: Error) => toast.error(err.message || "Failed to update visibility"),
+  });
+}
+
 export function useComponentSubmit(type: RegistryType) {
   const qc = useQueryClient();
   return useMutation({

--- a/web/src/hooks/use-review-api.ts
+++ b/web/src/hooks/use-review-api.ts
@@ -120,6 +120,21 @@ export function useApproveWithSkills() {
   });
 }
 
+/**
+ * Pending queue for one teamspace, used by the teamspace Review tab.
+ *
+ * Only a team owner or team reviewer may call this, so `enabled` must carry the
+ * team-role check: asking without the role earns a 403 rather than an empty
+ * list. The key stays under "review" so useReviewAction's invalidation reaches it.
+ */
+export function useTeamReviewQueue(teamId: string | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ["review", "team", teamId],
+    enabled: !!teamId && enabled,
+    queryFn: () => review.listForTeam(teamId!),
+  });
+}
+
 export function useReviewComponents(typeFilter?: string) {
   const params: Record<string, string> = { tab: "components" };
   if (typeFilter) params.type = typeFilter;

--- a/web/src/hooks/use-teams-api.ts
+++ b/web/src/hooks/use-teams-api.ts
@@ -25,6 +25,27 @@ export function useTeam(id?: string) {
 	});
 }
 
+/**
+ * Resolve a teamspace from the handle in the URL.
+ *
+ * `/teams/all` is the only listing that carries every discoverable teamspace
+ * together with the caller's own role in it, so handle resolution runs off that
+ * one query instead of guessing an id. `notFound` is reported explicitly so the
+ * detail page can say the handle is wrong instead of rendering a blank shell.
+ */
+export function useTeamByHandle(handle: string | undefined) {
+	const query = useAllTeams();
+	const team = handle ? query.data?.find((item) => item.handle === handle) : undefined;
+	return {
+		team,
+		isLoading: query.isLoading,
+		isError: query.isError,
+		error: query.error,
+		refetch: query.refetch,
+		notFound: !query.isLoading && !query.isError && !team,
+	};
+}
+
 export function useTeamMembers(teamId?: string, enabled = true) {
 	return useQuery({
 		queryKey: ["teams", teamId, "members"],

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -517,6 +517,13 @@ export const review = {
 		return get<ReviewItem[]>(`/review${qs}`);
 	},
 	listAgents: () => get<ReviewItem[]>("/review?tab=agents"),
+	/**
+	 * Pending queue narrowed to one teamspace. The server answers 403 when the
+	 * caller does not review for that teamspace, so callers must gate on the
+	 * team role before asking.
+	 */
+	listForTeam: (teamId: string, params?: Record<string, string>) =>
+		get<ReviewItem[]>(`/review?${new URLSearchParams({ ...params, team_id: teamId })}`),
 	get: (id: string) => get<ReviewItem>(`/review/${id}`),
 	approve: (id: string) => post(`/review/${id}/approve`),
 	reject: (id: string, body: { reason: string }) =>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -431,6 +431,8 @@ export const registry = {
 		),
 	validate: (body: {
 		components: { component_type: string; component_id: string }[];
+		team_id?: string;
+		visibility?: "public" | "team";
 	}) => post<ValidationResult>("/agents/validate", body),
 	previewConfig: (body: {
 		name: string;
@@ -462,6 +464,11 @@ export const registry = {
 		post(`/${type ?? "agents"}/${id}/submit`),
 	submit: (type: RegistryType, body: unknown) =>
 		post<RegistryItem>(`/${type}/submit`, body),
+	updateVisibility: (type: RegistryType, id: string, visibility: "public" | "team") =>
+		patch<{ id: string; visibility: "public" | "team" }>(
+			`/registry/${type === "agents" ? "agent" : type.slice(0, -1)}/${id}/visibility`,
+			{ visibility },
+		),
 	versionSuggestions: (id: string) =>
 		get<VersionSuggestions>(`/agents/${id}/version-suggestions`),
 	listVersions: (agentId: string, page = 1, pageSize = 50) =>

--- a/web/src/lib/features.ts
+++ b/web/src/lib/features.ts
@@ -23,7 +23,6 @@ export const FEATURE_VERSIONS: Record<string, string> = {
 	selfUpgrade: "1.0.0",
 	serverUpgrade: "1.0.0",
 	skills: "0.7.0",
-	teamspaces: "1.11.0",
 	versionCheck: "1.0.0",
 	versionEnforcement: "1.0.0",
 	versionNegotiation: "1.0.0",

--- a/web/src/lib/types/registry.ts
+++ b/web/src/lib/types/registry.ts
@@ -15,6 +15,9 @@ export interface RegistryItem {
 	namespace?: string;
 	slug?: string;
 	qualified_name?: string;
+	team_id?: string | null;
+	visibility?: "public" | "team";
+	is_private?: boolean;
 	description?: string;
 	status?: string;
 	rejection_reason?: string;

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -34,7 +34,7 @@ import {
   TabsContent,
 } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/layouts/page-header";
-import { useRegistryItem, useAgentValidation, useWhoami, useSaveDraft, useUpdateDraft, useStartEdit } from "@/hooks/use-api";
+import { useRegistryItem, useAgentValidation, useTeams, useWhoami, useSaveDraft, useUpdateDraft, useStartEdit } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import { registry, type RegistryType } from "@/lib/api";
 import { isValidAgentName, normalizeAgentName, slugifyRegistryText } from "@/lib/registry-name";
@@ -84,6 +84,7 @@ function AgentBuilderInner() {
   const isEditMode = !!editId;
 
   const { data: whoami } = useWhoami();
+  const { data: teams = [] } = useTeams();
   const { data: existingAgent } = useRegistryItem("agents", editId ?? draftParam ?? undefined);
 
   const [name, setName] = useState("");
@@ -96,6 +97,8 @@ function AgentBuilderInner() {
   const [modelsByHarness, setModelsByIde] = useState<Record<string, string>>({});
   const [publishing, setPublishing] = useState(false);
   const [activeTab, setActiveTab] = useState<RegistryType>("mcps");
+  const [teamId, setTeamId] = useState("");
+  const [visibility, setVisibility] = useState<"public" | "team">("public");
 
   // Version bump dialog
   const [showVersionDialog, setShowVersionDialog] = useState(false);
@@ -157,6 +160,10 @@ function AgentBuilderInner() {
     }
     const agentCategory = (existingAgent as Record<string, unknown>).category;
     if (typeof agentCategory === "string") setCategory(agentCategory);
+    const agentTeamId = (existingAgent as Record<string, unknown>).team_id;
+    if (typeof agentTeamId === "string") setTeamId(agentTeamId);
+    const agentVisibility = (existingAgent as Record<string, unknown>).visibility;
+    if (agentVisibility === "public" || agentVisibility === "team") setVisibility(agentVisibility);
 
     if (draftParam) setDraftId(draftParam);
 
@@ -248,7 +255,11 @@ function AgentBuilderInner() {
 
     validateTimerRef.current = setTimeout(() => {
       validation.mutate(
-        { components: allComponents },
+        {
+          components: allComponents,
+          team_id: teamId || undefined,
+          visibility,
+        },
         {
           onSuccess: (result) => setValidationResult(result),
           onError: () =>
@@ -435,7 +446,7 @@ function AgentBuilderInner() {
     }
 
 
-    return {
+    const body: Record<string, unknown> = {
       name: normalizeAgentName(name),
       version: (versionOverride ?? version).trim() || "1.0.0",
       description: description.trim(),
@@ -445,7 +456,10 @@ function AgentBuilderInner() {
       model_name: modelName,
       models_by_harness: modelsByHarness,
       components: components.length > 0 ? components : [],
+      visibility,
     };
+    if (teamId) body.team_id = teamId;
+    return body;
   }
 
   async function handlePublish() {
@@ -649,6 +663,40 @@ function AgentBuilderInner() {
                   />
                 </div>
               </div>
+              <div className="grid gap-4 max-w-3xl sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Publish to</Label>
+                  <PickerSelect
+                    value={teamId || "personal"}
+                    onValueChange={(value) => {
+                      const next = value === "personal" ? "" : value;
+                      setTeamId(next);
+                      if (!next) setVisibility("public");
+                    }}
+                    options={[
+                      { value: "personal", label: `Personal (${whoami?.username || whoami?.email || "me"})` },
+                      ...teams.map((team) => ({ value: team.id, label: `Team: ${team.name}` })),
+                    ]}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Visibility</Label>
+                  <PickerSelect
+                    value={visibility}
+                    onValueChange={(value) => {
+                      if (value === "team" && !teamId) {
+                        toast.error("Team visibility requires a teamspace");
+                        return;
+                      }
+                      setVisibility(value as "public" | "team");
+                    }}
+                    options={[
+                      { value: "public", label: "Public" },
+                      { value: "team", label: "Team members only" },
+                    ]}
+                  />
+                </div>
+              </div>
               <div className="max-w-3xl">
                 <ModelPicker
                   modelName={modelName}
@@ -726,6 +774,7 @@ function AgentBuilderInner() {
                       selected={selectedIds}
                       onToggle={handleToggle(ct.value)}
                       onCreateNew={() => setCreateDialogType(ct.value)}
+                      targetTeamId={visibility === "team" ? teamId || undefined : undefined}
                     />
                     {/* In-memory components not yet submitted */}
                     {pendingComponents.filter((p) => p.type === ct.value).map((p) => (
@@ -844,19 +893,23 @@ function AgentBuilderInner() {
           onSubmit={(body) => {
             const tempId = Math.random().toString(36).slice(2);
             const name = (body.name as string) || createDialogType.replace(/s$/, "");
-            setPendingComponents((prev) => [...prev, { id: tempId, type: createDialogType!, name, body }]);
+            const targetBody = teamId && !body.team_id ? { ...body, team_id: teamId, visibility } : body;
+            setPendingComponents((prev) => [...prev, { id: tempId, type: createDialogType!, name, body: targetBody }]);
             setCreateDialogType(null);
             toast.success(`${name} added, will be submitted with the agent.`);
           }}
           onSaveDraft={(body) => {
             const tempId = Math.random().toString(36).slice(2);
             const name = (body.name as string) || createDialogType.replace(/s$/, "");
-            setPendingComponents((prev) => [...prev, { id: tempId, type: createDialogType!, name, body }]);
+            const targetBody = teamId && !body.team_id ? { ...body, team_id: teamId, visibility } : body;
+            setPendingComponents((prev) => [...prev, { id: tempId, type: createDialogType!, name, body: targetBody }]);
             setCreateDialogType(null);
             toast.success(`${name} added, will be submitted with the agent.`);
           }}
           isSubmitting={false}
           isSavingDraft={false}
+          fixedTeamId={teamId || undefined}
+          fixedVisibility={visibility}
         />
       )}
 

--- a/web/src/pages/registry/agents/builder.tsx
+++ b/web/src/pages/registry/agents/builder.tsx
@@ -271,7 +271,10 @@ function AgentBuilderInner() {
     return () => {
       if (validateTimerRef.current) clearTimeout(validateTimerRef.current);
     };
-  }, [selectedComponents]); // eslint-disable-line react-hooks/exhaustive-deps
+  // The target is part of the question: the same components are valid for a
+  // team-private agent and invalid for a public one, so a change of teamspace or
+  // visibility has to revalidate.
+  }, [selectedComponents, teamId, visibility]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Check for localStorage draft on mount (skip if in edit mode)
   useEffect(() => {
@@ -309,6 +312,11 @@ function AgentBuilderInner() {
           components: selectedComponents,
           prompt: systemPrompt,
           draft_id: draftId,
+          // The publication target belongs with the draft. Without it a restored
+          // team-private draft silently reverts to a personal public agent, which
+          // is a change of audience the user never asked for.
+          team_id: teamId,
+          visibility,
           saved_at: new Date().toISOString(),
         };
         localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
@@ -320,7 +328,7 @@ function AgentBuilderInner() {
     return () => {
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     };
-  }, [name, description, version, modelName, modelsByHarness, selectedComponents, systemPrompt, draftId, isEditMode]);
+  }, [name, description, version, modelName, modelsByHarness, selectedComponents, systemPrompt, draftId, teamId, visibility, isEditMode]);
 
   function restoreLocalDraft() {
     try {
@@ -337,6 +345,10 @@ function AgentBuilderInner() {
       if (draft.components) setSelectedComponents(draft.components);
       if (typeof draft.prompt === "string") setSystemPrompt(draft.prompt);
       if (draft.draft_id) setDraftId(draft.draft_id);
+      // Restore the publication target too. A draft saved for a teamspace must
+      // not come back as a personal public agent.
+      if (typeof draft.team_id === "string") setTeamId(draft.team_id);
+      if (draft.visibility === "public" || draft.visibility === "team") setVisibility(draft.visibility);
       setShowRestoreBanner(false);
       toast.success("Draft restored");
     } catch {

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -700,8 +700,14 @@ export default function AgentDetailPage() {
   const isOwner = !!(whoami?.id && a?.created_by && whoami.id === String(a.created_by));
   const canTransferOwnership = isOwner;
   const teamRole = a?.team_id ? teams.find((team) => team.id === String(a.team_id))?.role : undefined;
+  // Mirror the server rule in PATCH /registry/agent/{id}/visibility exactly. See
+  // the matching comment in the component detail page: admins are privileged, a
+  // global reviewer is not, a team-owned agent needs a team owner or reviewer,
+  // and a personal one needs its creator.
   const canChangeVisibility = Boolean(
-    a && (isOwner || teamRole === "owner" || teamRole === "reviewer" || hasMinRole(getUserRole(), "reviewer")),
+    a &&
+      (hasMinRole(getUserRole(), "admin") ||
+        (a.team_id ? teamRole === "owner" || teamRole === "reviewer" : isOwner)),
   );
   const currentVisibility = a?.visibility ?? (a?.is_private ? "team" : "public");
   const canManageLifecycle = isAdmin || isOwner;

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -32,6 +32,8 @@ import {
   useFeedback,
   useFeedbackSummary,
   useMyFeedback,
+  useTeams,
+  useUpdateRegistryVisibility,
   useWhoami,
   useAgentVersions,
   useAgentVersionDetail,
@@ -60,6 +62,7 @@ import { HarnessBadges } from "@/components/registry/harness-badges";
 import { ReviewForm } from "@/components/registry/review-form";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -162,6 +165,9 @@ interface AgentDetail {
   version?: string;
   owner?: string;
   user_permission?: string;
+  team_id?: string | null;
+  visibility?: "public" | "team";
+  is_private?: boolean;
   description?: string;
   prompt?: string;
   model_name?: string;
@@ -618,6 +624,8 @@ export default function AgentDetailPage() {
   const { data: myReview } = useMyFeedback("agent", id);
 
   const { data: whoami } = useWhoami();
+  const { data: teams = [] } = useTeams();
+  const updateVisibility = useUpdateRegistryVisibility();
   const { data: versionsData } = useAgentVersions(id);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const { data: versionDetail, isLoading: isVersionDetailLoading } = useAgentVersionDetail(id, selectedVersion);
@@ -670,6 +678,10 @@ export default function AgentDetailPage() {
   const versionInferredIdes = vd?.inferred_supported_harnesses ?? (selectedVersion ? undefined : a?.inferred_supported_harnesses);
   const isOwner = !!(whoami?.id && a?.created_by && whoami.id === String(a.created_by));
   const canTransferOwnership = isOwner;
+  const teamRole = a?.team_id ? teams.find((team) => team.id === String(a.team_id))?.role : undefined;
+  const canChangeVisibility = Boolean(
+    a && (isOwner || teamRole === "owner" || teamRole === "reviewer" || hasMinRole(getUserRole(), "reviewer")),
+  );
   const canManageLifecycle = isAdmin || isOwner;
   const agentStatus = a?.status as string | undefined;
   const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && ["approved", "pending", "draft", "rejected"].includes(agentStatus ?? "");
@@ -720,6 +732,20 @@ export default function AgentDetailPage() {
                     handleClassName="text-sm text-muted-foreground"
                   />
                   {a.status && <StatusBadge status={a.status} />}
+                  {canChangeVisibility && (
+                    <PickerSelect
+                      value={a.visibility ?? (a.is_private ? "team" : "public")}
+                      onValueChange={(value) => updateVisibility.mutate({ type: "agents", id, visibility: value as "public" | "team" })}
+                      options={[
+                        { value: "public", label: "Public" },
+                        { value: "team", label: "Team members only" },
+                      ]}
+                      ariaLabel="Agent visibility"
+                      className="w-40"
+                      inputClassName="h-7 px-2 text-xs"
+                      disabled={updateVisibility.isPending || !a.team_id}
+                    />
+                  )}
                   {versions.length > 0 ? (
                     <VersionDropdown
                       versions={versions}

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -25,6 +25,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { useState, useEffect, useCallback, useMemo, useSyncExternalStore } from "react";
+import { toast } from "sonner";
 
 import {
   useRegistryItem,
@@ -60,6 +61,16 @@ import { VersionDropdown } from "@/components/registry/version-dropdown";
 import { StatusBadge } from "@/components/registry/status-badge";
 import { HarnessBadges } from "@/components/registry/harness-badges";
 import { ReviewForm } from "@/components/registry/review-form";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PickerSelect } from "@/components/ui/picker-select";
@@ -107,6 +118,15 @@ const COMPONENT_GROUP_BY_TYPE: Record<string, ComponentGroupKey> = {
   sandbox: "sandboxes",
   sandboxes: "sandboxes",
 };
+
+// The visibility PATCH reports whether the flip pushed the agent back into the
+// review queue. Read it off the response and return null when the server did not
+// say, so the UI never invents an outcome from the caller's role.
+function readReturnedToReview(payload: unknown): boolean | null {
+  if (!payload || typeof payload !== "object") return null;
+  const value = (payload as Record<string, unknown>).returned_to_review;
+  return typeof value === "boolean" ? value : null;
+}
 
 function semverCompareDesc(a: string, b: string): number {
   const pa = a.split(".").map(Number);
@@ -628,6 +648,7 @@ export default function AgentDetailPage() {
   const updateVisibility = useUpdateRegistryVisibility();
   const { data: versionsData } = useAgentVersions(id);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
+  const [confirmPublicOpen, setConfirmPublicOpen] = useState(false);
   const { data: versionDetail, isLoading: isVersionDetailLoading } = useAgentVersionDetail(id, selectedVersion);
 
   // Co-authors
@@ -682,6 +703,7 @@ export default function AgentDetailPage() {
   const canChangeVisibility = Boolean(
     a && (isOwner || teamRole === "owner" || teamRole === "reviewer" || hasMinRole(getUserRole(), "reviewer")),
   );
+  const currentVisibility = a?.visibility ?? (a?.is_private ? "team" : "public");
   const canManageLifecycle = isAdmin || isOwner;
   const agentStatus = a?.status as string | undefined;
   const canEdit = (isAdmin || a?.user_permission === "owner" || a?.user_permission === "edit") && ["approved", "pending", "draft", "rejected"].includes(agentStatus ?? "");
@@ -695,6 +717,33 @@ export default function AgentDetailPage() {
   const archivedComponents = components.filter((component) => component.status === "archived");
   const avgRating = feedbackSummary?.average_rating;
   const totalReviews = feedbackSummary?.total_reviews ?? 0;
+
+  function applyVisibility(visibility: "public" | "team") {
+    updateVisibility.mutate(
+      { type: "agents", id, visibility },
+      {
+        onSuccess: (data) => {
+          setConfirmPublicOpen(false);
+          if (visibility !== "public") return;
+          const returnedToReview = readReturnedToReview(data);
+          // The shared mutation hook already raised a generic "Visibility updated"
+          // toast. Clear it so the user reads one accurate outcome, not two.
+          toast.dismiss();
+          if (returnedToReview === null) {
+            toast.error(
+              `${agentName} is now public, but the server did not report whether it went back for review.`,
+            );
+            return;
+          }
+          toast.success(
+            returnedToReview
+              ? `${agentName} was submitted for review. It is public now, but stays out of the catalog until a reviewer approves it.`
+              : `${agentName} is now public.`,
+          );
+        },
+      },
+    );
+  }
 
   return (
     <>
@@ -734,8 +783,17 @@ export default function AgentDetailPage() {
                   {a.status && <StatusBadge status={a.status} />}
                   {canChangeVisibility && (
                     <PickerSelect
-                      value={a.visibility ?? (a.is_private ? "team" : "public")}
-                      onValueChange={(value) => updateVisibility.mutate({ type: "agents", id, visibility: value as "public" | "team" })}
+                      value={currentVisibility}
+                      onValueChange={(value) => {
+                        if (value === currentVisibility) return;
+                        // Going public widens the audience and re-opens review, so it
+                        // is confirmed. Narrowing to the teamspace needs no warning.
+                        if (value === "public") {
+                          setConfirmPublicOpen(true);
+                          return;
+                        }
+                        applyVisibility("team");
+                      }}
                       options={[
                         { value: "public", label: "Public" },
                         { value: "team", label: "Team members only" },
@@ -1095,6 +1153,35 @@ export default function AgentDetailPage() {
           </div>
         )}
       </div>
+
+      <AlertDialog open={confirmPublicOpen} onOpenChange={setConfirmPublicOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Make {agentName} public?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Everyone who can reach this registry will be able to find and pull this agent, not just the members of
+              its teamspace. Publishing publicly also returns it to the review queue, so it leaves the catalog until a
+              reviewer approves it. Approval is manual, so it will not be immediate.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={updateVisibility.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                applyVisibility("public");
+              }}
+              disabled={updateVisibility.isPending}
+            >
+              {updateVisibility.isPending ? (
+                <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Publishing...</>
+              ) : (
+                "Make public"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/web/src/pages/registry/agents/index.tsx
+++ b/web/src/pages/registry/agents/index.tsx
@@ -33,7 +33,7 @@ import { PickerSelect } from "@/components/ui/picker-select";
 import { UserSearchInput } from "@/components/shared/user-search-input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useRegistryList, useMyAgents, useArchivedAgents, useDeletedAgents, useWhoami, useArchiveAgent, useUnarchiveAgent, useDeleteAgent, useRestoreDeletedAgent, useSubmitDraft } from "@/hooks/use-api";
+import { useRegistryList, useMyAgents, useArchivedAgents, useDeletedAgents, useWhoami, useArchiveAgent, useUnarchiveAgent, useDeleteAgent, useRestoreDeletedAgent, useSubmitDraft, useTeams } from "@/hooks/use-api";
 import { registry, getUserRole } from "@/lib/api";
 import { hasMinRole } from "@/hooks/use-role-guard";
 import {
@@ -423,8 +423,10 @@ export default function AgentListPage() {
 }
 
 function AgentListContent() {
-  const { search: searchParam, namespace, category } = useSearch({ from: "/_authed/agents/" });
+  const { search: searchParam, namespace, team, category } = useSearch({ from: "/_authed/agents/" });
   const router = useRouter();
+  const { data: teams = [] } = useTeams();
+  const selectedTeam = teams.find((item) => item.handle === team);
   const initialSearch = searchParam ?? "";
   const [search, setSearch] = useState(initialSearch);
   const [debouncedSearch, setDebouncedSearch] = useState(initialSearch);
@@ -455,6 +457,7 @@ function AgentListContent() {
   } = useRegistryList("agents", {
     ...(debouncedSearch ? { search: debouncedSearch } : {}),
     ...(namespace ? { namespace } : {}),
+    ...(selectedTeam ? { team_id: selectedTeam.id } : {}),
     ...(category ? { category } : {}),
   });
 
@@ -522,7 +525,7 @@ function AgentListContent() {
     }
   }
 
-  function updateFilters(next: { search?: string; namespace?: string; category?: string }) {
+  function updateFilters(next: { search?: string; namespace?: string; team?: string; category?: string }) {
     router.navigate({
       to: "/agents",
       search: (current) => ({ ...current, ...next }),
@@ -534,10 +537,10 @@ function AgentListContent() {
     setSearch("");
     setDebouncedSearch("");
     setPublisherQuery("");
-    updateFilters({ search: undefined, namespace: undefined, category: undefined });
+    updateFilters({ search: undefined, namespace: undefined, team: undefined, category: undefined });
   }
 
-  const hasFilters = !!(search || namespace || category);
+  const hasFilters = !!(search || namespace || team || category);
 
   return (
     <>
@@ -566,6 +569,17 @@ function AgentListContent() {
                 className="pl-9 h-9"
               />
             </div>
+            <PickerSelect
+              value={team ?? ""}
+              onValueChange={(value) => updateFilters({ team: value || undefined })}
+              options={[
+                { value: "", label: "All visible teamspaces" },
+                ...teams.map((item) => ({ value: item.handle, label: `Team: ${item.name}` })),
+              ]}
+              placeholder="Teamspace"
+              className="w-[210px]"
+              inputClassName="h-9"
+            />
             <UserSearchInput
               value={publisherQuery}
               onValueChange={(value) => {
@@ -616,6 +630,12 @@ function AgentListContent() {
           </div>
           {hasFilters && (
             <div className="flex min-h-7 items-center gap-2 flex-wrap" aria-label="Active filters">
+              {team && (
+                <Button variant="secondary" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={() => updateFilters({ team: undefined })}>
+                  Team: {selectedTeam?.name ?? team}
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
               {namespace && (
                 <Button variant="secondary" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={() => updateFilters({ namespace: undefined })}>
                   Publisher: @{namespace}

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -9,6 +9,7 @@
 import { Link, useParams, useSearch } from "@tanstack/react-router";
 import { useState, useEffect, useCallback, useSyncExternalStore } from "react";
 import { Star, ArrowLeft, History, Loader2, ArrowDownToLine, Archive, ArchiveRestore, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
 import {
   useRegistryItem,
   useFeedback,
@@ -36,6 +37,16 @@ import { VersionDropdown } from "@/components/registry/version-dropdown";
 import { ComponentEditForm } from "@/components/registry/component-edit-form";
 import { ComponentInstallCommand } from "@/components/registry/component-install-command";
 import { RegistryName } from "@/components/registry/registry-name";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PickerSelect } from "@/components/ui/picker-select";
@@ -48,6 +59,15 @@ import { ErrorState } from "@/components/shared/error-state";
 import { EmptyState } from "@/components/shared/empty-state";
 import { HarnessBadges } from "@/components/registry/harness-badges";
 import { CoAuthorInput, type CoAuthor } from "@/components/registry/co-author-input";
+
+// The visibility PATCH reports whether the flip pushed the listing back into the
+// review queue. Read it off the response and return null when the server did not
+// say, so the UI never invents an outcome from the caller's role.
+function readReturnedToReview(payload: unknown): boolean | null {
+  if (!payload || typeof payload !== "object") return null;
+  const value = (payload as Record<string, unknown>).returned_to_review;
+  return typeof value === "boolean" ? value : null;
+}
 
 function statusVariant(status?: string) {
   if (status === "approved") return "default" as const;
@@ -114,6 +134,8 @@ export default function ComponentDetailPage() {
     item && (canEdit || teamRole === "owner" || teamRole === "reviewer" || hasMinRole(getUserRole(), "reviewer")),
   );
   const canTransferOwnership = !!(whoami?.id && item?.submitted_by && whoami.id === String(item.submitted_by));
+  const currentVisibility = (item?.visibility as string | undefined) ?? (item?.is_private ? "team" : "public");
+  const [confirmPublicOpen, setConfirmPublicOpen] = useState(false);
 
   // Co-authors
   const [coAuthors, setCoAuthors] = useState<CoAuthor[]>([]);
@@ -144,6 +166,34 @@ export default function ComponentDetailPage() {
   const identity = registryIdentity(item, id.slice(0, 8));
   const componentName = identity.name;
   const componentRef = identity.qualified;
+
+  function applyVisibility(visibility: "public" | "team") {
+    updateVisibility.mutate(
+      { type, id, visibility },
+      {
+        onSuccess: (data) => {
+          setConfirmPublicOpen(false);
+          if (visibility !== "public") return;
+          const returnedToReview = readReturnedToReview(data);
+          // The shared mutation hook already raised a generic "Visibility updated"
+          // toast. Clear it so the user reads one accurate outcome, not two.
+          toast.dismiss();
+          if (returnedToReview === null) {
+            toast.error(
+              `${componentName} is now public, but the server did not report whether it went back for review.`,
+            );
+            return;
+          }
+          toast.success(
+            returnedToReview
+              ? `${componentName} was submitted for review. It is public now, but stays out of the catalog until a reviewer approves it.`
+              : `${componentName} is now public.`,
+          );
+        },
+      },
+    );
+  }
+
   const avgRating = feedbackSummary?.average_rating;
   const totalReviews = feedbackSummary?.total_reviews ?? 0;
   const metricsEntries: [string, string][] = rawMetrics && typeof rawMetrics === "object"
@@ -201,8 +251,17 @@ export default function ComponentDetailPage() {
                 )}
                 {canChangeVisibility && (
                   <PickerSelect
-                    value={(item.visibility as string | undefined) ?? (item.is_private ? "team" : "public")}
-                    onValueChange={(value) => updateVisibility.mutate({ type, id, visibility: value as "public" | "team" })}
+                    value={currentVisibility}
+                    onValueChange={(value) => {
+                      if (value === currentVisibility) return;
+                      // Going public widens the audience and re-opens review, so it
+                      // is confirmed. Narrowing to the teamspace needs no warning.
+                      if (value === "public") {
+                        setConfirmPublicOpen(true);
+                        return;
+                      }
+                      applyVisibility("team");
+                    }}
                     options={[
                       { value: "public", label: "Public" },
                       { value: "team", label: "Team members only" },
@@ -500,6 +559,35 @@ export default function ComponentDetailPage() {
           </div>
         )}
       </div>
+
+      <AlertDialog open={confirmPublicOpen} onOpenChange={setConfirmPublicOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Make {componentName} public?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Everyone who can reach this registry will be able to find and install this {singularType}, not just the
+              members of its teamspace. Publishing publicly also returns it to the review queue, so it leaves the
+              catalog until a reviewer approves it. Approval is manual, so it will not be immediate.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={updateVisibility.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                applyVisibility("public");
+              }}
+              disabled={updateVisibility.isPending}
+            >
+              {updateVisibility.isPending ? (
+                <><Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />Publishing...</>
+              ) : (
+                "Make public"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -19,8 +19,12 @@ import {
   useComponentVersionDetail,
   useComponentArchive,
   useComponentUnarchive,
+  useTeams,
+  useUpdateRegistryVisibility,
   useWhoami,
 } from "@/hooks/use-api";
+import { getUserRole } from "@/lib/api";
+import { hasMinRole } from "@/hooks/use-role-guard";
 import type { RegistryType } from "@/lib/api";
 import type { FeedbackItem, RegistryItem, ComponentVersionSummary } from "@/lib/types";
 import { compactNumber } from "@/lib/utils";
@@ -34,6 +38,7 @@ import { ComponentInstallCommand } from "@/components/registry/component-install
 import { RegistryName } from "@/components/registry/registry-name";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PickerSelect } from "@/components/ui/picker-select";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -91,6 +96,8 @@ export default function ComponentDetailPage() {
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const { data: versionDetail } = useComponentVersionDetail(type, id, selectedVersion);
   const { data: whoami } = useWhoami();
+  const { data: teams = [] } = useTeams();
+  const updateVisibility = useUpdateRegistryVisibility();
 
   const storeSub = useCallback((cb: () => void) => {
     window.addEventListener("storage", cb);
@@ -102,6 +109,10 @@ export default function ComponentDetailPage() {
     () => false,
   );
   const canEdit = isAuthenticated && (item?.user_permission === "owner");
+  const teamRole = item?.team_id ? teams.find((team) => team.id === String(item.team_id))?.role : undefined;
+  const canChangeVisibility = Boolean(
+    item && (canEdit || teamRole === "owner" || teamRole === "reviewer" || hasMinRole(getUserRole(), "reviewer")),
+  );
   const canTransferOwnership = !!(whoami?.id && item?.submitted_by && whoami.id === String(item.submitted_by));
 
   // Co-authors
@@ -187,6 +198,20 @@ export default function ComponentDetailPage() {
                   >
                     {item.status}
                   </Badge>
+                )}
+                {canChangeVisibility && (
+                  <PickerSelect
+                    value={(item.visibility as string | undefined) ?? (item.is_private ? "team" : "public")}
+                    onValueChange={(value) => updateVisibility.mutate({ type, id, visibility: value as "public" | "team" })}
+                    options={[
+                      { value: "public", label: "Public" },
+                      { value: "team", label: "Team members only" },
+                    ]}
+                    ariaLabel="Listing visibility"
+                    className="w-40"
+                    inputClassName="h-7 px-2 text-xs"
+                    disabled={updateVisibility.isPending || !item.team_id}
+                  />
                 )}
                 {versionsForDropdown.length > 0 ? (
                   <VersionDropdown

--- a/web/src/pages/registry/components/detail.tsx
+++ b/web/src/pages/registry/components/detail.tsx
@@ -130,8 +130,17 @@ export default function ComponentDetailPage() {
   );
   const canEdit = isAuthenticated && (item?.user_permission === "owner");
   const teamRole = item?.team_id ? teams.find((team) => team.id === String(item.team_id))?.role : undefined;
+  // Mirror the server rule in PATCH /registry/{type}/{id}/visibility exactly.
+  // Admins are privileged; a global REVIEWER is not, because a team-private
+  // listing belongs to its teamspace. A team-owned listing needs a team owner or
+  // team reviewer, and a personal one needs its creator. Showing the control any
+  // wider just invites a 403.
   const canChangeVisibility = Boolean(
-    item && (canEdit || teamRole === "owner" || teamRole === "reviewer" || hasMinRole(getUserRole(), "reviewer")),
+    item &&
+      (hasMinRole(getUserRole(), "admin") ||
+        (item.team_id
+          ? teamRole === "owner" || teamRole === "reviewer"
+          : !!whoami?.id && whoami.id === String(item.submitted_by))),
   );
   const canTransferOwnership = !!(whoami?.id && item?.submitted_by && whoami.id === String(item.submitted_by));
   const currentVisibility = (item?.visibility as string | undefined) ?? (item?.is_private ? "team" : "public");

--- a/web/src/pages/registry/components/index.tsx
+++ b/web/src/pages/registry/components/index.tsx
@@ -32,6 +32,7 @@ import {
   useComponentUpdateDraft,
   useStartEdit,
   useCancelEdit,
+  useTeams,
 } from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
 import type { RegistryType } from "@/lib/api";
@@ -191,6 +192,7 @@ export default function ComponentsPage() {
   const router = useRouter();
   const searchParams = useSearch({ from: "/_authed/components/" });
   const { ready: authReady, role } = useAuthGuard();
+  const { data: teams = [] } = useTeams();
   const activeType = searchParams.type ?? "mcps";
   const [search, setSearch] = useState(searchParams.search ?? "");
   const [debouncedSearch, setDebouncedSearch] = useState(searchParams.search ?? "");
@@ -215,9 +217,11 @@ export default function ComponentsPage() {
   }, [searchParams.namespace]);
 
   const typeFilters = TYPE_FILTERS[activeType] ?? [];
+  const selectedTeam = teams.find((team) => team.handle === searchParams.team);
   const registryFilters: Record<string, string> = {
     ...(debouncedSearch ? { search: debouncedSearch } : {}),
     ...(searchParams.namespace ? { namespace: searchParams.namespace } : {}),
+    ...(selectedTeam ? { team_id: selectedTeam.id } : {}),
   };
   for (const filter of typeFilters) {
     const value = searchParams[filter.key];
@@ -299,6 +303,7 @@ export default function ComponentsPage() {
     updateFilters({
       search: undefined,
       namespace: undefined,
+      team: undefined,
       category: undefined,
       task_type: undefined,
       event: undefined,
@@ -310,6 +315,7 @@ export default function ComponentsPage() {
   const hasFilters = !!(
     search ||
     searchParams.namespace ||
+    searchParams.team ||
     typeFilters.some((filter) => searchParams[filter.key])
   );
 
@@ -340,6 +346,17 @@ export default function ComponentsPage() {
                 className="pl-9 h-9"
               />
             </div>
+            <PickerSelect
+              value={searchParams.team ?? ""}
+              onValueChange={(value) => updateFilters({ team: value || undefined })}
+              options={[
+                { value: "", label: "All visible teamspaces" },
+                ...teams.map((team) => ({ value: team.handle, label: `Team: ${team.name}` })),
+              ]}
+              placeholder="Teamspace"
+              className="w-[210px]"
+              inputClassName="h-9"
+            />
             <UserSearchInput
               value={publisherQuery}
               onValueChange={(value) => {
@@ -399,6 +416,12 @@ export default function ComponentsPage() {
           </div>
           {hasFilters && (
             <div className="flex min-h-7 items-center gap-2 flex-wrap" aria-label="Active filters">
+              {searchParams.team && (
+                <Button variant="secondary" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={() => updateFilters({ team: undefined })}>
+                  Team: {selectedTeam?.name ?? searchParams.team}
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
               {searchParams.namespace && (
                 <Button variant="secondary" size="sm" className="h-7 gap-1 px-2 text-xs" onClick={() => updateFilters({ namespace: undefined })}>
                   Publisher: @{searchParams.namespace}

--- a/web/src/pages/registry/teamspace-detail.tsx
+++ b/web/src/pages/registry/teamspace-detail.tsx
@@ -24,6 +24,7 @@ import { PageHeader } from "@/components/layouts/page-header";
 import { AgentCard } from "@/components/registry/agent-card";
 import { ComponentCard } from "@/components/registry/component-card";
 import { StatusBadge } from "@/components/registry/status-badge";
+import { ReviewDetailSheet } from "@/components/review/review-detail-sheet";
 import { EmptyState } from "@/components/shared/empty-state";
 import { ErrorState } from "@/components/shared/error-state";
 import { CardSkeleton, DetailSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
@@ -380,6 +381,7 @@ function ReviewTab({
 	const queryClient = useQueryClient();
 	const [rejectTarget, setRejectTarget] = useState<ReviewItem | null>(null);
 	const [reason, setReason] = useState("");
+	const [inspecting, setInspecting] = useState<ReviewItem | null>(null);
 
 	function runAction(vars: { id: string; type?: string; action: "approve" | "reject"; reason?: string }) {
 		reviewAction.mutate(vars, {
@@ -431,30 +433,37 @@ function ReviewTab({
 							</div>
 						</div>
 						<div className="flex shrink-0 items-center gap-2">
+							{/* Approving from summary text alone means approving a prompt, command or
+							    script you have not read. Open the same sheet the global queue uses so a
+							    team reviewer inspects the real payload before deciding. */}
 							<Button
 								size="sm"
-								className="h-8 text-xs"
-								disabled={reviewAction.isPending}
-								onClick={() => runAction({ id: item.id, type: item.type, action: "approve" })}
-							>
-								Approve
-							</Button>
-							<Button
 								variant="outline"
-								size="sm"
-								className="h-8 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
-								disabled={reviewAction.isPending}
-								onClick={() => {
-									setReason("");
-									setRejectTarget(item);
-								}}
+								className="h-8 text-xs"
+								onClick={() => setInspecting(item)}
 							>
-								Reject
+								Review
 							</Button>
 						</div>
 					</div>
 				))}
 			</div>
+
+			<ReviewDetailSheet
+				item={inspecting}
+				open={!!inspecting}
+				onOpenChange={(open) => {
+					if (!open) setInspecting(null);
+				}}
+				onApprove={(id, type) => {
+					runAction({ id, type, action: "approve" });
+					setInspecting(null);
+				}}
+				onReject={(id, rejectReason, type) => {
+					runAction({ id, type, action: "reject", reason: rejectReason });
+					setInspecting(null);
+				}}
+			/>
 
 			<Dialog
 				open={!!rejectTarget}

--- a/web/src/pages/registry/teamspace-detail.tsx
+++ b/web/src/pages/registry/teamspace-detail.tsx
@@ -1,0 +1,719 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useState } from "react";
+import {
+	ArrowLeft,
+	Bot,
+	Building2,
+	ClipboardCheck,
+	Loader2,
+	Lock,
+	LogOut,
+	Plus,
+	Puzzle,
+	ShieldCheck,
+	Terminal,
+	Trash2,
+	UserPlus,
+	Users,
+} from "lucide-react";
+import { PageHeader } from "@/components/layouts/page-header";
+import { AgentCard } from "@/components/registry/agent-card";
+import { ComponentCard } from "@/components/registry/component-card";
+import { StatusBadge } from "@/components/registry/status-badge";
+import { EmptyState } from "@/components/shared/empty-state";
+import { ErrorState } from "@/components/shared/error-state";
+import { CardSkeleton, DetailSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
+import { UserSearchInput } from "@/components/shared/user-search-input";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { PickerSelect } from "@/components/ui/picker-select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	useDeleteTeam,
+	useLeaveTeam,
+	useRegistryList,
+	useRemoveTeamMember,
+	useReviewAction,
+	useTeamByHandle,
+	useTeamMembers,
+	useTeamReviewQueue,
+	useUpsertTeamMember,
+} from "@/hooks/use-api";
+import { hasMinRole } from "@/hooks/use-role-guard";
+import { getUserRole, type RegistryType } from "@/lib/api";
+import type { RegistryItem, ReviewItem, Team, TeamMember, TeamRole } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+const ROLE_OPTIONS = [
+	{ value: "member", label: "Member" },
+	{ value: "reviewer", label: "Reviewer" },
+	{ value: "owner", label: "Owner" },
+];
+
+const COMPONENT_TYPES: { value: RegistryType; label: string }[] = [
+	{ value: "mcps", label: "MCPs" },
+	{ value: "skills", label: "Skills" },
+	{ value: "hooks", label: "Hooks" },
+	{ value: "prompts", label: "Prompts" },
+	{ value: "sandboxes", label: "Sandboxes" },
+];
+
+const COMPONENT_TYPE_LABELS: Record<string, string> = Object.fromEntries(
+	COMPONENT_TYPES.map((type) => [type.value, type.label]),
+);
+
+/** Team owners and team reviewers are the only roles that clear team-private review. */
+const REVIEWING_TEAM_ROLES: TeamRole[] = ["owner", "reviewer"];
+
+const GRID_CLASS = "grid gap-4 pt-2 sm:grid-cols-2 xl:grid-cols-3";
+
+function isPrivateItem(item: RegistryItem): boolean {
+	return item.visibility === "team" || item.is_private === true;
+}
+
+/**
+ * Chip that straddles the top border of a registry card.
+ *
+ * The registry cards already own their own top-right corner (version for
+ * agents, type for components), so the private marker floats above the card
+ * rather than competing for space inside it. Pointer events pass through so the
+ * whole card stays one click target.
+ */
+function PrivateChip() {
+	return (
+		<Badge
+			variant="outline"
+			className="pointer-events-none absolute -top-2 left-3 z-10 gap-1 border-primary-accent/40 bg-card px-1.5 py-0 text-[10px] font-medium text-primary-accent"
+		>
+			<Lock className="h-2.5 w-2.5" />
+			Team-private
+		</Badge>
+	);
+}
+
+function AgentsTab({ team }: { team: Team }) {
+	const { data: agents = [], isLoading, isError, error, refetch } = useRegistryList("agents", { team_id: team.id });
+
+	if (isLoading) return <CardSkeleton count={6} columns={3} />;
+	if (isError) return <ErrorState message={error?.message} onRetry={() => refetch()} />;
+	if (agents.length === 0) {
+		return (
+			<EmptyState
+				icon={Bot}
+				title="No agents in this teamspace"
+				description={`Agents published under ${team.handle}/ appear here, both public and team-private.`}
+			/>
+		);
+	}
+
+	return (
+		<div className={GRID_CLASS}>
+			{agents.map((agent: RegistryItem) => (
+				<div key={agent.id} className="relative">
+					{isPrivateItem(agent) && <PrivateChip />}
+					<AgentCard
+						id={agent.id}
+						name={agent.name}
+						namespace={agent.namespace}
+						slug={agent.slug}
+						qualified_name={agent.qualified_name}
+						description={agent.description}
+						owner={agent.owner as string | undefined}
+						version={agent.version as string | undefined}
+						downloads={agent.download_count as number | undefined}
+						score={(agent.average_rating as number | null) ?? undefined}
+						status={agent.status}
+						component_count={agent.component_count as number | undefined}
+						supported_harnesses={agent.supported_harnesses as string[] | undefined}
+						inferred_supported_harnesses={agent.inferred_supported_harnesses as string[] | undefined}
+						className="h-full"
+					/>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function ComponentsTab({
+	team,
+	activeType,
+	onTypeChange,
+}: {
+	team: Team;
+	activeType: RegistryType;
+	onTypeChange: (type: RegistryType) => void;
+}) {
+	const { data: items = [], isLoading, isError, error, refetch } = useRegistryList(activeType, { team_id: team.id });
+	const label = COMPONENT_TYPE_LABELS[activeType] ?? activeType;
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center gap-1 border-b border-border">
+				{COMPONENT_TYPES.map((type) => (
+					<button
+						key={type.value}
+						type="button"
+						onClick={() => onTypeChange(type.value)}
+						className={cn(
+							"relative px-3 py-2 text-sm font-medium transition-colors hover:text-foreground",
+							activeType === type.value ? "text-foreground" : "text-muted-foreground",
+						)}
+					>
+						{type.label}
+						{activeType === type.value && <span className="absolute inset-x-0 -bottom-px h-0.5 bg-primary-accent" />}
+					</button>
+				))}
+			</div>
+
+			{isLoading ? (
+				<CardSkeleton count={6} columns={3} />
+			) : isError ? (
+				<ErrorState message={error?.message} onRetry={() => refetch()} />
+			) : items.length === 0 ? (
+				<EmptyState
+					icon={Puzzle}
+					title={`No ${label.toLowerCase()} in this teamspace`}
+					description={`${label} published under ${team.handle}/ appear here, both public and team-private.`}
+				/>
+			) : (
+				<div className={GRID_CLASS}>
+					{items.map((item: RegistryItem) => (
+						<div key={item.id} className="relative">
+							{isPrivateItem(item) && <PrivateChip />}
+							<ComponentCard
+								id={item.id}
+								name={item.name}
+								namespace={item.namespace}
+								slug={item.slug}
+								qualified_name={item.qualified_name}
+								type={activeType}
+								description={item.description}
+								version={item.version as string | undefined}
+								status={item.status}
+								git_url={item.git_url as string | undefined}
+								className="h-full"
+							/>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function MembersTab({ team }: { team: Team }) {
+	const isOwner = team.role === "owner";
+	const isMember = Boolean(team.role);
+	const canManageMembers = isOwner || hasMinRole(getUserRole(), "admin");
+	const canViewMembers = isMember || hasMinRole(getUserRole(), "admin");
+	const { data: members = [], isLoading, isError, error, refetch } = useTeamMembers(team.id, canViewMembers);
+	const upsert = useUpsertTeamMember(team.id);
+	const removeMember = useRemoveTeamMember(team.id);
+	const [role, setRole] = useState<TeamRole>("member");
+	const [searchValue, setSearchValue] = useState("");
+	const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+
+	function addUser() {
+		if (!selectedUserId) return;
+		upsert.mutate(
+			{ user_id: selectedUserId, role },
+			{
+				onSuccess: () => {
+					setSearchValue("");
+					setSelectedUserId(null);
+				},
+			},
+		);
+	}
+
+	if (!canViewMembers) {
+		return (
+			<EmptyState
+				icon={ShieldCheck}
+				title="Membership required"
+				description="This teamspace is discoverable, but its member roster is only visible to members and administrators."
+			/>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			{canManageMembers && (
+				<div className="rounded-lg border border-border/80 bg-card/70 p-4">
+					<div className="mb-3 flex items-center gap-2">
+						<UserPlus className="h-4 w-4 text-primary-accent" />
+						<div>
+							<h3 className="text-sm font-medium">Add a member</h3>
+							<p className="text-xs text-muted-foreground">Search for a person, then choose their role.</p>
+						</div>
+					</div>
+					<div className="flex flex-col gap-2 lg:flex-row lg:items-center">
+						<UserSearchInput
+							placeholder="Search people"
+							value={searchValue}
+							onValueChange={(value) => {
+								setSearchValue(value);
+								setSelectedUserId(null);
+							}}
+							onSelect={(user) => {
+								setSearchValue(user.username ? `@${user.username}` : user.email);
+								setSelectedUserId(user.id);
+							}}
+							className="min-w-0 flex-1"
+							disabled={upsert.isPending}
+						/>
+						<PickerSelect
+							value={role}
+							onValueChange={(value) => setRole(value as TeamRole)}
+							className="w-full lg:w-32"
+							options={ROLE_OPTIONS}
+						/>
+						<Button
+							className="bg-primary-accent text-primary-foreground hover:bg-primary-accent/90"
+							onClick={addUser}
+							disabled={upsert.isPending || !selectedUserId}
+						>
+							{upsert.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
+							Add member
+						</Button>
+					</div>
+					<p className="mt-3 text-xs leading-5 text-muted-foreground">
+						Owners and reviewers clear the team-private review queue. Members publish, but their team-private
+						submissions wait for an owner or a reviewer.
+					</p>
+				</div>
+			)}
+
+			{isLoading ? (
+				<div className="space-y-2" aria-label="Loading members">
+					<div className="h-12 animate-pulse rounded-md bg-muted/60" />
+					<div className="h-12 animate-pulse rounded-md bg-muted/60" />
+				</div>
+			) : isError ? (
+				<ErrorState message={error?.message} onRetry={() => refetch()} />
+			) : members.length === 0 ? (
+				<EmptyState
+					icon={Users}
+					title="No members yet"
+					description="Add someone above to start publishing together."
+				/>
+			) : (
+				<div className="divide-y divide-border/70 rounded-lg border border-border/80">
+					{members.map((member: TeamMember) => (
+						<div key={member.id} className="flex items-center justify-between gap-4 px-4 py-3">
+							<div className="min-w-0">
+								<p className="truncate text-sm font-medium">{member.username ? `@${member.username}` : member.email}</p>
+								{member.name && <p className="truncate text-xs text-muted-foreground">{member.name}</p>}
+							</div>
+							<div className="flex shrink-0 items-center gap-2">
+								{canManageMembers ? (
+									<PickerSelect
+										value={member.role}
+										onValueChange={(value) => {
+											const nextRole = value as TeamRole;
+											if (nextRole !== member.role) upsert.mutate({ user_id: member.id, role: nextRole });
+										}}
+										options={ROLE_OPTIONS}
+										ariaLabel={`Change role for ${member.username ? `@${member.username}` : member.email}`}
+										className="w-28"
+										inputClassName="h-8 bg-background/80 px-2 text-xs"
+										disabled={upsert.isPending}
+									/>
+								) : (
+									<Badge variant="outline" className="capitalize px-2 py-0.5 text-[11px]">
+										{member.role}
+									</Badge>
+								)}
+								{canManageMembers && (
+									<Button
+										variant="ghost"
+										size="icon"
+										className="h-7 w-7 text-muted-foreground hover:text-destructive"
+										onClick={() => removeMember.mutate(member.id)}
+										disabled={removeMember.isPending}
+										aria-label={`Remove ${member.username ? `@${member.username}` : member.email}`}
+										title="Remove member"
+									>
+										<Trash2 className="h-3.5 w-3.5" />
+									</Button>
+								)}
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ReviewTab({
+	items,
+	isLoading,
+	isError,
+	errorMessage,
+	onRetry,
+}: {
+	items: ReviewItem[];
+	isLoading: boolean;
+	isError: boolean;
+	errorMessage?: string;
+	onRetry: () => void;
+}) {
+	const reviewAction = useReviewAction();
+	const queryClient = useQueryClient();
+	const [rejectTarget, setRejectTarget] = useState<ReviewItem | null>(null);
+	const [reason, setReason] = useState("");
+
+	function runAction(vars: { id: string; type?: string; action: "approve" | "reject"; reason?: string }) {
+		reviewAction.mutate(vars, {
+			// An approval publishes the item, so the Agents and Components tabs
+			// on this same page are now stale.
+			onSuccess: () => queryClient.invalidateQueries({ queryKey: ["registry"] }),
+		});
+	}
+
+	if (isLoading) return <TableSkeleton rows={3} cols={3} />;
+	if (isError) return <ErrorState message={errorMessage} onRetry={onRetry} />;
+	if (items.length === 0) {
+		return (
+			<EmptyState
+				icon={ClipboardCheck}
+				title="Nothing waiting on you"
+				description="Team-private submissions from this teamspace land here for its owners and reviewers. Anything published as public goes to the global review queue instead."
+			/>
+		);
+	}
+
+	return (
+		<>
+			<div className="divide-y divide-border/70 overflow-hidden rounded-lg border border-border/80">
+				{items.map((item) => (
+					<div key={`${item.type}-${item.id}`} className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start">
+						<div className="min-w-0 flex-1">
+							<div className="flex flex-wrap items-center gap-2">
+								<p className="truncate text-sm font-medium">{item.name ?? "Unnamed"}</p>
+								{item.type && (
+									<Badge variant="outline" className="px-1.5 py-0 text-[10px] capitalize">
+										{item.type}
+									</Badge>
+								)}
+								{item.version && <span className="font-mono text-xs text-muted-foreground">v{item.version}</span>}
+								{item.status && <StatusBadge status={item.status} />}
+							</div>
+							{item.description && (
+								<p className="mt-1 line-clamp-2 max-w-2xl text-xs leading-5 text-muted-foreground">{item.description}</p>
+							)}
+							<div className="mt-1.5 flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+								{item.submitted_by && <span>by {item.submitted_by}</span>}
+								{(item.submitted_at || item.created_at) && (
+									<span>{new Date((item.submitted_at ?? item.created_at)!).toLocaleDateString()}</span>
+								)}
+								{item.components_ready === false && (
+									<span className="text-warning">Blocked: components still pending</span>
+								)}
+							</div>
+						</div>
+						<div className="flex shrink-0 items-center gap-2">
+							<Button
+								size="sm"
+								className="h-8 text-xs"
+								disabled={reviewAction.isPending}
+								onClick={() => runAction({ id: item.id, type: item.type, action: "approve" })}
+							>
+								Approve
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								className="h-8 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+								disabled={reviewAction.isPending}
+								onClick={() => {
+									setReason("");
+									setRejectTarget(item);
+								}}
+							>
+								Reject
+							</Button>
+						</div>
+					</div>
+				))}
+			</div>
+
+			<Dialog
+				open={!!rejectTarget}
+				onOpenChange={(open) => {
+					if (!open) setRejectTarget(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Reject {rejectTarget?.name ?? "submission"}?</DialogTitle>
+					</DialogHeader>
+					<div className="space-y-2">
+						<Label htmlFor="team-review-reason">Reason</Label>
+						<Textarea
+							id="team-review-reason"
+							value={reason}
+							onChange={(event) => setReason(event.target.value)}
+							rows={4}
+							placeholder="Tell the submitter what to change before resubmitting"
+						/>
+						<p className="text-xs text-muted-foreground">
+							The reason is shown to the submitter, so a rejection without one is not accepted.
+						</p>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setRejectTarget(null)}>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							disabled={!reason.trim() || reviewAction.isPending}
+							onClick={() => {
+								if (!rejectTarget) return;
+								runAction({
+									id: rejectTarget.id,
+									type: rejectTarget.type,
+									action: "reject",
+									reason: reason.trim(),
+								});
+								setRejectTarget(null);
+							}}
+						>
+							Reject submission
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}
+
+export default function TeamspaceDetailPage() {
+	const { handle } = useParams({ from: "/_authed/teamspaces/$handle" });
+	const { tab, type } = useSearch({ from: "/_authed/teamspaces/$handle" });
+	const navigate = useNavigate();
+	const { team, isLoading, isError, error, refetch, notFound } = useTeamByHandle(handle);
+	const leaveTeam = useLeaveTeam();
+	const deleteTeam = useDeleteTeam();
+	const [deleteOpen, setDeleteOpen] = useState(false);
+
+	const canReview = team?.role ? REVIEWING_TEAM_ROLES.includes(team.role) : false;
+	const reviewQueue = useTeamReviewQueue(team?.id, canReview);
+	const reviewItems = reviewQueue.data ?? [];
+
+	const tabs = [
+		{ value: "agents", label: "Agents" },
+		{ value: "components", label: "Components" },
+		{ value: "members", label: "Members" },
+		...(canReview ? [{ value: "review", label: "Review" }] : []),
+	];
+	const activeTab = tabs.some((entry) => entry.value === tab) ? tab! : "agents";
+	const activeType: RegistryType = type ?? "mcps";
+
+	function goto(next: { tab?: string; type?: RegistryType }) {
+		navigate({
+			to: "/teamspaces/$handle",
+			params: { handle },
+			search: { tab, type, ...next },
+			replace: true,
+		});
+	}
+
+	const header = (
+		<PageHeader
+			title={team?.name ?? handle}
+			breadcrumbs={[
+				{ label: "Registry", href: "/" },
+				{ label: "Teamspaces", href: "/teamspaces" },
+				{ label: team?.name ?? handle },
+			]}
+		/>
+	);
+
+	if (isLoading) {
+		return (
+			<>
+				{header}
+				<div className="mx-auto w-full max-w-6xl p-4 sm:p-6 lg:p-8">
+					<DetailSkeleton />
+				</div>
+			</>
+		);
+	}
+
+	if (isError) {
+		return (
+			<>
+				{header}
+				<div className="mx-auto w-full max-w-6xl p-4 sm:p-6 lg:p-8">
+					<ErrorState message={error?.message} onRetry={() => refetch()} />
+				</div>
+			</>
+		);
+	}
+
+	if (notFound || !team) {
+		return (
+			<>
+				{header}
+				<div className="mx-auto w-full max-w-6xl p-4 sm:p-6 lg:p-8">
+					<EmptyState
+						icon={Building2}
+						title={`No teamspace named ${handle}`}
+						description="The handle does not match any teamspace you can see. It may have been renamed or deleted."
+						actionLabel="Back to teamspaces"
+						actionHref="/teamspaces"
+					/>
+				</div>
+			</>
+		);
+	}
+
+	const isMember = Boolean(team.role);
+	const isOwner = team.role === "owner";
+
+	return (
+		<>
+			{header}
+			<main className="min-h-0 flex-1 overflow-y-auto bg-surface-sunken/30">
+				<div className="mx-auto w-full max-w-6xl p-4 sm:p-6 lg:p-8">
+					<Link
+						to="/teamspaces"
+						className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+					>
+						<ArrowLeft className="h-3.5 w-3.5" />
+						All teamspaces
+					</Link>
+
+					<header className="mt-4 flex flex-col gap-5 border-b border-border/80 pb-6 sm:flex-row sm:items-start sm:justify-between">
+						<div className="flex min-w-0 items-start gap-3">
+							<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-primary-accent/25 bg-primary-accent/10 text-primary-accent">
+								<Building2 className="h-5 w-5" />
+							</div>
+							<div className="min-w-0">
+								<h2 className="truncate text-xl font-semibold tracking-tight">{team.name}</h2>
+								<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+									<span className="font-mono">{team.handle}</span>
+									<span aria-hidden="true">·</span>
+									<Badge variant="outline" className="px-1.5 py-0 text-[11px] font-medium capitalize">
+										{team.role ?? "discoverable"}
+									</Badge>
+									{team.member_count != null && <span>{team.member_count} members</span>}
+								</div>
+								{team.description && (
+									<p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">{team.description}</p>
+								)}
+							</div>
+						</div>
+						<div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+							{isMember && (
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => leaveTeam.mutate(team.id, { onSuccess: () => navigate({ to: "/teamspaces" }) })}
+									disabled={leaveTeam.isPending}
+								>
+									<LogOut className="mr-1.5 h-3.5 w-3.5" /> Leave
+								</Button>
+							)}
+							{isOwner && (
+								<Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)} disabled={deleteTeam.isPending}>
+									<Trash2 className="mr-1.5 h-3.5 w-3.5" /> Delete
+								</Button>
+							)}
+						</div>
+					</header>
+
+					<Tabs value={activeTab} onValueChange={(value) => goto({ tab: value })} className="mt-6">
+						<TabsList>
+							{tabs.map((entry) => (
+								<TabsTrigger key={entry.value} value={entry.value}>
+									{entry.label}
+									{entry.value === "review" && reviewItems.length > 0 && (
+										<span className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-accent px-1 text-[10px] font-semibold text-primary-foreground">
+											{reviewItems.length}
+										</span>
+									)}
+								</TabsTrigger>
+							))}
+						</TabsList>
+
+						<TabsContent value="agents" className="mt-5">
+							<AgentsTab team={team} />
+						</TabsContent>
+						<TabsContent value="components" className="mt-5">
+							<ComponentsTab team={team} activeType={activeType} onTypeChange={(next) => goto({ type: next })} />
+						</TabsContent>
+						<TabsContent value="members" className="mt-5">
+							<MembersTab team={team} />
+						</TabsContent>
+						{canReview && (
+							<TabsContent value="review" className="mt-5">
+								<ReviewTab
+									items={reviewItems}
+									isLoading={reviewQueue.isLoading}
+									isError={reviewQueue.isError}
+									errorMessage={reviewQueue.error?.message}
+									onRetry={() => reviewQueue.refetch()}
+								/>
+							</TabsContent>
+						)}
+					</Tabs>
+
+					<footer className="mt-6 flex flex-col gap-3 rounded-lg border border-border/80 bg-card/70 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+						<div className="flex items-start gap-2.5">
+							<Terminal className="mt-0.5 h-4 w-4 shrink-0 text-primary-accent" />
+							<div>
+								<p className="text-xs font-medium text-foreground">Publishing namespace</p>
+								<p className="mt-1 text-xs text-muted-foreground">
+									Use this identity when installing an agent or component from the team.
+								</p>
+							</div>
+						</div>
+						<code className="rounded-md border border-border/80 bg-background px-3 py-2 font-mono text-xs text-foreground">
+							observal pull {team.handle}/agent-name
+						</code>
+					</footer>
+				</div>
+			</main>
+
+			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete {team.name}?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This permanently removes the teamspace and its membership records. Published items are not deleted.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+							onClick={() => deleteTeam.mutate(team.id, { onSuccess: () => navigate({ to: "/teamspaces" }) })}
+						>
+							Delete teamspace
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
+}

--- a/web/src/pages/registry/teamspaces.tsx
+++ b/web/src/pages/registry/teamspaces.tsx
@@ -3,46 +3,19 @@
 
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
-import { Building2, Loader2, LogOut, Plus, RefreshCw, Search, ShieldCheck, Terminal, Trash2, UserPlus, Users } from "lucide-react";
+import { Building2, ChevronRight, Loader2, Plus, RefreshCw, Search, Users } from "lucide-react";
 import { PageHeader } from "@/components/layouts/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
-import { UserSearchInput } from "@/components/shared/user-search-input";
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { PickerSelect } from "@/components/ui/picker-select";
 import { Textarea } from "@/components/ui/textarea";
 import { hasMinRole } from "@/hooks/use-role-guard";
-import {
-	useAllTeams,
-	useCreateTeam,
-	useDeleteTeam,
-	useLeaveTeam,
-	useRemoveTeamMember,
-	useTeamMembers,
-	useTeams,
-	useUpsertTeamMember,
-} from "@/hooks/use-teams-api";
+import { useAllTeams, useCreateTeam, useTeams } from "@/hooks/use-api";
 import { getUserRole } from "@/lib/api";
 import { slugifyRegistryText } from "@/lib/registry-name";
-import type { Team, TeamMember, TeamRole } from "@/lib/types";
-
-const ROLE_OPTIONS = [
-	{ value: "member", label: "Member" },
-	{ value: "reviewer", label: "Reviewer" },
-	{ value: "owner", label: "Owner" },
-];
+import type { Team } from "@/lib/types";
 
 const CONTROL_CLASS_NAME =
 	"bg-background/80 border-input/90 placeholder:text-muted-foreground/80 hover:border-primary-accent/50 focus-visible:border-primary-accent focus-visible:ring-primary-accent/30";
@@ -52,211 +25,52 @@ function slugifyHandle(value: string) {
 	return base && base.length < 3 ? `${base}-team` : base;
 }
 
-function TeamDetail({ team }: { team: Team }) {
-	const isOwner = team.role === "owner";
-	const isMember = Boolean(team.role);
-	const canManageMembers = isOwner || hasMinRole(getUserRole(), "admin");
-	const canViewMembers = isMember || hasMinRole(getUserRole(), "admin");
-	const { data: members = [], isLoading, isError } = useTeamMembers(team.id, canViewMembers);
-	const upsert = useUpsertTeamMember(team.id);
-	const removeMember = useRemoveTeamMember(team.id);
-	const leaveTeam = useLeaveTeam();
-	const deleteTeam = useDeleteTeam();
-	const [role, setRole] = useState<TeamRole>("member");
-	const [searchValue, setSearchValue] = useState("");
-	const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
-	const [deleteOpen, setDeleteOpen] = useState(false);
-
-	function addUser() {
-		if (!selectedUserId) return;
-		upsert.mutate(
-			{ user_id: selectedUserId, role },
-			{ onSuccess: () => { setSearchValue(""); setSelectedUserId(null); } },
-		);
-	}
-
+function TeamspaceCard({ team }: { team: Team }) {
 	return (
-		<main className="min-h-0 flex-1 overflow-y-auto bg-surface-sunken/30">
-			<div className="mx-auto w-full max-w-6xl p-4 sm:p-6 lg:p-8">
-				<header className="flex flex-col gap-5 border-b border-border/80 pb-6 sm:flex-row sm:items-start sm:justify-between">
-					<div className="flex min-w-0 items-start gap-3">
-						<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-primary-accent/25 bg-primary-accent/10 text-primary-accent">
-							<Building2 className="h-5 w-5" />
-						</div>
-						<div className="min-w-0">
-							<h2 className="truncate text-xl font-semibold tracking-tight">{team.name}</h2>
-							<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-								<span className="font-mono">{team.handle}</span>
-								<span aria-hidden="true">·</span>
-								<Badge variant="outline" className="capitalize px-1.5 py-0 text-[11px] font-medium">
-									{team.role ?? "discoverable"}
-								</Badge>
-								{team.member_count != null && <span>{team.member_count} members</span>}
-							</div>
-							{team.description && <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-foreground">{team.description}</p>}
-						</div>
-					</div>
-					<div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
-						<Link to="/components" search={{ team: team.handle }}>
-							<Button variant="outline" size="sm">Browse registry</Button>
-						</Link>
-						{isMember && (
-							<Button variant="outline" size="sm" onClick={() => leaveTeam.mutate(team.id)} disabled={leaveTeam.isPending}>
-								<LogOut className="mr-1.5 h-3.5 w-3.5" /> Leave
-							</Button>
-						)}
-						{isOwner && (
-							<Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)} disabled={deleteTeam.isPending}>
-								<Trash2 className="mr-1.5 h-3.5 w-3.5" /> Delete
-							</Button>
-						)}
-					</div>
-				</header>
-
-				<section className="mt-6 flex min-h-[calc(100dvh-11rem)] flex-col overflow-hidden rounded-xl border border-border/80 bg-card/70">
-					<div className="flex flex-col gap-1 border-b border-border/70 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
-						<div>
-							<h3 className="text-sm font-semibold">Members</h3>
-							<p className="mt-1 text-xs text-muted-foreground">
-								{canViewMembers ? "People who can publish and manage this teamspace." : "Join the teamspace to view its members."}
-							</p>
-						</div>
-						{team.member_count != null && <span className="text-xs text-muted-foreground">{team.member_count} total</span>}
-					</div>
-
-					{canManageMembers && (
-						<div className="border-b border-border/70 bg-background/30 px-5 py-4">
-							<div className="mb-3 flex items-center gap-2">
-								<UserPlus className="h-4 w-4 text-primary-accent" />
-								<div>
-									<h4 className="text-sm font-medium">Add a member</h4>
-									<p className="text-xs text-muted-foreground">Search for a person, then choose their role.</p>
-								</div>
-							</div>
-							<div className="flex flex-col gap-2 lg:flex-row lg:items-center">
-								<UserSearchInput
-									placeholder="Search people"
-									value={searchValue}
-									onValueChange={(value) => { setSearchValue(value); setSelectedUserId(null); }}
-									onSelect={(user) => {
-										setSearchValue(user.username ? `@${user.username}` : user.email);
-										setSelectedUserId(user.id);
-									}}
-									className="min-w-0 flex-1"
-									disabled={upsert.isPending}
-								/>
-								<PickerSelect value={role} onValueChange={(value) => setRole(value as TeamRole)} className="w-full lg:w-32" options={ROLE_OPTIONS} />
-								<Button className="bg-primary-accent text-primary-foreground hover:bg-primary-accent/90" onClick={addUser} disabled={upsert.isPending || !selectedUserId}>
-									{upsert.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
-									Add member
-								</Button>
-							</div>
-						</div>
-					)}
-
-					<div className="flex-1 p-5">
-						{!canViewMembers ? (
-							<div className="rounded-lg border border-dashed border-border/80 px-5 py-8 text-center">
-								<ShieldCheck className="mx-auto h-6 w-6 text-muted-foreground/70" />
-								<p className="mt-3 text-sm font-medium">Membership required</p>
-								<p className="mx-auto mt-1 max-w-sm text-xs leading-5 text-muted-foreground">This teamspace is discoverable, but its member roster is only visible to members and administrators.</p>
-							</div>
-						) : isLoading ? (
-							<div className="space-y-2" aria-label="Loading members">
-								<div className="h-12 animate-pulse rounded-md bg-muted/60" />
-								<div className="h-12 animate-pulse rounded-md bg-muted/60" />
-							</div>
-						) : isError ? (
-							<div className="rounded-lg border border-dashed border-border/80 px-5 py-8 text-center">
-								<p className="text-sm font-medium">Members could not be loaded</p>
-								<p className="mt-1 text-xs text-muted-foreground">Try refreshing this teamspace.</p>
-							</div>
-						) : members.length === 0 ? (
-							<div className="rounded-lg border border-dashed border-border/80 px-5 py-8 text-center">
-								<Users className="mx-auto h-6 w-6 text-muted-foreground/70" />
-								<p className="mt-3 text-sm font-medium">No members yet</p>
-								<p className="mt-1 text-xs text-muted-foreground">Add someone above to start publishing together.</p>
-							</div>
-						) : (
-							<div className="divide-y divide-border/70 rounded-lg border border-border/80">
-								{members.map((member: TeamMember) => (
-									<div key={member.id} className="flex items-center justify-between gap-4 px-4 py-3">
-										<div className="min-w-0">
-											<p className="truncate text-sm font-medium">{member.username ? `@${member.username}` : member.email}</p>
-											{member.name && <p className="truncate text-xs text-muted-foreground">{member.name}</p>}
-										</div>
-										<div className="flex shrink-0 items-center gap-2">
-											{canManageMembers ? (
-												<PickerSelect
-													value={member.role}
-													onValueChange={(value) => {
-														const nextRole = value as TeamRole;
-														if (nextRole !== member.role) upsert.mutate({ user_id: member.id, role: nextRole });
-													}}
-													options={ROLE_OPTIONS}
-													ariaLabel={`Change role for ${member.username ? `@${member.username}` : member.email}`}
-													className="w-28"
-													inputClassName="h-8 bg-background/80 px-2 text-xs"
-													disabled={upsert.isPending}
-												/>
-											) : (
-												<Badge variant="outline" className="capitalize px-2 py-0.5 text-[11px]">{member.role}</Badge>
-											)}
-											{canManageMembers && (
-												<Button
-													variant="ghost"
-													size="icon"
-													className="h-7 w-7 text-muted-foreground hover:text-destructive"
-													onClick={() => removeMember.mutate(member.id)}
-													disabled={removeMember.isPending}
-													aria-label={`Remove ${member.username ? `@${member.username}` : member.email}`}
-													title="Remove member"
-												>
-													<Trash2 className="h-3.5 w-3.5" />
-												</Button>
-											)}
-										</div>
-									</div>
-								))}
-							</div>
-						)}
-					</div>
-
-					<footer className="flex flex-col gap-3 border-t border-border/70 bg-background/20 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
-						<div className="flex items-start gap-2.5">
-							<Terminal className="mt-0.5 h-4 w-4 shrink-0 text-primary-accent" />
-							<div>
-								<p className="text-xs font-medium text-foreground">Publishing namespace</p>
-								<p className="mt-1 text-xs text-muted-foreground">Use this identity when installing an agent or component from the team.</p>
-							</div>
-						</div>
-						<code className="rounded-md border border-border/80 bg-background px-3 py-2 font-mono text-xs text-foreground">observal pull {team.handle}/agent-name</code>
-					</footer>
-				</section>
+		<Link
+			to="/teamspaces/$handle"
+			params={{ handle: team.handle }}
+			className="group flex flex-col rounded-lg border border-border/80 bg-card p-4 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-primary-accent/40 hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accent/50"
+		>
+			<div className="flex items-start gap-3">
+				<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary-accent/25 bg-primary-accent/10 text-primary-accent">
+					<Building2 className="h-4.5 w-4.5" />
+				</div>
+				<div className="min-w-0 flex-1">
+					<p className="truncate text-sm font-semibold leading-tight">{team.name}</p>
+					<p className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{team.handle}</p>
+				</div>
+				<ChevronRight className="mt-1 h-4 w-4 shrink-0 text-muted-foreground/60 transition-transform group-hover:translate-x-0.5" />
 			</div>
 
-			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>Delete {team.name}?</AlertDialogTitle>
-						<AlertDialogDescription>This permanently removes the teamspace and its membership records. Published items are not deleted.</AlertDialogDescription>
-					</AlertDialogHeader>
-					<AlertDialogFooter>
-						<AlertDialogCancel>Cancel</AlertDialogCancel>
-						<AlertDialogAction
-							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-							onClick={() => deleteTeam.mutate(team.id)}
-						>
-							Delete teamspace
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
-		</main>
+			{team.description && (
+				<p className="mt-3 line-clamp-2 text-xs leading-5 text-muted-foreground">{team.description}</p>
+			)}
+
+			<div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+				<Badge variant="outline" className="px-1.5 py-0 text-[10px] font-medium capitalize">
+					{team.role ?? "discoverable"}
+				</Badge>
+				{team.member_count != null && (
+					<span className="inline-flex items-center gap-1">
+						<Users className="h-3 w-3" />
+						{team.member_count}
+					</span>
+				)}
+			</div>
+		</Link>
 	);
 }
 
-function CreatePanel({ onCreated, onCancel, firstTeamspace = false }: { onCreated: () => void; onCancel?: () => void; firstTeamspace?: boolean }) {
+function CreatePanel({
+	onCreated,
+	onCancel,
+	firstTeamspace = false,
+}: {
+	onCreated: () => void;
+	onCancel?: () => void;
+	firstTeamspace?: boolean;
+}) {
 	const createTeam = useCreateTeam();
 	const [name, setName] = useState("");
 	const [handle, setHandle] = useState("");
@@ -282,101 +96,140 @@ function CreatePanel({ onCreated, onCancel, firstTeamspace = false }: { onCreate
 	}
 
 	return (
-		<main className="min-h-0 flex-1 overflow-y-auto bg-surface-sunken/30">
-			<div className="mx-auto flex min-h-full w-full max-w-6xl items-start p-4 sm:p-6 lg:p-8 xl:p-10">
-				<section className="grid min-h-[620px] w-full overflow-hidden rounded-lg border border-border/80 bg-card 2xl:grid-cols-[minmax(260px,0.82fr)_minmax(0,1.5fr)]">
-					<aside className="grid gap-8 border-b border-border/70 bg-primary-accent/[0.04] p-5 sm:p-6 md:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] 2xl:flex 2xl:flex-col 2xl:justify-between 2xl:border-b-0 2xl:border-r">
-						<div>
-							<div className="flex items-center gap-2 text-xs font-medium text-primary-accent">
-								<Building2 className="h-4 w-4" /> Registry identity
-							</div>
-							<h2 className="mt-6 max-w-xs text-2xl font-semibold tracking-tight">{firstTeamspace ? "Give your team a home." : "Define the namespace your team will publish from."}</h2>
-							<p className="mt-3 max-w-sm text-sm leading-6 text-muted-foreground">The name is for people. The handle is the stable slug that travels with every install command.</p>
-						</div>
-
-						<div className="self-center" aria-live="polite" aria-atomic="true">
-							<p className="text-xs font-medium text-muted-foreground">Live install identity</p>
-							<div className="mt-3 min-h-16 border-b border-primary-accent/20 pb-4 font-mono text-xl tracking-tight 2xl:text-2xl">
-								<span className="text-primary-accent/70">observal pull </span>
-								<span key={previewHandle} className="inline-block text-foreground motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200 motion-reduce:animate-none">{previewHandle}</span>
-								<span className="text-muted-foreground">/agent-name</span>
-							</div>
-							<p className="mt-3 text-xs leading-5 text-muted-foreground">This preview updates as you type and uses the same slug rules as the teamspace handle.</p>
-						</div>
-
-						<div className="hidden border-t border-border/70 pt-4 text-xs leading-5 text-muted-foreground 2xl:block">
-							<p className="font-medium text-foreground">After creation</p>
-							<p className="mt-1">Invite members, assign roles, and publish agents or components under this namespace.</p>
-						</div>
-					</aside>
-
-					<div className="flex min-w-0 flex-col">
-						<header className="flex items-start justify-between gap-4 border-b border-border/70 px-6 py-6 sm:px-8 sm:py-8">
-							<div>
-								<p className="text-sm font-medium text-primary-accent">New teamspace</p>
-								<h3 className="mt-2 text-2xl font-semibold tracking-tight">{firstTeamspace ? "Create your first teamspace" : "Create a teamspace"}</h3>
-								<p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">Create a shared namespace for publishing agents and components with your team.</p>
-							</div>
-							{onCancel && <Button type="button" variant="ghost" size="sm" onClick={onCancel}>Cancel</Button>}
-						</header>
-
-						<form className="flex min-h-0 flex-1 flex-col" onSubmit={(event) => { event.preventDefault(); submit(); }}>
-							<div className="grid flex-1 content-start gap-6 p-6 sm:p-8 md:grid-cols-2">
-								<div className="space-y-2">
-									<Label htmlFor="team-name">Name</Label>
-									<Input
-										id="team-name"
-										autoFocus={firstTeamspace}
-										required
-										value={name}
-										onChange={(event) => setName(event.target.value)}
-										placeholder="Platform Tools"
-										className={`${CONTROL_CLASS_NAME} h-11 text-base`}
-									/>
-								</div>
-								<div className="space-y-2">
-									<div className="flex items-center justify-between gap-3">
-										<Label htmlFor="team-handle">Handle</Label>
-										{handleEdited && (
-											<button type="button" className="inline-flex items-center gap-1 text-xs text-primary-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accent/50" onClick={() => { setHandle(""); setHandleEdited(false); }}>
-												<RefreshCw className="h-3 w-3" /> Use generated
-											</button>
-										)}
-									</div>
-									<Input
-										id="team-handle"
-										value={handleEdited ? handle : generatedHandle}
-										onChange={(event) => { setHandle(slugifyRegistryText(event.target.value, { maxLength: 32, preserveTrailingSeparator: true })); setHandleEdited(true); }}
-										placeholder="platform-tools"
-										aria-describedby="team-handle-help"
-										className={`${CONTROL_CLASS_NAME} h-11 font-mono text-base`}
-									/>
-									<p id="team-handle-help" className="text-xs leading-5 text-muted-foreground">Generated live from the name. Short names use a readable `-team` suffix to meet namespace rules.</p>
-								</div>
-								<div className="space-y-2 md:col-span-2">
-									<Label htmlFor="team-description">Description <span className="font-normal text-muted-foreground">(optional)</span></Label>
-									<Textarea
-										id="team-description"
-										value={description}
-										onChange={(event) => setDescription(event.target.value)}
-										rows={5}
-										placeholder="What this team publishes, who it serves, and what belongs in this namespace"
-										className={`${CONTROL_CLASS_NAME} min-h-28 resize-y text-base leading-6`}
-									/>
-								</div>
-							</div>
-							<footer className="flex flex-col gap-3 border-t border-border/70 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
-								<p className="text-xs leading-5 text-muted-foreground">You can manage members and roles after creation.</p>
-								<Button type="submit" className="bg-primary-accent px-5 text-primary-foreground hover:bg-primary-accent/90" disabled={!name.trim() || createTeam.isPending}>
-									{createTeam.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-									Create teamspace
-								</Button>
-							</footer>
-						</form>
+		<section className="grid min-h-[620px] w-full overflow-hidden rounded-lg border border-border/80 bg-card 2xl:grid-cols-[minmax(260px,0.82fr)_minmax(0,1.5fr)]">
+			<aside className="grid gap-8 border-b border-border/70 bg-primary-accent/[0.04] p-5 sm:p-6 md:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] 2xl:flex 2xl:flex-col 2xl:justify-between 2xl:border-b-0 2xl:border-r">
+				<div>
+					<div className="flex items-center gap-2 text-xs font-medium text-primary-accent">
+						<Building2 className="h-4 w-4" /> Registry identity
 					</div>
-				</section>
+					<h2 className="mt-6 max-w-xs text-2xl font-semibold tracking-tight">
+						{firstTeamspace ? "Give your team a home." : "Define the namespace your team will publish from."}
+					</h2>
+					<p className="mt-3 max-w-sm text-sm leading-6 text-muted-foreground">
+						The name is for people. The handle is the stable slug that travels with every install command.
+					</p>
+				</div>
+
+				<div className="self-center" aria-live="polite" aria-atomic="true">
+					<p className="text-xs font-medium text-muted-foreground">Live install identity</p>
+					<div className="mt-3 min-h-16 border-b border-primary-accent/20 pb-4 font-mono text-xl tracking-tight 2xl:text-2xl">
+						<span className="text-primary-accent/70">observal pull </span>
+						<span
+							key={previewHandle}
+							className="inline-block text-foreground motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-1 motion-safe:duration-200 motion-reduce:animate-none"
+						>
+							{previewHandle}
+						</span>
+						<span className="text-muted-foreground">/agent-name</span>
+					</div>
+					<p className="mt-3 text-xs leading-5 text-muted-foreground">
+						This preview updates as you type and uses the same slug rules as the teamspace handle.
+					</p>
+				</div>
+
+				<div className="hidden border-t border-border/70 pt-4 text-xs leading-5 text-muted-foreground 2xl:block">
+					<p className="font-medium text-foreground">After creation</p>
+					<p className="mt-1">Invite members, assign roles, and publish agents or components under this namespace.</p>
+				</div>
+			</aside>
+
+			<div className="flex min-w-0 flex-col">
+				<header className="flex items-start justify-between gap-4 border-b border-border/70 px-6 py-6 sm:px-8 sm:py-8">
+					<div>
+						<p className="text-sm font-medium text-primary-accent">New teamspace</p>
+						<h3 className="mt-2 text-2xl font-semibold tracking-tight">
+							{firstTeamspace ? "Create your first teamspace" : "Create a teamspace"}
+						</h3>
+						<p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+							Create a shared namespace for publishing agents and components with your team.
+						</p>
+					</div>
+					{onCancel && (
+						<Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+							Cancel
+						</Button>
+					)}
+				</header>
+
+				<form
+					className="flex min-h-0 flex-1 flex-col"
+					onSubmit={(event) => {
+						event.preventDefault();
+						submit();
+					}}
+				>
+					<div className="grid flex-1 content-start gap-6 p-6 sm:p-8 md:grid-cols-2">
+						<div className="space-y-2">
+							<Label htmlFor="team-name">Name</Label>
+							<Input
+								id="team-name"
+								autoFocus={firstTeamspace}
+								required
+								value={name}
+								onChange={(event) => setName(event.target.value)}
+								placeholder="Platform Tools"
+								className={`${CONTROL_CLASS_NAME} h-11 text-base`}
+							/>
+						</div>
+						<div className="space-y-2">
+							<div className="flex items-center justify-between gap-3">
+								<Label htmlFor="team-handle">Handle</Label>
+								{handleEdited && (
+									<button
+										type="button"
+										className="inline-flex items-center gap-1 text-xs text-primary-accent hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accent/50"
+										onClick={() => {
+											setHandle("");
+											setHandleEdited(false);
+										}}
+									>
+										<RefreshCw className="h-3 w-3" /> Use generated
+									</button>
+								)}
+							</div>
+							<Input
+								id="team-handle"
+								value={handleEdited ? handle : generatedHandle}
+								onChange={(event) => {
+									setHandle(slugifyRegistryText(event.target.value, { maxLength: 32, preserveTrailingSeparator: true }));
+									setHandleEdited(true);
+								}}
+								placeholder="platform-tools"
+								aria-describedby="team-handle-help"
+								className={`${CONTROL_CLASS_NAME} h-11 font-mono text-base`}
+							/>
+							<p id="team-handle-help" className="text-xs leading-5 text-muted-foreground">
+								Generated live from the name. Short names use a readable `-team` suffix to meet namespace rules.
+							</p>
+						</div>
+						<div className="space-y-2 md:col-span-2">
+							<Label htmlFor="team-description">
+								Description <span className="font-normal text-muted-foreground">(optional)</span>
+							</Label>
+							<Textarea
+								id="team-description"
+								value={description}
+								onChange={(event) => setDescription(event.target.value)}
+								rows={5}
+								placeholder="What this team publishes, who it serves, and what belongs in this namespace"
+								className={`${CONTROL_CLASS_NAME} min-h-28 resize-y text-base leading-6`}
+							/>
+						</div>
+					</div>
+					<footer className="flex flex-col gap-3 border-t border-border/70 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-8">
+						<p className="text-xs leading-5 text-muted-foreground">You can manage members and roles after creation.</p>
+						<Button
+							type="submit"
+							className="bg-primary-accent px-5 text-primary-foreground hover:bg-primary-accent/90"
+							disabled={!name.trim() || createTeam.isPending}
+						>
+							{createTeam.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+							Create teamspace
+						</Button>
+					</footer>
+				</form>
 			</div>
-		</main>
+		</section>
 	);
 }
 
@@ -384,111 +237,101 @@ export default function TeamspacesPage() {
 	const { data: teams = [], isLoading: isTeamsLoading } = useTeams();
 	const { data: allTeams = [], isLoading: isAllTeamsLoading } = useAllTeams();
 	const canCreate = hasMinRole(getUserRole(), "reviewer");
-	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [showCreate, setShowCreate] = useState(false);
 	const [teamQuery, setTeamQuery] = useState("");
 
 	const browse = teams.length === 0 ? allTeams : teams;
 	const isLoading = isTeamsLoading || (teams.length === 0 && isAllTeamsLoading);
-	const filteredTeams = browse.filter((team) => {
-		const query = teamQuery.trim().toLowerCase();
-		return !query || team.name.toLowerCase().includes(query) || team.handle.toLowerCase().includes(query);
-	});
-	const selectedTeam = browse.find((team) => team.id === selectedId);
+	const query = teamQuery.trim().toLowerCase();
+	const filteredTeams = browse.filter(
+		(team) => !query || team.name.toLowerCase().includes(query) || team.handle.toLowerCase().includes(query),
+	);
 	const firstTeamspace = !isLoading && browse.length === 0 && canCreate;
 	const listTitle = teams.length > 0 ? "Your teamspaces" : "Discover teamspaces";
 
 	return (
 		<>
 			<PageHeader title="Teamspaces" breadcrumbs={[{ label: "Registry", href: "/" }, { label: "Teamspaces" }]} />
-			<div className="flex min-h-0 flex-1 flex-col overflow-hidden border-t border-border md:flex-row">
-				<aside className="flex w-full shrink-0 flex-col border-b border-border bg-sidebar-background md:w-72 md:border-b-0 md:border-r">
-					<div className="space-y-4 p-4">
-						<div className="flex items-start justify-between gap-3">
-							<div>
-								<h2 className="text-sm font-semibold">Teamspaces</h2>
-								<p className="mt-1 text-xs text-muted-foreground">Shared publishing namespaces</p>
-							</div>
-							<span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{browse.length}</span>
-						</div>
-						{canCreate && (
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								className="w-full justify-start border-primary-accent/30 hover:border-primary-accent/60 hover:bg-primary-accent/10"
-								onClick={() => { setShowCreate(true); setSelectedId(null); }}
-							>
-								<Plus className="mr-1.5 h-3.5 w-3.5 text-primary-accent" /> New teamspace
-							</Button>
-						)}
-						{browse.length > 0 && (
-							<div className="relative">
-								<Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-								<Input
-									value={teamQuery}
-									onChange={(event) => setTeamQuery(event.target.value)}
-									placeholder="Search teamspaces"
-									aria-label="Search teamspaces"
-									className={`${CONTROL_CLASS_NAME} h-8 pl-8 text-xs`}
-								/>
-							</div>
-						)}
-					</div>
-
-					<div className="min-h-0 max-h-64 flex-1 overflow-y-auto px-3 pb-3 md:max-h-none">
-						{browse.length === 0 ? (
-							<div className="rounded-lg border border-dashed border-sidebar-border px-4 py-8 text-center">
-								<Users className="mx-auto h-6 w-6 text-muted-foreground/70" />
-								<p className="mt-3 text-sm font-medium">No teamspaces yet</p>
-								<p className="mt-1 text-xs leading-5 text-muted-foreground">{canCreate ? "Create your first one in the main pane." : "There are no discoverable teamspaces yet."}</p>
-							</div>
-						) : filteredTeams.length === 0 ? (
-							<div className="px-3 py-8 text-center text-xs text-muted-foreground">No matching teamspaces.</div>
-						) : (
-							<>
-								<p className="px-2 pb-2 pt-1 text-xs font-medium text-muted-foreground">{listTitle}</p>
-								<div className="space-y-1">
-									{filteredTeams.map((team) => (
-										<button
-											key={team.id}
-											type="button"
-											className={`group w-full rounded-md border px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-accent/50 ${selectedId === team.id ? "border-primary-accent/35 bg-primary-accent/10" : "border-transparent hover:border-sidebar-border hover:bg-sidebar-accent/60"}`}
-											onClick={() => { setSelectedId(team.id); setShowCreate(false); }}
-										>
-											<div className="flex items-center justify-between gap-2">
-												<p className="truncate text-sm font-medium">{team.name}</p>
-												{team.role && <span className="shrink-0 text-[10px] capitalize text-muted-foreground">{team.role}</span>}
-											</div>
-											<p className="mt-1 truncate font-mono text-[11px] text-muted-foreground">{team.handle}</p>
-										</button>
-									))}
-								</div>
-							</>
-						)}
-					</div>
-				</aside>
-
-				<div className="flex min-h-0 flex-1 flex-col">
+			<main className="min-h-0 flex-1 overflow-y-auto bg-surface-sunken/30">
+				<div className="mx-auto w-full max-w-6xl p-4 sm:p-6 lg:p-8">
 					{showCreate || firstTeamspace ? (
 						<CreatePanel
 							firstTeamspace={firstTeamspace}
-							onCreated={() => { setShowCreate(false); setSelectedId(null); }}
+							onCreated={() => setShowCreate(false)}
 							onCancel={firstTeamspace ? undefined : () => setShowCreate(false)}
 						/>
-					) : selectedTeam ? (
-						<TeamDetail team={selectedTeam} />
 					) : (
-						<div className="flex min-h-0 flex-1 items-center justify-center bg-surface-sunken/30 p-6">
-							<EmptyState
-								icon={browse.length > 0 ? Building2 : Users}
-								title={browse.length > 0 ? "Select a teamspace" : "No teamspaces to browse"}
-								description={browse.length > 0 ? "Choose a teamspace from the rail to view its members and publishing context." : "When a teamspace is available, it will appear here for browsing."}
-							/>
-						</div>
+						<>
+							<header className="flex flex-col gap-4 border-b border-border/80 pb-5 sm:flex-row sm:items-end sm:justify-between">
+								<div>
+									<h2 className="text-xl font-semibold tracking-tight">{listTitle}</h2>
+									<p className="mt-1 text-sm text-muted-foreground">
+										Shared publishing namespaces. Open one to browse its agents and components, manage members, and
+										clear its review queue.
+									</p>
+								</div>
+								<div className="flex items-center gap-2">
+									{browse.length > 0 && (
+										<div className="relative">
+											<Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+											<Input
+												value={teamQuery}
+												onChange={(event) => setTeamQuery(event.target.value)}
+												placeholder="Search teamspaces"
+												aria-label="Search teamspaces"
+												className={`${CONTROL_CLASS_NAME} h-9 w-full pl-8 text-xs sm:w-56`}
+											/>
+										</div>
+									)}
+									{canCreate && (
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											className="h-9 shrink-0 border-primary-accent/30 hover:border-primary-accent/60 hover:bg-primary-accent/10"
+											onClick={() => setShowCreate(true)}
+										>
+											<Plus className="mr-1.5 h-3.5 w-3.5 text-primary-accent" /> New teamspace
+										</Button>
+									)}
+								</div>
+							</header>
+
+							<div className="mt-6">
+								{isLoading ? (
+									<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3" aria-label="Loading teamspaces">
+										<div className="h-32 animate-pulse rounded-lg bg-muted/60" />
+										<div className="h-32 animate-pulse rounded-lg bg-muted/60" />
+										<div className="h-32 animate-pulse rounded-lg bg-muted/60" />
+									</div>
+								) : browse.length === 0 ? (
+									<EmptyState
+										icon={Users}
+										title="No teamspaces to browse"
+										description={
+											canCreate
+												? "Create the first teamspace to give your team a shared publishing namespace."
+												: "There are no discoverable teamspaces yet. Ask an owner to add you to one."
+										}
+									/>
+								) : filteredTeams.length === 0 ? (
+									<EmptyState
+										icon={Search}
+										title="No matching teamspaces"
+										description={`Nothing matches "${teamQuery.trim()}". Clear the search to see all ${browse.length}.`}
+									/>
+								) : (
+									<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+										{filteredTeams.map((team) => (
+											<TeamspaceCard key={team.id} team={team} />
+										))}
+									</div>
+								)}
+							</div>
+						</>
 					)}
 				</div>
-			</div>
+			</main>
 		</>
 	);
 }

--- a/web/src/pages/registry/teamspaces.tsx
+++ b/web/src/pages/registry/teamspaces.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 import { Building2, Loader2, LogOut, Plus, RefreshCw, Search, ShieldCheck, Terminal, Trash2, UserPlus, Users } from "lucide-react";
 import { PageHeader } from "@/components/layouts/page-header";
@@ -96,6 +97,9 @@ function TeamDetail({ team }: { team: Team }) {
 						</div>
 					</div>
 					<div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+						<Link to="/components" search={{ team: team.handle }}>
+							<Button variant="outline" size="sm">Browse registry</Button>
+						</Link>
 						{isMember && (
 							<Button variant="outline" size="sm" onClick={() => leaveTeam.mutate(team.id)} disabled={leaveTeam.isPending}>
 								<LogOut className="mr-1.5 h-3.5 w-3.5" /> Leave

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as authDeviceRouteImport } from './routes/(auth)/device'
 import { Route as AuthedWikiIndexRouteImport } from './routes/_authed/wiki/index'
 import { Route as AuthedComponentsIndexRouteImport } from './routes/_authed/components/index'
 import { Route as AuthedAgentsIndexRouteImport } from './routes/_authed/agents/index'
+import { Route as AuthedTeamspacesHandleRouteImport } from './routes/_authed/teamspaces.$handle'
 import { Route as AuthedInsightsReportIdRouteImport } from './routes/_authed/insights/$reportId'
 import { Route as AuthedComponentsComponentIdRouteImport } from './routes/_authed/components/$componentId'
 import { Route as AuthedAgentsBuilderRouteImport } from './routes/_authed/agents/builder'
@@ -94,6 +95,11 @@ const AuthedAgentsIndexRoute = AuthedAgentsIndexRouteImport.update({
   id: '/agents/',
   path: '/agents/',
   getParentRoute: () => AuthedRoute,
+} as any)
+const AuthedTeamspacesHandleRoute = AuthedTeamspacesHandleRouteImport.update({
+  id: '/$handle',
+  path: '/$handle',
+  getParentRoute: () => AuthedTeamspacesRoute,
 } as any)
 const AuthedInsightsReportIdRoute = AuthedInsightsReportIdRouteImport.update({
   id: '/insights/$reportId',
@@ -185,7 +191,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof authLoginRoute
   '/register': typeof authRegisterRoute
   '/leaderboard': typeof AuthedLeaderboardRoute
-  '/teamspaces': typeof AuthedTeamspacesRoute
+  '/teamspaces': typeof AuthedTeamspacesRouteWithChildren
   '/audit-log': typeof AuthedAdminAuditLogRoute
   '/dashboard': typeof AuthedAdminDashboardRoute
   '/diagnostics': typeof AuthedAdminDiagnosticsRoute
@@ -199,6 +205,7 @@ export interface FileRoutesByFullPath {
   '/agents/builder': typeof AuthedAgentsBuilderRoute
   '/components/$componentId': typeof AuthedComponentsComponentIdRoute
   '/insights/$reportId': typeof AuthedInsightsReportIdRoute
+  '/teamspaces/$handle': typeof AuthedTeamspacesHandleRoute
   '/agents/': typeof AuthedAgentsIndexRoute
   '/components/': typeof AuthedComponentsIndexRoute
   '/wiki/': typeof AuthedWikiIndexRoute
@@ -212,7 +219,7 @@ export interface FileRoutesByTo {
   '/register': typeof authRegisterRoute
   '/': typeof AuthedIndexRoute
   '/leaderboard': typeof AuthedLeaderboardRoute
-  '/teamspaces': typeof AuthedTeamspacesRoute
+  '/teamspaces': typeof AuthedTeamspacesRouteWithChildren
   '/audit-log': typeof AuthedAdminAuditLogRoute
   '/dashboard': typeof AuthedAdminDashboardRoute
   '/diagnostics': typeof AuthedAdminDiagnosticsRoute
@@ -226,6 +233,7 @@ export interface FileRoutesByTo {
   '/agents/builder': typeof AuthedAgentsBuilderRoute
   '/components/$componentId': typeof AuthedComponentsComponentIdRoute
   '/insights/$reportId': typeof AuthedInsightsReportIdRoute
+  '/teamspaces/$handle': typeof AuthedTeamspacesHandleRoute
   '/agents': typeof AuthedAgentsIndexRoute
   '/components': typeof AuthedComponentsIndexRoute
   '/wiki': typeof AuthedWikiIndexRoute
@@ -242,7 +250,7 @@ export interface FileRoutesById {
   '/_authed/_admin': typeof AuthedAdminRouteWithChildren
   '/_authed/_user': typeof AuthedUserRouteWithChildren
   '/_authed/leaderboard': typeof AuthedLeaderboardRoute
-  '/_authed/teamspaces': typeof AuthedTeamspacesRoute
+  '/_authed/teamspaces': typeof AuthedTeamspacesRouteWithChildren
   '/_authed/': typeof AuthedIndexRoute
   '/_authed/_admin/audit-log': typeof AuthedAdminAuditLogRoute
   '/_authed/_admin/dashboard': typeof AuthedAdminDashboardRoute
@@ -257,6 +265,7 @@ export interface FileRoutesById {
   '/_authed/agents/builder': typeof AuthedAgentsBuilderRoute
   '/_authed/components/$componentId': typeof AuthedComponentsComponentIdRoute
   '/_authed/insights/$reportId': typeof AuthedInsightsReportIdRoute
+  '/_authed/teamspaces/$handle': typeof AuthedTeamspacesHandleRoute
   '/_authed/agents/': typeof AuthedAgentsIndexRoute
   '/_authed/components/': typeof AuthedComponentsIndexRoute
   '/_authed/wiki/': typeof AuthedWikiIndexRoute
@@ -286,6 +295,7 @@ export interface FileRouteTypes {
     | '/agents/builder'
     | '/components/$componentId'
     | '/insights/$reportId'
+    | '/teamspaces/$handle'
     | '/agents/'
     | '/components/'
     | '/wiki/'
@@ -313,6 +323,7 @@ export interface FileRouteTypes {
     | '/agents/builder'
     | '/components/$componentId'
     | '/insights/$reportId'
+    | '/teamspaces/$handle'
     | '/agents'
     | '/components'
     | '/wiki'
@@ -343,6 +354,7 @@ export interface FileRouteTypes {
     | '/_authed/agents/builder'
     | '/_authed/components/$componentId'
     | '/_authed/insights/$reportId'
+    | '/_authed/teamspaces/$handle'
     | '/_authed/agents/'
     | '/_authed/components/'
     | '/_authed/wiki/'
@@ -443,6 +455,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/agents/'
       preLoaderRoute: typeof AuthedAgentsIndexRouteImport
       parentRoute: typeof AuthedRoute
+    }
+    '/_authed/teamspaces/$handle': {
+      id: '/_authed/teamspaces/$handle'
+      path: '/$handle'
+      fullPath: '/teamspaces/$handle'
+      preLoaderRoute: typeof AuthedTeamspacesHandleRouteImport
+      parentRoute: typeof AuthedTeamspacesRoute
     }
     '/_authed/insights/$reportId': {
       id: '/_authed/insights/$reportId'
@@ -601,6 +620,17 @@ const AuthedUserRouteWithChildren = AuthedUserRoute._addFileChildren(
   AuthedUserRouteChildren,
 )
 
+interface AuthedTeamspacesRouteChildren {
+  AuthedTeamspacesHandleRoute: typeof AuthedTeamspacesHandleRoute
+}
+
+const AuthedTeamspacesRouteChildren: AuthedTeamspacesRouteChildren = {
+  AuthedTeamspacesHandleRoute: AuthedTeamspacesHandleRoute,
+}
+
+const AuthedTeamspacesRouteWithChildren =
+  AuthedTeamspacesRoute._addFileChildren(AuthedTeamspacesRouteChildren)
+
 interface AuthedAgentsAgentIdRouteChildren {
   AuthedAgentsAgentIdInsightsReportIdRoute: typeof AuthedAgentsAgentIdInsightsReportIdRoute
 }
@@ -617,7 +647,7 @@ interface AuthedRouteChildren {
   AuthedAdminRoute: typeof AuthedAdminRouteWithChildren
   AuthedUserRoute: typeof AuthedUserRouteWithChildren
   AuthedLeaderboardRoute: typeof AuthedLeaderboardRoute
-  AuthedTeamspacesRoute: typeof AuthedTeamspacesRoute
+  AuthedTeamspacesRoute: typeof AuthedTeamspacesRouteWithChildren
   AuthedIndexRoute: typeof AuthedIndexRoute
   AuthedAgentsAgentIdRoute: typeof AuthedAgentsAgentIdRouteWithChildren
   AuthedAgentsBuilderRoute: typeof AuthedAgentsBuilderRoute
@@ -632,7 +662,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedAdminRoute: AuthedAdminRouteWithChildren,
   AuthedUserRoute: AuthedUserRouteWithChildren,
   AuthedLeaderboardRoute: AuthedLeaderboardRoute,
-  AuthedTeamspacesRoute: AuthedTeamspacesRoute,
+  AuthedTeamspacesRoute: AuthedTeamspacesRouteWithChildren,
   AuthedIndexRoute: AuthedIndexRoute,
   AuthedAgentsAgentIdRoute: AuthedAgentsAgentIdRouteWithChildren,
   AuthedAgentsBuilderRoute: AuthedAgentsBuilderRoute,

--- a/web/src/routes/_authed/agents/index.tsx
+++ b/web/src/routes/_authed/agents/index.tsx
@@ -8,6 +8,7 @@ const AgentsPage = lazy(() => import("@/pages/registry/agents/index"));
 export type AgentsSearch = {
   search?: string;
   namespace?: string;
+  team?: string;
   category?: string;
 };
 
@@ -16,6 +17,7 @@ export const Route = createFileRoute("/_authed/agents/")({
   validateSearch: (search: Record<string, unknown>): AgentsSearch => ({
     search: (search.search as string) || undefined,
     namespace: (search.namespace as string) || undefined,
+    team: (search.team as string) || undefined,
     category: (search.category as string) || undefined,
   }),
 });

--- a/web/src/routes/_authed/components/index.tsx
+++ b/web/src/routes/_authed/components/index.tsx
@@ -11,6 +11,7 @@ export type ComponentsSearch = {
   type?: RegistryType;
   search?: string;
   namespace?: string;
+  team?: string;
   category?: string;
   task_type?: string;
   event?: string;
@@ -34,6 +35,7 @@ export const Route = createFileRoute("/_authed/components/")({
       : undefined,
     search: (search.search as string) || undefined,
     namespace: (search.namespace as string) || undefined,
+    team: (search.team as string) || undefined,
     category: (search.category as string) || undefined,
     task_type: (search.task_type as string) || undefined,
     event: (search.event as string) || undefined,

--- a/web/src/routes/_authed/teamspaces.$handle.tsx
+++ b/web/src/routes/_authed/teamspaces.$handle.tsx
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import { createFileRoute } from "@tanstack/react-router";
+import { lazy } from "react";
+import type { RegistryType } from "@/lib/api";
+
+const TeamspaceDetailPage = lazy(() => import("@/pages/registry/teamspace-detail"));
+
+export type TeamspaceDetailSearch = {
+	tab?: string;
+	type?: RegistryType;
+};
+
+const COMPONENT_TYPES = new Set<RegistryType>(["mcps", "skills", "hooks", "prompts", "sandboxes"]);
+
+export const Route = createFileRoute("/_authed/teamspaces/$handle")({
+	component: TeamspaceDetailPage,
+	validateSearch: (search: Record<string, unknown>): TeamspaceDetailSearch => ({
+		tab: (search.tab as string) || undefined,
+		type: COMPONENT_TYPES.has(search.type as RegistryType) ? (search.type as RegistryType) : undefined,
+	}),
+});

--- a/web/src/routes/_authed/teamspaces.tsx
+++ b/web/src/routes/_authed/teamspaces.tsx
@@ -1,11 +1,27 @@
 // SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
 import { lazy } from "react";
 
 const TeamspacesPage = lazy(() => import("@/pages/registry/teamspaces"));
 
+/**
+ * `/teamspaces` is both the index and the parent of `/teamspaces/$handle`, the
+ * same shape `agents/$agentId.tsx` uses: render the list at the exact path and
+ * hand the child route the outlet otherwise.
+ */
+function TeamspacesRoute() {
+	const location = useLocation();
+	const currentPath = location.pathname.replace(/\/$/, "");
+
+	if (currentPath === "/teamspaces") {
+		return <TeamspacesPage />;
+	}
+
+	return <Outlet />;
+}
+
 export const Route = createFileRoute("/_authed/teamspaces")({
-	component: TeamspacesPage,
+	component: TeamspacesRoute,
 });


### PR DESCRIPTION
## Purpose / Description

Feature 3 of the registry publish loop: team publishing. Feature 2 gave teamspaces an identity and members; this makes them a publishing target. Authorized members can publish agents and all five component types into a team namespace, and can keep them visible only to that team. Agents gain a private concept for the first time.

## Fixes

* Part of the registry publish loop plan, following #1619. No issue tracker entry.

## Approach

- **Migration `018_team_publishing`** adds `is_private` to `agents` and `team_id` to `agents`, the five component listings, and `component_sources`. `team_id` is the sole ownership and privacy axis; organization scoping is not used for registry visibility. There is no backfill: the shared helpers already resolve a legacy private row with no teamspace as creator-only, so a bulk publish would disclose data for no benefit. The downgrade refuses to run while any listing still belongs to a teamspace, because dropping `team_id` loses the only record of team ownership.
- **Shared authorization helpers**, not per-route logic: `apply_visibility_filter` and `apply_registry_scope` for queries, `resolve_visible_listing` and `check_listing_visibility_async` for detail and install paths, `resolve_publish_target` for publish authorization. A hidden listing returns 404, never 403, so it is not distinguishable from one that does not exist.
- **Review scope.** Team owners and team reviewers clear review for team-visibility publishing only. Team roles are self-service, since a team owner can promote any member to owner, so publishing PUBLIC from a team namespace still enters the global review queue. Turning a team-private listing public is a publication, so it returns to that queue unless the actor is a global reviewer, admin, or super_admin. Without that second rule the first is bypassed in two steps.
- **Agent composition** is enforced at validate, draft save, create, version, publish, and install: a public agent cannot contain a private component, and a team-private agent cannot contain another team's private component.
- **CLI** gains `--team` and `--visibility` on publish, `--team` and `--namespace` on browse, and composition validation in `agent build`. Bundled skills updated to match.
- **Web** builder scopes component pickers to the agent's target, and team members see approved private team items in normal registry lists.

## How Has This Been Tested?

Automated:

- `tests/`: 4,980 passed, 20 skipped, zero failures.
- `observal_cli/tests/`: 78 passed. `observal-server/tests/`: 407 passed, with 19 pre-existing failures in `test_jwt.py` and `test_multi_tenancy.py` from an uninitialized KeyManager in this environment, unrelated to this branch. Note `make test` runs only `tests/`, so the other two directories need running directly, and `observal-server/tests/` needs `PYTHONPATH=packages/observal-shared`.
- Ruff check and format clean. Pre-commit passes on every changed file. Frontend lint, type checking, and production build pass.
- Migration verified on a clone of a populated database: upgrade, downgrade, and repeat upgrade reach head, all seven `team_id` columns appear and disappear together, and the downgrade guard fires while team-owned rows exist.

Manual, against a local stack with 22 users, 5 teamspaces (one user deliberately in two), 50 components across all five types, and 10 agents:

- 7,810 of 7,810 HTTP visibility checks pass across list, detail, install, resolve, versions, and search, for every principal including anonymous, non-member, member, team reviewer, team owner, global reviewer, and admin.
- 104 of 104 write-path and privilege-escalation checks pass, covering publish authorization, auto-approval by role, namespace forgery, the composition matrix at each write boundary, the visibility endpoint, secondary read paths, reconcile, and dashboards.
- 3,419 of 3,419 CLI checks pass across 2,231 invocations of the commands the bundled skills document.

To reproduce the stack: `make rebuild-fast`, then `uv tool install --editable . --force`.

## Learning (optional, can help others)

Adversarially probing the running stack found defects the unit suite did not, all fixed here:

- `POST /agents/preview-config` resolved component ids with no visibility filter and returned the rendered config, disclosing team-private MCP commands, hook handlers, prompt templates, and SKILL.md to any authenticated user. The code comment said the builder UI had already scoped the selection, which is client-side trust.
- `PATCH /registry/{type}/{id}/visibility` never changed status, so a team role could self-approve a team-private listing and flip it public, reaching the global catalog without review.
- `_require_agent_edit_access` in `insights.py` had been weakened to a condition that can never fire, exposing every public agent's insight reports.
- The five component listing models lacked `post_update=True` on `latest_version`, which `Agent` already had. Any unit of work touching a listing field and a version field raised `CircularDependencyError`, which made resubmitting a pending or rejected component name a 500.

Two stale-mock lessons: patching a route-local binding stops working the moment a route calls a shared helper instead, and an unset attribute on a `MagicMock` is truthy, so an unset `is_private` silently made every listing look private and kept assertions green for the wrong reason.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

This branch does change the web registry and agent builder, so the box stays unchecked. Screenshots will be added by the author rather than generated.

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): Claude Code
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publish agents and registry components to personal or team spaces with public or team-only visibility.
  * Filter listings by team and namespace, with visibility-aware results.
  * Manage visibility, team membership, publishing, and review workflows from the web interface.
  * Added dedicated teamspace pages with searchable content, member management, and review actions.
  * CLI commands support team and visibility options and display install commands after publishing.
* **Bug Fixes**
  * Restricted listings and components are no longer exposed to unauthorized users.
  * Improved handling of inaccessible components and ambiguous names.
  * Teamspaces with published content can no longer be deleted accidentally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->