### PR TITLE
ci: add OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+name: Scorecard analysis
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   <a href="https://github.com/orgs/Observal/packages?repo_name=Observal"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Haz3-jolt/b28aba6d0efebb0b430d43c8068feb91/raw/ghcr-pulls.json&style=flat-square" alt="GHCR pulls"></a>
   <a href="https://artifacthub.io/packages/search?repo=observal"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/observal" alt="Artifact Hub"></a>
   <a href="https://cla-assistant.io/Observal/Observal"><img src="https://cla-assistant.io/readme/badge/Observal/Observal" alt="CLA assistant" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/Observal/Observal"><img src="https://api.scorecard.dev/projects/github.com/Observal/Observal/badge" alt="OpenSSF Scorecard"></a>
 </p>
 
 > If you find Observal useful, please consider giving it a star. It helps others discover the project and keeps development going.


### PR DESCRIPTION
## Purpose / Description

Add OpenSSF Scorecard analysis and expose the published security score in the README.

## Fixes

No linked issue.

## Approach

- Run the official Scorecard action on pushes to `main` and weekly.
- Publish results to OpenSSF and upload SARIF results to GitHub code scanning.
- Add the OpenSSF Scorecard badge to the existing README badge group.
- Pin every action to a full commit SHA.

## How Has This Been Tested?

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 .github/workflows/scorecard.yml`
- Parsed `.github/workflows/scorecard.yml` with PyYAML.
- Confirmed every pinned action commit resolves through the GitHub API.
- Ran `git diff --cached --check` before committing.

The badge will populate after this workflow first succeeds on `main`.

## Learning (optional, can help others)

Based on the official OpenSSF Scorecard workflow and badge documentation:

- https://github.com/ossf/scorecard-action
- https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas (not applicable: no application code or complex logic changed)
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (not applicable: this changes a README badge, not the application UI)

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes (Pi coding agent)
- [x] Was the generated code manually reviewed and tested?
