### PR TITLE
ci: pin dependencies, attach signed release provenance, and docs fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
       helm: ${{ steps.filter.outputs.helm }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       # v4 compares merge-queue candidates using merge_group.base_sha/head_sha.
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |
@@ -103,10 +103,10 @@ jobs:
           echo "::notice::No Python changes detected, skipping lint"
           echo "This job reports success to satisfy branch protection"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         if: needs.changes.outputs.python == 'true'
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         if: needs.changes.outputs.python == 'true'
         with:
           enable-cache: true
@@ -128,10 +128,10 @@ jobs:
     name: reuse-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: REUSE compliance check
-        uses: fsfe/reuse-action@v6
+        uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6
 
 # ── Job 3: Python tests (matrix) ──────────────────────────────────────────────
   test:
@@ -150,10 +150,10 @@ jobs:
           echo "::notice::No Python changes detected, skipping test"
           echo "This job reports success to satisfy branch protection"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         if: needs.changes.outputs.python == 'true'
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         if: needs.changes.outputs.python == 'true'
         with:
           enable-cache: true
@@ -183,7 +183,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: needs.changes.outputs.python == 'true' && matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           files: observal-server/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -206,15 +206,15 @@ jobs:
           echo "::notice::No web changes detected, skipping web-lint"
           echo "This job reports success to satisfy branch protection"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         if: needs.changes.outputs.web == 'true'
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         if: needs.changes.outputs.web == 'true'
         with:
           standalone: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         if: needs.changes.outputs.web == 'true'
         with:
           node-version: 24
@@ -246,10 +246,10 @@ jobs:
           echo "::notice::No Helm changes detected, skipping helm-lint"
           echo "This job reports success to satisfy branch protection"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         if: needs.changes.outputs.helm == 'true'
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         if: needs.changes.outputs.helm == 'true'
 
       - name: Lint chart
@@ -304,7 +304,7 @@ jobs:
           echo "::notice::No Docker changes detected, skipping docker-build"
           echo "This job reports success to satisfy branch protection"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         if: needs.changes.outputs.docker == 'true'
 
       - name: Create stub .env
@@ -320,9 +320,9 @@ jobs:
     name: dependency-audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -333,7 +333,7 @@ jobs:
           uv run --with pip-audit pip-audit --desc --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-161 --ignore-vuln CVE-2026-47265
 
       - name: Audit Node dependencies
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
         with:
           scan-args: |-
             --lockfile=pnpm-lock.yaml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,14 +34,14 @@ jobs:
       matrix:
         language: [javascript-typescript, python]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,10 +20,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           deny-licenses: SSPL-1.0, BUSL-1.1, Elastic-2.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Deploy to EC2
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu

--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -25,9 +25,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -72,9 +72,9 @@ jobs:
           cd docker && docker compose logs --tail 50 observal-web observal-lb || true
           exit 1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-frontend-results
           path: web/test-results/

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,9 +23,18 @@ jobs:
           fetch-depth: 0
 
       - name: Install Gitleaks
+        env:
+          # Pinned to gitleaks v8.30.1 (tag commit 83d9cd684c87d95d656c1458ef04895a7f1cbd8e).
+          # SHA-256 of gitleaks_8.30.1_linux_x64.tar.gz from the official release.
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
         run: |
-          VERSION=$(curl -sI https://github.com/gitleaks/gitleaks/releases/latest | grep -i ^location | sed 's|.*/v||' | tr -d '\r')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
+          set -eu
+          cd "$(mktemp -d)"
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "$url" -o gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar xzf gitleaks.tar.gz -C /usr/local/bin gitleaks
 
       - name: Run Gitleaks
         env:

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -70,7 +70,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -140,7 +140,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -249,7 +249,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,13 @@ jobs:
     steps:
       - name: Generate release app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: read
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -211,12 +211,12 @@ jobs:
             artifact: observal-windows-arm64.exe
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.preflight.outputs.target }}
           persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
           cache: pip
@@ -240,7 +240,7 @@ jobs:
         if: matrix.os == 'windows'
         run: mv dist/observal.exe dist/${{ matrix.artifact }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.artifact }}
@@ -267,14 +267,14 @@ jobs:
             platform: linux/arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.preflight.outputs.target }}
           persist-credentials: false
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -282,7 +282,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: docker/Dockerfile.${{ matrix.image }}
@@ -298,7 +298,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-digest-${{ matrix.image }}-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -317,15 +317,15 @@ jobs:
         image: [api, web]
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: /tmp/digests
           pattern: docker-digest-${{ matrix.image }}-*
           merge-multiple: true
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -352,7 +352,7 @@ jobs:
     if: needs.preflight.outputs.is_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.preflight.outputs.target }}
           persist-credentials: false
@@ -381,7 +381,7 @@ jobs:
 
           tar -czf "observal-server-v${VERSION}.tar.gz" "$STAGING"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: observal-server-v${{ needs.preflight.outputs.version }}.tar.gz
           path: observal-server-v${{ needs.preflight.outputs.version }}.tar.gz
@@ -406,13 +406,13 @@ jobs:
     steps:
       - name: Generate release app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           ref: ${{ needs.preflight.outputs.target }}
@@ -448,12 +448,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.preflight.outputs.target }}
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -461,7 +461,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   # ── Job 5: npm publish (after approval) ────────────────────
   npm:
@@ -471,12 +471,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.preflight.outputs.target }}
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
@@ -508,15 +508,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           ref: ${{ needs.preflight.outputs.target }}
           persist-credentials: false
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
-      - uses: oras-project/setup-oras@v1
+      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
 
       - name: Lint and package chart
         env:
@@ -530,7 +530,7 @@ jobs:
             --version "$VERSION" \
             --app-version "$VERSION"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: observal-helm-chart-v${{ needs.preflight.outputs.version }}
           path: chart-dist/observal-${{ needs.preflight.outputs.version }}.tgz
@@ -566,14 +566,14 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           ref: ${{ needs.preflight.outputs.target }}
           persist-credentials: false
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
           pattern: observal-*
@@ -589,7 +589,7 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: "release/observal-*"
 
@@ -641,17 +641,17 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
         description: "Release preparation commit SHA to validate and resume"
         required: true
         type: string
+      prerelease:
+        description: "Force the GitHub Release to be marked as a pre-release (skips --latest)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release
@@ -598,10 +603,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
           CHANNEL: ${{ needs.preflight.outputs.channel }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
           VERSION="v$RELEASE_VERSION"
           FLAGS=(--title "Observal $VERSION" --notes-file .github/release-notes.md)
-          if [ "$CHANNEL" = "stable" ]; then
+          # Manual override: inputs.prerelease forces a pre-release even when
+          # the .release.toml channel is stable. Only set on push runs, the
+          # input is empty so channel drives the flag as before.
+          if [ "$PRERELEASE" = "true" ]; then
+            FLAGS+=(--prerelease)
+          elif [ "$CHANNEL" = "stable" ]; then
             FLAGS+=(--latest)
           else
             FLAGS+=(--prerelease)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -594,9 +594,40 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: "release/observal-*"
+
+      - name: Copy attestation bundle into release/
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          test -n "$BUNDLE_PATH" -a -s "$BUNDLE_PATH" || {
+            echo "::error::Attestation bundle is missing or empty"
+            exit 1
+          }
+          cp "$BUNDLE_PATH" release/build-provenance.intoto.jsonl
+          echo "Bundle copied ($(wc -c < release/build-provenance.intoto.jsonl) bytes)"
+
+      - name: Verify provenance before publishing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Verify every attested artifact against the bundle. gh attestation verify
+          # validates the Sigstore certificate chain, the signer workflow identity,
+          # and the source repository/commit recorded in the provenance.
+          fail=0
+          for f in release/observal-*; do
+            echo "Verifying $f"
+            gh attestation verify "$f" \
+              --repo "$GITHUB_REPOSITORY" \
+              --bundle release/build-provenance.intoto.jsonl \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml@${{ needs.preflight.outputs.target }}" \
+              || { echo "::error::Provenance verification failed for $f"; fail=1; }
+          done
+          [ "$fail" -eq 0 ] || exit 1
+          echo "All artifacts verified against the attestation bundle."
 
       - name: Create or resume GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,16 +219,16 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.14"
-          cache: pip
 
-      - name: Install dependencies
-        run: |
-          pip install pyinstaller
-          pip install -e .
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Install project and release deps from frozen lockfile
+        run: uv sync --frozen --group release
 
       - name: Build binary
-        run: |
-          pyinstaller observal_cli/pyinstaller.spec --noconfirm
+        run: uv run --frozen --group release pyinstaller observal_cli/pyinstaller.spec --noconfirm
         env:
           TARGET_ARCH: ${{ matrix.arch }}
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -25,10 +25,10 @@ jobs:
       contents: write
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # ── Python SBOM (observal-server) ────────────────────────
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -46,9 +46,9 @@ jobs:
             --output-reproducible
 
       # ── Node.js SBOM (web) ───────────────────────────────────
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
           cache: pnpm
@@ -95,7 +95,7 @@ jobs:
         run: uv run --no-project scripts/generate_third_party_notices.py THIRD_PARTY_NOTICES.md
 
       # ── Upload SBOM artifacts ────────────────────────────────
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom
           path: |
@@ -121,9 +121,9 @@ jobs:
     name: License compliance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not

--- a/.github/workflows/take-command.yml
+++ b/.github/workflows/take-command.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
     steps:
       - name: Check labels and assign
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const issue = context.payload.issue;
@@ -114,7 +114,7 @@ jobs:
       issues: write
     steps:
       - name: Unassign commenter
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const issue = context.payload.issue;
@@ -156,7 +156,7 @@ jobs:
       issues: write
     steps:
       - name: Unassign stale issues
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const STALE_DAYS = 30;

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -63,10 +63,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.9.8
           terraform_wrapper: false
@@ -133,10 +133,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup tflint
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6
         with:
           tflint_version: v0.55.0
 
@@ -159,10 +159,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.9.8
           terraform_wrapper: false
@@ -186,10 +186,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.14'
 

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Generate tap app token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -82,7 +82,7 @@ jobs:
           repositories: homebrew-observal
 
       - name: Checkout homebrew-observal
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: Observal/homebrew-observal
           token: ${{ steps.app-token.outputs.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,11 @@
 
 Thank you for considering contributing to Observal. Contributions of all kinds are welcome: bug reports, bug fixes, new features, documentation improvements, and tests.
 
-> \[!TIP] This page is a quick-start summary. For the full setup walkthrough, architecture notes, and detailed workflows, see the [Development Guide](docs/DEVELOPMENT_GUIDE.md). For new Python tests, follow the [Testing Guide](docs/testing/Testing_Guide.md).
+> [!TIP]
+> This page is a quick-start summary. For the full setup walkthrough, architecture notes, and detailed workflows, see the [Development Guide](docs/DEVELOPMENT_GUIDE.md). For new Python tests, follow the [Testing Guide](docs/testing/Testing_Guide.md).
 
-> \[!IMPORTANT] **Discord is our primary communication channel.** Join at [discord.observal.io](https://discord.observal.io) and ask questions in **#contributing**, report bugs in **#bug**, or discuss ideas in **#feature-requests**. GitHub issues and PRs are for concrete, actionable items, not exploratory discussion.
+> [!IMPORTANT]
+> **Discord is our primary communication channel.** Join at [discord.observal.io](https://discord.observal.io) and ask questions in **#contributing**, report bugs in **#bug**, or discuss ideas in **#feature-requests**. GitHub issues and PRs are for concrete, actionable items, not exploratory discussion.
 
 Please read our [Code of Conduct](https://github.com/Observal/Observal/blob/main/CODE_OF_CONDUCT.md) and [AI Policy](AI_POLICY.md) before contributing.
 
@@ -84,7 +86,8 @@ cd web && pnpm install && pnpm dev
 
 Set `NEXT_PUBLIC_API_URL=http://localhost` in `web/.env.local` if the backend is on a different host.
 
-> \[!NOTE] See the [Development Guide](docs/DEVELOPMENT_GUIDE.md) for the full environment setup and troubleshooting steps.
+> [!NOTE]
+> See the [Development Guide](docs/DEVELOPMENT_GUIDE.md) for the full environment setup and troubleshooting steps.
 
 ***
 
@@ -101,7 +104,8 @@ For larger changes, open an issue or discuss in **#contributing** on Discord bef
 * Max **2 open assigned issues** at a time.
 * Issues with no activity for **30 days** are automatically unassigned.
 
-> \[!WARNING] Issues labeled `keep open` cannot be claimed. Anyone may submit a PR for those without assignment.
+> [!WARNING]
+> Issues labeled `keep open` cannot be claimed. Anyone may submit a PR for those without assignment.
 
 ***
 
@@ -169,7 +173,8 @@ Add an entry under `[Unreleased]` in [CHANGELOG.md](https://github.com/Observal/
 
 ## Submitting a Pull Request
 
-> \[!IMPORTANT] Read the [AI Policy](AI_POLICY.md) before submitting. AI-assisted contributions are welcome but must meet the standards described there. **Autonomous coding agents (Devin, SWE-agent, OpenHands, and similar tools that write and submit code without meaningful human authorship) are not permitted**, see the AI Policy for the legal and practical reasons. PRs that show obvious signs of unreviewed AI output will be closed without review.
+> [!IMPORTANT]
+> Read the [AI Policy](AI_POLICY.md) before submitting. AI-assisted contributions are welcome but must meet the standards described there. **Autonomous coding agents (Devin, SWE-agent, OpenHands, and similar tools that write and submit code without meaningful human authorship) are not permitted**, see the AI Policy for the legal and practical reasons. PRs that show obvious signs of unreviewed AI output will be closed without review.
 
 1.  Rebase against `main` before opening:
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Logs are written to `~/.observal/logs/dev.log` and include structured context fo
 
 ## Security
 
-Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://github.com/Observal/Observal/security/advisories) or email harisrini21@gmail.com. Do not open a public issue. See [SECURITY.md](SECURITY.md).
+Report vulnerabilities via [GitHub Private Vulnerability Reporting](https://github.com/Observal/Observal/security/advisories) or email contact@observal.io. Do not open a public issue. See [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@
 If you discover a security vulnerability in Observal, please report it responsibly through one of these channels:
 
 1. **GitHub Private Vulnerability Reporting** (preferred): Go to the [Security Advisories](https://github.com/Observal/Observal/security/advisories) page and click "Report a vulnerability".
-2. **Email**: Send details to **harisrini21@gmail.com**.
+2. **Email**: Send details to **contact@observal.io**.
 
 ### What to Include
 

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -6,9 +6,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build stage
-FROM python:3.14-slim AS builder
+# python:3.14-slim (multi-arch: linux/amd64, linux/arm64)
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.25 /uv /uvx /bin/
+# uv 0.11.25 (multi-arch: linux/amd64, linux/arm64)
+COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9 /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -21,7 +23,8 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 
 # Runtime stage
-FROM python:3.14-slim
+# python:3.14-slim (multi-arch: linux/amd64, linux/arm64)
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 RUN groupadd --system --gid 1001 appgroup && \
     useradd --system --uid 1001 --gid appgroup appuser && \

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -4,7 +4,9 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:24-alpine AS base
+# ── Build stage: install pnpm, deps, and build the Next.js app ──────────────
+# node:24-alpine (multi-arch: linux/amd64, linux/arm64, linux/s390x)
+FROM node:24-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS builder
 ARG TARGETARCH
 ARG PNPM_VERSION=10.34.4
 ARG PNPM_SHA256_AMD64=15092b4d71f1192f67501116dd87dd20be8c4238434371959820255a374219c1
@@ -19,23 +21,20 @@ RUN apk add --no-cache wget && \
     echo "${PNPM_SHA256}  /usr/local/bin/pnpm" | sha256sum -c - && \
     chmod +x /usr/local/bin/pnpm
 
-FROM base AS deps
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY web/package.json ./web/
 RUN mkdir -p tests/e2e && echo '{"name":"@observal/e2e","version":"0.0.0","private":true,"devDependencies":{"@playwright/test":"^1.59.1"}}' > tests/e2e/package.json
 RUN pnpm install --frozen-lockfile
 
-FROM base AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/web/node_modules ./web/node_modules
 COPY web/ ./web/
 COPY docs/ ./docs/
 WORKDIR /app/web
 RUN pnpm run build
 
-FROM nginx:alpine AS runner
+# ── Runtime stage: nginx serves the static SPA build ────────────────────────
+# nginx:alpine (multi-arch: linux/amd64, linux/arm64, others)
+FROM nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752 AS runner
 # NGINX_CONF selects the nginx config to bake in.
 # - docker/nginx-spa.conf     (default) — includes proxy_pass for Docker Compose
 # - docker/nginx-spa-ecs.conf            — SPA-only, no upstream (for ECS/Fargate)

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -3,7 +3,8 @@
 
 # Development Guide
 
-> \[!IMPORTANT] **Discord is the primary place to ask questions.** Join at [discord.observal.io](https://discord.observal.io).
+> [!IMPORTANT]
+> **Discord is the primary place to ask questions.** Join at [discord.observal.io](https://discord.observal.io).
 >
 > * **#contributing**, setup help, workflow questions, anything about the contribution process
 > * **#bug**, discuss bugs before filing a GitHub issue
@@ -65,7 +66,8 @@
 
 We are a small, active community and we take the quality of interactions seriously.
 
-> \[!WARNING] The following will result in a **moderator warning**. A second violation results in a **temporary or permanent ban** from the repository and Discord:
+> [!WARNING]
+> The following will result in a **moderator warning**. A second violation results in a **temporary or permanent ban** from the repository and Discord:
 >
 > * Pinging contributors, maintainers, or reviewers unnecessarily (outside of a direct reply on your own open PR or issue)
 > * Submitting low-effort or unreviewed PRs (slop), including unreviewed AI output or autonomous agent submissions
@@ -451,7 +453,8 @@ Edit the generated file in `observal-server/alembic/versions/`. Then verify the 
 python3 scripts/check_migrations.py
 ```
 
-> \[!CAUTION] Never edit an existing migration file. Always create a new one. A broken migration chain blocks CI and prevents the server from starting.
+> [!CAUTION]
+> Never edit an existing migration file. Always create a new one. A broken migration chain blocks CI and prevents the server from starting.
 
 Apply migrations to your local stack:
 
@@ -555,7 +558,8 @@ When adding new UI, use the semantic tokens, never hardcode colors. Check all fi
 
 ### Screenshots for UI changes
 
-> \[!IMPORTANT] Any PR that touches the web frontend must include **screenshots of all affected screens** in the PR description. This is required regardless of how small the change is. Attach screenshots directly to the PR body, not as review comments.
+> [!IMPORTANT]
+> Any PR that touches the web frontend must include **screenshots of all affected screens** in the PR description. This is required regardless of how small the change is. Attach screenshots directly to the PR body, not as review comments.
 
 ***
 
@@ -673,4 +677,5 @@ If you are stuck, the best place to ask is **#contributing** on [Discord](https:
 
 For bugs use **#bug**. For feature ideas use **#feature-requests**.
 
-> \[!NOTE] Do not open a GitHub issue just to ask a question. Issues are for confirmed bugs and accepted feature requests. Questions belong on Discord.
+> [!NOTE]
+> Do not open a GitHub issue just to ask a question. Issues are for confirmed bugs and accepted feature requests. Questions belong on Discord.

--- a/infra/terraform/aws/deploy.sh
+++ b/infra/terraform/aws/deploy.sh
@@ -168,8 +168,16 @@ for img in observal-api observal-web; do
   if check_ghcr_image "$img" "$TAG"; then
     pass "ghcr.io/observal/$img:$TAG exists"
   else
-    # Try with token auth
-    TOKEN=$(curl -s "https://ghcr.io/token?scope=repository:observal/$img:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
+    # Try with token auth. Python performs the HTTP fetch + JSON parse directly
+    # so no remote content is piped into an interpreter (Scorecard supply-chain check).
+    TOKEN=$(GHCR_IMG="$img" python3 -c 'import json,os,urllib.request
+try:
+    url = "https://ghcr.io/token?scope=repository:observal/" + os.environ["GHCR_IMG"] + ":pull"
+    with urllib.request.urlopen(url, timeout=10) as r:
+        print(json.load(r).get("token", ""))
+except Exception:
+    pass
+' 2>/dev/null || echo "")
     if [ -n "$TOKEN" ]; then
       status=$(curl -s -o /dev/null -w "%{http_code}" \
         -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \

--- a/infra/terraform/deploy.sh
+++ b/infra/terraform/deploy.sh
@@ -230,7 +230,15 @@ validate_standard() {
   # Check GHCR image accessibility (requires token even for public images)
   local tag="${image_tag:-latest}"
   local token status
-  token=$(curl -s "https://ghcr.io/token?scope=repository:observal/observal-api:pull" 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))' 2>/dev/null || echo "")
+  # Python performs the HTTP fetch + JSON parse directly so no remote content
+  # is piped into an interpreter (Scorecard supply-chain check).
+  token=$(python3 -c 'import json,urllib.request
+try:
+    with urllib.request.urlopen("https://ghcr.io/token?scope=repository:observal/observal-api:pull", timeout=10) as r:
+        print(json.load(r).get("token",""))
+except Exception:
+    pass
+' 2>/dev/null || echo "")
   if [ -n "$token" ]; then
     status=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://ghcr.io/v2/observal/observal-api/manifests/$tag" 2>/dev/null || echo "000")
   else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,8 @@ dev = [
     "hypothesis>=6.0",
     "pyarrow>=15.0.0",
 ]
+# Exact pins for reproducible CLI binary builds (release pipeline).
+# `uv sync --frozen --group release` in the cli-binaries job installs these.
+release = [
+    "pyinstaller==6.21.0",
+]

--- a/renovate.json
+++ b/renovate.json
@@ -28,12 +28,12 @@
       "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "pre-commit hooks (minor/patch)"
-    },
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
     }
-  ]
+  ],
+  "dockerfile": {
+    "pinDigests": true
+  },
+  "docker-compose": {
+    "pinDigests": true
+  }
 }

--- a/scripts/test_version_e2e.sh
+++ b/scripts/test_version_e2e.sh
@@ -90,7 +90,12 @@ section "4. SERVER VERSION ENDPOINT"
 # ═══════════════════════════════════════════════════════════
 
 echo "GET /api/v1/config/version:"
-curl -s $API/api/v1/config/version | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin),indent=2))"
+# Python performs the HTTP fetch + JSON parse directly so no remote content is
+# piped into an interpreter (Scorecard supply-chain check).
+API="$API" python3 -c 'import json,os,urllib.request
+with urllib.request.urlopen(os.environ["API"] + "/api/v1/config/version", timeout=10) as r:
+    print(json.dumps(json.load(r), indent=2))
+'
 pass "Version endpoint returns extended fields"
 
 # ═══════════════════════════════════════════════════════════

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -472,6 +481,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -527,6 +548,9 @@ dev = [
     { name = "ruff" },
     { name = "sqlalchemy" },
 ]
+release = [
+    { name = "pyinstaller" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -557,6 +581,7 @@ dev = [
     { name = "ruff", specifier = "==0.15.15" },
     { name = "sqlalchemy", specifier = ">=2.0.49" },
 ]
+release = [{ name = "pyinstaller", specifier = "==6.21.0" }]
 
 [[package]]
 name = "packaging"
@@ -565,6 +590,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
 ]
 
 [[package]]
@@ -774,6 +808,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz", hash = "sha256:bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd", size = 4061519, upload-time = "2026-06-13T14:15:06.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4a/53cf98bf66daed012dc9cd78c8203f19a675d696f2fc12afcf8c5049a0e0/pyinstaller-6.21.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:327d132389f37912609e01be62810cf96b5aa95b613903e4b8692e0d12fb0eda", size = 1052350, upload-time = "2026-06-13T14:13:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/b591295c352ef464c50b4c6ffff1c4f771d875c9e833f578d1b9f564f6b3/pyinstaller-6.21.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7071d4b094d5b40deeef5fa3d3b98a1b846087f7562b49209663d5f9281fe251", size = 748477, upload-time = "2026-06-13T14:14:00.327Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8f/88fff4e403873b1e22286911350e75ff00db014aa08e57045da9d4328993/pyinstaller-6.21.0-py3-none-manylinux2014_i686.whl", hash = "sha256:6b6374d652107dd4a2eeece903ff82bb4045bb5e1006c5a158a6dcdbefe84bf2", size = 760877, upload-time = "2026-06-13T14:14:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/f0e48fbdfd1d05d948157121cea8b1b823dcb89efe6934b71fdd8bdb3f0f/pyinstaller-6.21.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4e3108b3f02384560da70e39b8bf22b0ad597d02bd68a40d76ea91c1cfa00cad", size = 759194, upload-time = "2026-06-13T14:14:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/ea7878cf9924ed30d946d8288777424e6d069d94f5bde56b4d0890069664/pyinstaller-6.21.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:697532279f535ad572bda613db4f821540e235c7854ca6da4d3bf0373f4415ee", size = 754979, upload-time = "2026-06-13T14:14:15.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/51b8905714b733bac66dbc041a7821372d70d888d273ae474c4037d4202d/pyinstaller-6.21.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:605169523a6b5ace39f13dfbff21add9f2bc43df99c7daf9394fefb2c45e8b6f", size = 754812, upload-time = "2026-06-13T14:14:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/d77779439d8c6c2e27a77bcfbd1d5cc0f568ebb611bb472b11af81b5f177/pyinstaller-6.21.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5fa56746c1e76f93634d018502301378a2d0c382553d37d8c3c34ff436c12dd1", size = 753887, upload-time = "2026-06-13T14:14:25.268Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/c22df1f6837784ac349057ba693f08e7b1ca7a0e06f9c33c63bc6280007b/pyinstaller-6.21.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:42395ec76df8e8120c36b13339d9db8cab83e316a12839ee303cc00fc941bb74", size = 753779, upload-time = "2026-06-13T14:14:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/76/1ce8a27ce62ba8cf3a87c9ce6d575610f4e55d7cb0123e7512fc3f4b921a/pyinstaller-6.21.0-py3-none-win32.whl", hash = "sha256:c6b28d30d8fd99ce162ff3aab5013ed44dbfb747566b1f01b9bed7964d7c14e9", size = 1336462, upload-time = "2026-06-13T14:14:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/ca1d7e5257dd8566a9dfc0dfb02f8a8075eeb53d4b2d3c579f1276759042/pyinstaller-6.21.0-py3-none-win_amd64.whl", hash = "sha256:7fae06c494ce0ebfe6bd3055c0e409def884f63af2e3705d06bd431ad9237fc7", size = 1397487, upload-time = "2026-06-13T14:14:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/75/21b51523ce8d96629b71311775a0a65f5f5a872124ab0de33e5c848f8bff/pyinstaller-6.21.0-py3-none-win_arm64.whl", hash = "sha256:f13c95c9c03fb567217135919f93815c305813126780b0ed6e0123cb8acaf025", size = 1346094, upload-time = "2026-06-13T14:14:48.914Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -842,6 +916,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -962,6 +1045,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
     { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
     { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose / Description

OpenSSF Scorecard Pinned-Dependencies (0 -> 10) and Signed Releases (0 -> 10), plus three small follow-on changes that came up during the work: a release pre-release override flag, GitHub alert syntax fixes in the contributor docs, and moving the security vulnerability contact to the project address.

## Fixes

* Targets OpenSSF Scorecard Pinned-Dependencies check (raise from 0 to 10)
* Targets OpenSSF Scorecard Signed-Releases check (raise from 0 to 10)

## Approach

Nine atomic commits, grouped by concern.

**Pinned Dependencies:**
1. `ci: pin GitHub Actions to commit SHAs with version comments` - every mutable action reference across the workflows is now pinned to a full 40-character commit SHA resolved from the action repo's own release tag, with the human-readable release kept as a trailing comment. `scorecard.yml` was already SHA-pinned and is left untouched. 94 total `uses:` references, all pinned by SHA. Tags are mutable; a SHA fixes the exact action code executed with repository tokens and secrets.
2. `build: pin Docker base images to multi-arch manifest digests` - pin `python:3.14-slim`, `node:24-alpine`, `nginx:alpine`, and `ghcr.io/astral-sh/uv` to their multi-architecture manifest digests (amd64 + arm64) so both release runners build from identical, immutable bases. Simplified `Dockerfile.web` from four alias-only base stages to one pinned Node build stage and one pinned nginx runtime stage, removing the `FROM base` aliases that Scorecard misclassified as unpinned images.
3. `fix: fetch JSON via Python in deploy scripts to clear shell findings` - the three Scorecard shell findings (`infra/terraform/aws/deploy.sh`, `infra/terraform/deploy.sh`, `scripts/test_version_e2e.sh`) were `curl | python3` for JSON parsing. None downloaded executable code, but Scorecard read the pipe as download then execute. Python now performs the HTTP fetch and JSON parse directly via `urllib.request`, with variables passed through the environment. No fake checksums are added; checksums are for fixed executable releases, not live JSON metadata.
4. `ci: pin gitleaks release with SHA-256 checksum verification` - replaced the latest-tag download that piped a tarball straight into `tar` extraction with a fixed gitleaks v8.30.1 release URL and a committed SHA-256 checksum verified before extraction. Closes the real supply-chain risk Scorecard did not flag but that mirrors the shell findings.
5. `build: build CLI release binaries from frozen uv lockfile` - added a `release` dependency group pinning `pyinstaller==6.21.0` exactly and regenerated `uv.lock` so the full transitive set (altgraph, macholib, pefile, pyinstaller-hooks-contrib, pywin32-ctypes, setuptools) is locked. The `cli-binaries` job now syncs the frozen lockfile with `--group release` and invokes PyInstaller through `uv run` instead of a mutable `pip install`, giving exact versions and consistent Windows, Linux, and macOS builds.
6. `ci: pin Docker digests and disable Renovate automerge` - enabled `pinDigestes` for the `dockerfile` and `docker-compose` Renovate managers so Renovate pins and opens digest-update PRs for Docker images, and relies on the `github-actions` manager to update SHA-pinned actions and their version comments. Removed the automerge packageRule so every Renovate PR receives human review, prioritizing the Code Review goal over fast auto-merges.

**Signed Releases:**
7. `ci(release): attach and verify in-toto provenance bundle on releases` - the release job already ran `actions/attest-build-provenance` but never attached the generated bundle to the GitHub Release, so Scorecard reported no signed/provenanced recent release artifacts. Now: the provenance step has an id, the bundle output is copied into `release/` as `build-provenance.intoto.jsonl`, every attested artifact is verified against the bundle with `gh attestation verify` (Sigstore chain, signer workflow identity, source repo/commit) before publication, and the bundle is uploaded alongside the other release assets. The asset-count check already counts every file in `release/` so the bundle is included. The release job retains job-level `contents: write`, `id-token: write`, and `attestations: write`. Future releases carry valid provenance; Scorecard gives full credit once the latest five artifact-bearing releases are compliant.

**Follow-on changes (came up during the work):**
8. `feat(release): add workflow_dispatch prerelease override flag` - new boolean `prerelease` input on `workflow_dispatch`. When true, the GitHub Release is forced to `--prerelease` and `--latest` is skipped, regardless of the `.release.toml` channel. Push-triggered runs are unaffected (`inputs.prerelease` is empty, channel drives the flag as before).
9. `docs: fix GitHub alert syntax in contributing and development guides` - the alert blocks in `CONTRIBUTING.md` and `docs/DEVELOPMENT_GUIDE.md` used escaped brackets (`> \[!TIP] ...`) with content on the same line, which GitHub does not render as alerts. Converted each to the proper multi-line form (`> [!TYPE]` on its own line, content on following `>` lines). `AI_POLICY.md` already used the correct form and is unchanged.
10. `docs: use contact@observal.io as the security vulnerability contact` - replaced the personal email in `SECURITY.md` and the `README.md` security summary with `contact@observal.io`.

## How Has This Been Tested?

**Pinned Dependencies:**
- All 94 `uses:` references verified pinned to 40-char SHAs; zero mutable refs remain (programmatically checked).
- Every workflow parses with `yaml.safe_load`; all valid.
- actionlint v1.7.12: 0 findings after the change (the only pre-existing findings were `create-github-app-token@v3` `client-id` vs `app-id` input warnings, unrelated to this work and present before).
- Both Docker images build for `linux/amd64` via `docker buildx build`; all four base-image digests confirmed multi-arch (amd64 + arm64) via `docker buildx imagetools inspect`. arm64 builds on the native release runners.
- The three shell scripts pass `bash -n` syntax checks; the embedded Python (with env-passed variables) was executed locally and successfully fetched a GHCR token.
- The gitleaks install step (download + `sha256sum -c` + extract + `gitleaks version`) was run locally and produced `gitleaks.tar.gz: OK` then `8.30.1`.
- `uv sync --frozen --group release` and `uv run --frozen --group release pyinstaller --version` resolve cleanly and report `6.21.0`.
- `renovate.json` is valid JSON.

**Signed Releases:**
- `release.yml` parses with `yaml.safe_load`; actionlint clean.
- The attestation wiring (provenance id, bundle copy with non-empty check, `gh attestation verify` loop, asset-count inclusion) is in place. `gh attestation` is not available on the local old `gh`, but runs on the CI runner which has a current `gh`.

**Runtime, exercised by the live CI run on this PR (depend on runtime secrets, not reproducible locally):** CI + CodeQL green, and the next real release confirms the attestation bundle attaches and `gh attestation verify` passes. Multi-architecture Docker builds for arm64 are verified on the release runners.

## Learning (optional, can help others)

- A job-level `permissions` block replaces the inherited set, it does not augment it. A job that needs `packages: write` and also checks out the repo must list both `contents: read` and `packages: write` explicitly.
- GitHub alerts require `> [!TYPE]` on its own line with content on following `>` lines. Escaped brackets (`> \[!TIP]`) or content on the same line render as literal text.
- `actions/attest-build-provenance` writes the bundle to the path in its `bundle-path` output; that file must be copied into the release assets explicitly, it is not attached automatically.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - N/A, no UI changes (CI workflows, Dockerfiles, shell scripts, lockfile, docs).

## AI Assistance

- [x] Yes(Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?
