### PR TITLE
ci: support linear releases and merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Observal CI — runs on every PR targeting main and on pushes to main.
+# Observal CI — runs on every PR and merge-queue candidate targeting main,
+# and on pushes to main.
 #
 # Recommended branch-protection rules (Settings → Branches → main):
 #   Required status checks:
@@ -29,6 +30,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 
@@ -41,6 +44,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       python: ${{ steps.filter.outputs.python }}
@@ -49,6 +53,7 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
     steps:
       - uses: actions/checkout@v6
+      # v4 compares merge-queue candidates using merge_group.base_sha/head_sha.
       - uses: dorny/paths-filter@v4
         id: filter
         with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,8 @@ name: Dependency Review
 on:
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -23,6 +25,8 @@ jobs:
         with:
           fail-on-severity: high
           deny-licenses: SSPL-1.0, BUSL-1.1, Elastic-2.0
-          comment-summary-in-pr: always
+          base-ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          comment-summary-in-pr: ${{ github.event_name == 'pull_request' && 'always' || 'never' }}
           license-check: true
           vulnerability-check: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,6 +5,8 @@ name: Secrets Scan
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 
@@ -26,9 +28,21 @@ jobs:
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
 
       - name: Run Gitleaks
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          QUEUE_BASE: ${{ github.event.merge_group.base_sha }}
+          QUEUE_HEAD: ${{ github.event.merge_group.head_sha }}
+          PUSH_BASE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            gitleaks detect --source . --log-opts="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" --verbose
-          else
-            gitleaks detect --source . --verbose
+          case "$EVENT_NAME" in
+            pull_request) BASE=$PR_BASE; HEAD=$PR_HEAD ;;
+            merge_group) BASE=$QUEUE_BASE; HEAD=$QUEUE_HEAD ;;
+            *) BASE=$PUSH_BASE; HEAD=$PUSH_HEAD ;;
+          esac
+          if [[ "$BASE" =~ ^0+$ ]]; then
+            BASE=$(git rev-parse "$HEAD^")
           fi
+          gitleaks detect --source . --log-opts="$BASE..$HEAD" --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@
 
 # Curated release pipeline for Observal.
 #
-# A release PR is based on a selected, contiguous main-branch cutoff. After that
-# PR is merge-committed, this workflow builds and publishes its second parent so
-# later commits already on main cannot leak into the release.
+# A release PR is based on a selected, contiguous main-branch cutoff. After the
+# PR is squash/rebase merged, this workflow builds and publishes its exact PR
+# head so later commits already on main cannot leak into the release.
 
 name: Release
 
@@ -27,6 +27,7 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  pull-requests: read
   id-token: write
   attestations: write
 
@@ -65,22 +66,24 @@ jobs:
       - name: Resolve release target
         id: target
         env:
+          GH_TOKEN: ${{ github.token }}
           MANUAL_TARGET: ${{ inputs.target }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
         run: |
           if [ -n "$MANUAL_TARGET" ]; then
+            git fetch --no-tags origin "$MANUAL_TARGET" || true
             TARGET=$(git rev-parse "$MANUAL_TARGET^{commit}")
           else
-            read -ra PARENTS <<< "$(git show -s --format=%P HEAD)"
-            if [ "${#PARENTS[@]}" -ne 2 ]; then
-              if git diff-tree --no-commit-id --name-only -r HEAD | grep -qx '.release.toml'; then
-                echo "::error::Release PRs must use a merge commit, not squash or rebase"
-                exit 1
-              fi
-              echo "is_release=false" >> "$GITHUB_OUTPUT"
-              exit 0
+            if [[ "$BEFORE" =~ ^0+$ ]]; then
+              BEFORE=$(git rev-parse "$AFTER^")
             fi
-            TARGET="${PARENTS[1]}"
-            if [[ "$(git show -s --format=%s "$TARGET")" != chore\(release\):\ v* ]]; then
+            TARGET=$(python3 tools/release.py \
+              --resolve-push \
+              --before "$BEFORE" \
+              --after "$AFTER" \
+              --repo "$GITHUB_REPOSITORY")
+            if [ -z "$TARGET" ]; then
               echo "is_release=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
@@ -122,9 +125,15 @@ jobs:
           parents = subprocess.check_output(["git", "show", "-s", "--format=%P", target], text=True).split()
           if parents != [cutoff]:
               raise SystemExit("release commit must have the selected cutoff as its only parent")
-          subprocess.run(["git", "merge-base", "--is-ancestor", previous_tag, cutoff], check=True)
+          previous_manifest = subprocess.run(
+              ["git", "show", f"{previous_tag}:.release.toml"], text=True, capture_output=True
+          )
+          if previous_manifest.returncode == 0:
+              previous_cutoff = tomllib.loads(previous_manifest.stdout)["cutoff"]
+          else:
+              previous_cutoff = previous_tag
+          subprocess.run(["git", "merge-base", "--is-ancestor", previous_cutoff, cutoff], check=True)
           subprocess.run(["git", "merge-base", "--is-ancestor", cutoff, "origin/main"], check=True)
-          subprocess.run(["git", "merge-base", "--is-ancestor", target, "origin/main"], check=True)
 
           allowed = {
               "pyproject.toml", "observal-server/pyproject.toml", "web/package.json",

--- a/docs/self-hosting/releasing.md
+++ b/docs/self-hosting/releasing.md
@@ -26,9 +26,9 @@ For a no-write rehearsal:
 make release-preview
 ```
 
-The tool fetches tags, finds every commit after the latest stable release, associates commits with GitHub pull requests, and presents the pull requests in chronological order.
+The tool fetches tags, reads the latest stable release's recorded cutoff (or uses the tag for older releases), associates every later `main` commit with GitHub pull requests, and presents the pull requests in chronological order. Prior release metadata commits are skipped.
 
-Select the last pull request that should ship. Every commit from the previous tag through that pull request is included. Later commits remain deferred to the next release. A pull request cannot be partially included, and commits cannot be removed from the middle of the range.
+Select the last pull request that should ship. Every non-release commit from the previous cutoff through that pull request is included. Later commits remain deferred to the next release. A pull request cannot be partially included, and commits cannot be removed from the middle of the range.
 
 Commits without an associated pull request appear as standalone choices.
 
@@ -71,13 +71,13 @@ The tool creates `release/vX.Y.Z` from the selected cutoff, not from the latest 
 - `.release.toml`
 - `.github/release-notes.md`
 
-The branch is pushed to the maintainer fork and a fully populated pull request is opened.
-
-Merge the release pull request with a merge commit. Squash and rebase merges are rejected because they would make the selected cutoff impossible to enforce.
+The branch is pushed to the maintainer fork and a fully populated pull request is opened. Because the branch starts at the selected cutoff, GitHub may show that it is behind `main`; do not update it. Merge it with squash, rebase, or the squash-configured merge queue.
 
 ## Pipeline
 
-After the merge, the workflow validates the release commit as the merge commit's second parent. Every build checks out that exact commit, so later code already on `main` cannot enter the release.
+After the merge, the workflow finds the release commit anywhere in the pushed `main` range, resolves its associated merged pull request, and fetches that pull request's exact head. Every build checks out that validated head, so later code already on `main` cannot enter the release even though `main` remains linear.
+
+Release tags can therefore point to a detached release head rather than an ancestor of `main`. The next release reads the prior manifest's recorded cutoff and discovers later changes from that point; tags created before release manifests existed fall back to their tagged commit.
 
 Before approval, the workflow builds:
 
@@ -104,7 +104,7 @@ The local tool and workflow reject releases when:
 
 - The working tree is dirty
 - Local `main` differs from `upstream/main`
-- The previous tag is missing or not an ancestor of the cutoff
+- The previous release's recorded cutoff (or a pre-manifest tag) is missing or not an ancestor of the selected cutoff
 - The cutoff is not an ancestor of `main`
 - A pull request is split across noncontiguous commits
 - The release commit contains application code
@@ -112,7 +112,7 @@ The local tool and workflow reject releases when:
 - Release notes omit the contributor section
 - The changelog already contains the target version
 - The tag points to another commit
-- The release pull request was squash or rebase merged
+- The automatic target is not the exact head of one associated merged release pull request
 
 If local preparation fails after creating its worktree, the worktree is preserved under `.worktrees/` for inspection and recovery.
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -6,6 +6,7 @@ import tomllib
 from types import ModuleType
 
 import pytest
+import tools.release as release
 from tools.release import (
     Change,
     Commit,
@@ -14,9 +15,14 @@ from tools.release import (
     all_contributors,
     bump_version,
     choose_release,
+    discover_changes,
+    latest_tag,
+    pr_body,
     prepend_changelog,
+    release_cutoff,
     render_changelog_section,
     render_release_notes,
+    resolve_release_push,
     set_version,
     validate_version_channel,
     write_manifest,
@@ -126,6 +132,106 @@ def test_set_version_rejects_missing_version(tmp_path):
 
     with pytest.raises(ReleaseError, match="top-level version"):
         set_version(path, "1.1.0")
+
+
+def test_latest_tag_chooses_highest_stable_even_when_detached(monkeypatch):
+    monkeypatch.setattr(release, "run", lambda *args, **kwargs: "v1.10.7\nv1.11.0-rc.1\nv1.10.9\n")
+
+    assert latest_tag() == "v1.10.9"
+
+
+def test_release_cutoff_uses_manifest_with_old_tag_fallback(monkeypatch):
+    cutoff = "b" * 40
+
+    def fake_run(*args, **kwargs):
+        if args[:3] == ("git", "show", "v1.10.8:.release.toml"):
+            return f'cutoff = "{cutoff}"\n'
+        if args[:3] == ("git", "show", "v1.10.7:.release.toml"):
+            raise ReleaseError("missing manifest")
+        if args[:3] == ("git", "cat-file", "-e"):
+            return ""
+        raise AssertionError(args)
+
+    monkeypatch.setattr(release, "run", fake_run)
+
+    assert release_cutoff("v1.10.8") == cutoff
+    assert release_cutoff("v1.10.7") == "v1.10.7"
+
+
+def test_release_discovery_skips_prior_release_metadata(monkeypatch):
+    release_commit = Commit("a" * 40, "Maintainer", "m@example.com", "chore(release): v1.10.8", "")
+    feature_commit = Commit("b" * 40, "Contributor", "c@example.com", "feat: next change", "")
+    monkeypatch.setattr(release, "commit_log", lambda revision_range: [release_commit, feature_commit])
+    monkeypatch.setattr(
+        release,
+        "gh_json",
+        lambda repo, endpoint: (
+            [{"number": 1, "merged_at": "2026-08-01", "base": {"ref": "main"}, "title": release_commit.title}]
+            if release_commit.sha in endpoint
+            else []
+        ),
+    )
+
+    changes = discover_changes("Observal/Observal", "c" * 40, "upstream/main")
+
+    assert [change.title for change in changes] == ["feat: next change"]
+
+
+def test_resolve_release_push_uses_exact_merged_pr_head(monkeypatch):
+    normal = Commit("a" * 40, "A", "a@example.com", "fix: normal", "")
+    merged = Commit("b" * 40, "B", "b@example.com", "chore(release): v1.10.8", "")
+    head = "c" * 40
+    monkeypatch.setattr(release, "commit_log", lambda revision_range: [normal, merged])
+
+    def fake_run(*args, **kwargs):
+        if args[:4] == ("git", "log", "--format=%H", "0" * 40 + ".." + "f" * 40):
+            return merged.sha
+        if args[:3] == ("git", "fetch", "--no-tags"):
+            return ""
+        if args[:3] == ("git", "rev-parse", "FETCH_HEAD^{commit}"):
+            return head
+        raise AssertionError(args)
+
+    def fake_gh_json(repo, endpoint):
+        if endpoint == f"commits/{merged.sha}/pulls":
+            return [
+                {
+                    "number": 42,
+                    "merged_at": "2026-08-02T00:00:00Z",
+                    "base": {"ref": "main"},
+                    "title": merged.title,
+                }
+            ]
+        if endpoint == "pulls/42":
+            return {
+                "merged_at": "2026-08-02T00:00:00Z",
+                "merge_commit_sha": merged.sha,
+                "title": merged.title,
+                "base": {"ref": "main"},
+                "head": {"sha": head},
+            }
+        raise AssertionError(endpoint)
+
+    monkeypatch.setattr(release, "run", fake_run)
+    monkeypatch.setattr(release, "gh_json", fake_gh_json)
+
+    assert resolve_release_push("0" * 40, "f" * 40, "Observal/Observal") == (head, 42)
+
+
+def test_resolve_release_push_rejects_manifest_without_release_commit(monkeypatch):
+    normal = Commit("a" * 40, "A", "a@example.com", "fix: normal", "")
+    monkeypatch.setattr(release, "commit_log", lambda revision_range: [normal])
+    monkeypatch.setattr(release, "run", lambda *args, **kwargs: normal.sha)
+
+    with pytest.raises(ReleaseError, match="ambiguous or malformed"):
+        resolve_release_push("0" * 40, "f" * 40, "Observal/Observal")
+
+
+def test_release_pr_instructions_allow_linear_merges():
+    body = pr_body("1.10.8", "v1.10.7", "a" * 40, [_change()], "preview")
+
+    assert "squash, rebase, or the merge queue" in body
+    assert "merge commit" not in body
 
 
 def test_write_manifest_supports_no_pull_requests(tmp_path):

--- a/tools/release.py
+++ b/tools/release.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import tomllib
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -39,6 +40,7 @@ RELEASE_FILES = (
     ".release.toml",
     ".github/release-notes.md",
 )
+RELEASE_TITLE = re.compile(r"chore\(release\): v\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?")
 
 
 class ReleaseError(RuntimeError):
@@ -180,10 +182,52 @@ def commit_log(revision_range: str) -> list[Commit]:
     return commits
 
 
-def discover_changes(repo: str, previous_tag: str, branch: str) -> list[Change]:
+def resolve_release_push(before: str, after: str, repo: str, remote: str = "origin") -> tuple[str, int] | None:
+    revision_range = f"{before}..{after}"
+    commits = commit_log(revision_range)
+    release_commits = [commit for commit in commits if RELEASE_TITLE.fullmatch(commit.title)]
+    manifest_commits = set(
+        filter(None, run("git", "log", "--format=%H", revision_range, "--", ".release.toml").splitlines())
+    )
+    if not release_commits and not manifest_commits:
+        return None
+    if len(release_commits) != 1 or manifest_commits != {release_commits[0].sha}:
+        raise ReleaseError("push contains an ambiguous or malformed release change")
+
+    merged = [
+        pull
+        for pull in gh_json(repo, f"commits/{release_commits[0].sha}/pulls")
+        if pull.get("merged_at")
+        and pull.get("base", {}).get("ref") == "main"
+        and RELEASE_TITLE.fullmatch(pull.get("title", ""))
+    ]
+    if len(merged) != 1:
+        raise ReleaseError("release commit must belong to exactly one merged release PR")
+
+    number = merged[0]["number"]
+    pull = gh_json(repo, f"pulls/{number}")
+    head = pull.get("head", {}).get("sha") if isinstance(pull, dict) else None
+    if (
+        not isinstance(head, str)
+        or not re.fullmatch(r"[0-9a-f]{40}", head)
+        or not pull.get("merged_at")
+        or pull.get("base", {}).get("ref") != "main"
+        or pull.get("merge_commit_sha") != release_commits[0].sha
+        or not RELEASE_TITLE.fullmatch(pull.get("title", ""))
+    ):
+        raise ReleaseError(f"merged release PR #{number} has invalid head metadata")
+
+    run("git", "fetch", "--no-tags", remote, f"refs/pull/{number}/head")
+    fetched = run("git", "rev-parse", "FETCH_HEAD^{commit}")
+    if fetched != head:
+        raise ReleaseError(f"release PR #{number} head changed while resolving it")
+    return head, number
+
+
+def discover_changes(repo: str, previous_ref: str, branch: str) -> list[Change]:
     changes: list[Change] = []
     seen_prs: set[int] = set()
-    for commit in commit_log(f"{previous_tag}..{branch}"):
+    for commit in commit_log(f"{previous_ref}..{branch}"):
         pulls = gh_json(repo, f"commits/{commit.sha}/pulls")
         matching = [pr for pr in pulls if pr.get("merged_at") and pr.get("base", {}).get("ref") == "main"]
         pr = max(matching, key=lambda item: item["merged_at"]) if matching else None
@@ -197,6 +241,8 @@ def discover_changes(repo: str, previous_tag: str, branch: str) -> list[Change]:
             seen_prs.add(pr_number)
         labels = [label["name"] for label in pr.get("labels", [])] if pr else []
         title = pr["title"] if pr else commit.title
+        if RELEASE_TITLE.fullmatch(title):
+            continue
         user = pr.get("user") if pr else None
         login = user.get("login") if user else None
         association = pr.get("author_association", "") if pr else ""
@@ -406,7 +452,7 @@ No linked issue. This is a release preparation change.
 ## Approach
 The release contains {len(changes)} PR or commit groups. This PR updates version metadata, lockfiles, the curated release notes, and prepends one new changelog section without rewriting existing changelog history.
 
-Merge this PR with a merge commit. Squash and rebase merges are rejected by the release workflow.
+Merge this PR with squash, rebase, or the merge queue. The release workflow publishes this PR's selected-cutoff head rather than the resulting `main` commit.
 
 ## How Has This Been Tested?
 
@@ -446,12 +492,26 @@ def ensure_preflight(upstream: str) -> None:
         raise ReleaseError(f"Local main must exactly match {upstream}/main")
 
 
-def latest_tag(branch: str) -> str:
-    tags = run("git", "tag", "--merged", branch, "--list", "v[0-9]*").splitlines()
+def latest_tag() -> str:
+    tags = run("git", "tag", "--list", "v[0-9]*").splitlines()
     stable = [tag for tag in tags if re.fullmatch(r"v\d+\.\d+\.\d+", tag)]
     if not stable:
-        raise ReleaseError(f"No stable release tag is reachable from {branch}")
+        raise ReleaseError("No stable release tag exists")
     return max(stable, key=lambda tag: parse_version(tag[1:]))
+
+
+def release_cutoff(tag: str) -> str:
+    try:
+        manifest = tomllib.loads(run("git", "show", f"{tag}:.release.toml"))
+    except ReleaseError:
+        return tag
+    except tomllib.TOMLDecodeError as exc:
+        raise ReleaseError(f"Invalid release manifest in {tag}: {exc}") from exc
+    cutoff = manifest.get("cutoff")
+    if not isinstance(cutoff, str) or not re.fullmatch(r"[0-9a-f]{40}", cutoff):
+        raise ReleaseError(f"Invalid release cutoff in {tag}")
+    run("git", "cat-file", "-e", f"{cutoff}^{{commit}}")
+    return cutoff
 
 
 def _ask(prompt):
@@ -541,8 +601,9 @@ def prepare(preview_only: bool, upstream: str = "upstream", fork: str = "origin"
     repo = f"{owner}/{name}"
     fork_owner, _ = repository(fork)
     branch = f"{upstream}/main"
-    previous_tag = latest_tag(branch)
-    changes = discover_changes(repo, previous_tag, branch)
+    previous_tag = latest_tag()
+    previous_cutoff = release_cutoff(previous_tag)
+    changes = discover_changes(repo, previous_cutoff, branch)
     if not changes:
         raise ReleaseError(f"No commits exist after {previous_tag}")
     included, version, channel = choose_release(
@@ -555,7 +616,9 @@ def prepare(preview_only: bool, upstream: str = "upstream", fork: str = "origin"
         )
         raise ReleaseError(f"Database migrations must be included in release notes: {names}")
     cutoff = included[-1].commits[-1]
-    commits = commit_log(f"{previous_tag}..{cutoff}")
+    commits = [
+        commit for commit in commit_log(f"{previous_cutoff}..{cutoff}") if not RELEASE_TITLE.fullmatch(commit.title)
+    ]
     contributors = all_contributors(included, commits)
     date = datetime.now(UTC).date().isoformat()
     changelog_section = render_changelog_section(version, date, included)
@@ -617,7 +680,7 @@ def prepare(preview_only: bool, upstream: str = "upstream", fork: str = "origin"
                 cwd=worktree,
             )
         print(f"\nRelease PR created: {url}")
-        print("Merge it with a merge commit. The workflow rejects squash and rebase merges.")
+        print("Merge with squash, rebase, or the merge queue; the selected cutoff remains the release target.")
     except Exception:
         print(f"Release worktree preserved for recovery: {worktree}", file=sys.stderr)
         raise
@@ -630,8 +693,19 @@ def main() -> None:
     parser.add_argument("--preview", action="store_true", help="render the release without creating a branch or PR")
     parser.add_argument("--upstream", default="upstream", help="remote for the canonical repository")
     parser.add_argument("--fork", default="origin", help="remote that receives the release branch")
+    parser.add_argument("--resolve-push", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--before", help=argparse.SUPPRESS)
+    parser.add_argument("--after", help=argparse.SUPPRESS)
+    parser.add_argument("--repo", help=argparse.SUPPRESS)
     args = parser.parse_args()
     try:
+        if args.resolve_push:
+            if not all((args.before, args.after, args.repo)):
+                raise ReleaseError("--resolve-push requires --before, --after, and --repo")
+            resolved = resolve_release_push(args.before, args.after, args.repo)
+            if resolved:
+                print(resolved[0])
+            return
         prepare(args.preview, args.upstream, args.fork)
     except (ReleaseError, KeyboardInterrupt) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)


### PR DESCRIPTION
## Purpose / Description

Make curated releases compatible with linear history, squash/rebase merges, and GitHub's merge queue while preserving the selected release cutoff.

## Fixes

No linked issue.

## Approach

- Detect release commits across the complete push range, resolve their merged PR, and build/tag the exact PR head instead of a merge commit parent.
- Keep detached release tags continuous through each prior manifest's recorded cutoff, with a fallback for pre-manifest tags.
- Stop rediscovering prior release metadata during local release preparation.
- Run CI, dependency review, and Gitleaks on `merge_group` candidates using the queue base/head range.
- Update release instructions and focused tests for squash, rebase, and merge-queue operation.

Build and publication jobs are unchanged.

## How Has This Been Tested?

- `uv run pytest tests/test_release.py tests/test_version_sync.py -q` (20 passed)
- `uv run ruff check tools/release.py tests/test_release.py`
- `uv run ruff format --check tools/release.py tests/test_release.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 .github/workflows/ci.yml .github/workflows/dependency-review.yml .github/workflows/gitleaks.yml .github/workflows/release.yml`
- Parsed all changed workflows with PyYAML.
- Confirmed an ordinary non-release push range resolves as a no-op.
- Confirmed `v1.10.7` uses the pre-manifest compatibility fallback and remains an ancestor of `main`.

## Learning (optional, can help others)

- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
- https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (not applicable: no UI changes)

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes (Pi coding agent)
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for merge-queue validation across continuous integration, dependency, and security checks.
  - Release workflows now support squash merges, rebases, merge queues, manual targets, and detached release tags.
  - Release discovery handles noncontiguous releases and uses recorded release metadata for accurate change selection.

- **Documentation**
  - Updated self-hosting release guidance with revised cutoff selection, merge requirements, and safety checks.

- **Bug Fixes**
  - Improved handling of initial pushes, malformed releases, and release validation across different merge strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->