### PR TITLE
ci: scope workflow token permissions to read-only defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 # ── Job 0: Path filtering ─────────────────────────────────────────────────────
 jobs:
   changes:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,9 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,12 +11,14 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   dependency-review:
     name: License & vulnerability gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ concurrency:
   group: deploy-ec2
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository == 'Observal/Observal'

--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -15,6 +15,9 @@ concurrency:
   group: e2e-frontend-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: e2e-frontend-flows

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -11,14 +11,16 @@ on:
     branches: [main]
 
 permissions:
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   # Applies 'new contributor' to PRs from authors with no prior merged PRs
   new-contributor:
     if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v9
         with:
@@ -64,6 +66,9 @@ jobs:
   auto-label:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v9
         with:
@@ -131,6 +136,9 @@ jobs:
   env-changed:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v9
         with:
@@ -237,6 +245,9 @@ jobs:
   # Applies or removes 'Has Conflicts' based on mergeable_state
   conflict-label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/github-script@v9
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  packages: write
-  pull-requests: read
-  id-token: write
-  attestations: write
+  contents: read
 
 env:
   REGISTRY: ghcr.io
@@ -254,6 +250,9 @@ jobs:
     name: Docker (${{ matrix.image }}-${{ matrix.arch }})
     needs: preflight
     if: needs.preflight.outputs.is_release == 'true'
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -311,6 +310,8 @@ jobs:
     needs: [preflight, docker-build, tag]
     if: needs.tag.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       matrix:
         image: [api, web]
@@ -444,6 +445,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
@@ -559,6 +561,10 @@ jobs:
     needs: [preflight, cli-binaries, docker-merge, server-package, pypi, npm, helm-chart, tag]
     if: needs.tag.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -15,13 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 jobs:
   sbom:
     name: Generate SBOM
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,12 +9,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/take-command.yml
+++ b/.github/workflows/take-command.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   take:
@@ -21,6 +21,8 @@ jobs:
       github.event.issue.pull_request == null &&
       contains(github.event.comment.body, '/take')
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check labels and assign
         uses: actions/github-script@v9
@@ -108,6 +110,8 @@ jobs:
       github.event.issue.pull_request == null &&
       contains(github.event.comment.body, '/drop')
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Unassign commenter
         uses: actions/github-script@v9
@@ -148,6 +152,8 @@ jobs:
   stale-assignments:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Unassign stale issues
         uses: actions/github-script@v9

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,6 +39,9 @@ concurrency:
   group: terraform-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # ── fmt + validate (aws, gcp) ──────────────────────────────────────────────
   fmt-validate:


### PR DESCRIPTION
## Purpose / Description

OpenSSF Scorecard flagged Token-Permissions at 0/10 because workflows either had no top-level permission declaration (defaulting to the repo's broad default token) or declared broad top-level write scopes, with several jobs holding `contents: write` / `packages: write` even when they only compile or test.

The correct model is a read-only top-level default in every workflow, with write scopes pushed down to the specific jobs that publish, label, comment, attest, or upload releases.

## Fixes

* Targets OpenSSF Scorecard Token-Permissions check (raise from 0 to 10)

## Approach

Every workflow now declares a read-only top-level `permissions` default. A job-level `permissions` block replaces the inherited set, so every required scope is listed explicitly for each write job.

**Workflows that lacked a top-level declaration** now set `contents: read` at the top:
- `ci.yml`, `codeql.yml`, `deploy.yml`, `e2e-frontend.yml`, `terraform.yml`

**Workflows that had top-level write scopes** are now read-only at the top with job-level writes only where required:
- `release.yml`: `release` job keeps `contents: write, id-token: write, attestations: write` (the only job needing release asset upload, identity token, and attestation write); `docker-build`, `docker-merge`, `helm-chart` keep `packages: write`; `pypi` keeps `id-token: write` (+ `contents: read`); `verify` keeps `contents: read, packages: read`. `preflight`, `cli-binaries`, `server-package`, `approve`, `tag`, `npm` stay read-only. `tag` needs no `GITHUB_TOKEN` write because the tag push is performed by the release GitHub App token (`permission-contents: write` on the app token, not the workflow token). `npm` publishes via `NPM_TOKEN`, not `GITHUB_TOKEN`.
- `sbom.yml`: only the `sbom` job keeps `contents: write, issues: write` (it creates labels/issues and uploads SBOM assets to a release); `license-check` stays read-only. Splitting generation from publishing was considered but not needed to reach the Scorecard target.
- `dependency-review.yml`: the review job gets `contents: read, pull-requests: write` (write only to post the PR summary).
- `pr-labels.yml`: each labeling job (`new-contributor`, `auto-label`, `env-changed`, `conflict-label`) gets `issues: write, pull-requests: write`. Minimizing permissions here is particularly important because this workflow runs on `pull_request_target`.
- `stale.yml`: the `stale` job gets `issues: write, pull-requests: write`.
- `take-command.yml`: `take`, `drop`, `stale-assignments` each get `issues: write`.

**Already correct, left untouched:**
- `badge-ghcr-pulls.yml` keeps `permissions: {}` (stronger than `read-all`, no token scopes granted at all).
- `scorecard.yml` keeps `read-all` at top with `security-events: write, id-token: write` on the analysis job.
- `update-homebrew-tap.yml` stays read-only; external repo updates use the release GitHub App token.
- `gitleaks.yml` stays `contents: read`.

## How Has This Been Tested?

- YAML validity: every workflow under `.github/workflows/` parses with `yaml.safe_load`. All valid.
- actionlint v1.7.12: ran across all workflows. The only findings are pre-existing `create-github-app-token@v3` `client-id` vs `app-id` input warnings in `release.yml` and `update-homebrew-tap.yml`, present before and after this change (identical count of 9 on both the stashed and unstashed tree). No permission-block errors and no new findings introduced by this PR.
- Verified the final permission topology programmatically: every workflow has a read-only top-level default and only the documented write jobs carry write scopes.
- Manual release preflight, SBOM generation, label/issue automation, and deployment secret access are exercised by the live CI run on this PR and depend on runtime secrets, not on local reproduction.

## Learning (optional, can help others)

A job-level `permissions` block **replaces** the inherited set, it does not augment it. So a job that needs `packages: write` and also checks out the repo must list both `contents: read` and `packages: write` explicitly, otherwise checkout silently loses read access.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - N/A, no UI changes (CI workflow YAML only).

## AI Assistance

- [x] Yes(Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened automation permissions by defaulting workflows to read-only repository access.
  * Limited write permissions to only the specific jobs that require them, including releases, labeling, issue management, deployments, and SBOM generation.
  * Improved protection against unintended changes made by automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->