### PR TITLE
revert: drop redundant workflow_dispatch prerelease override flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,6 @@ on:
         description: "Release preparation commit SHA to validate and resume"
         required: true
         type: string
-      prerelease:
-        description: "Force the GitHub Release to be marked as a pre-release (skips --latest)"
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: release
@@ -634,16 +629,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
           CHANNEL: ${{ needs.preflight.outputs.channel }}
-          PRERELEASE: ${{ inputs.prerelease }}
         run: |
           VERSION="v$RELEASE_VERSION"
           FLAGS=(--title "Observal $VERSION" --notes-file .github/release-notes.md)
-          # Manual override: inputs.prerelease forces a pre-release even when
-          # the .release.toml channel is stable. Only set on push runs, the
-          # input is empty so channel drives the flag as before.
-          if [ "$PRERELEASE" = "true" ]; then
-            FLAGS+=(--prerelease)
-          elif [ "$CHANNEL" = "stable" ]; then
+          if [ "$CHANNEL" = "stable" ]; then
             FLAGS+=(--latest)
           else
             FLAGS+=(--prerelease)


### PR DESCRIPTION
## Purpose / Description

Reverts the `workflow_dispatch` `prerelease` override flag added in #1648 (commit `5515d9517`). The flag was redundant: the release pipeline already marks releases as `--prerelease` or `--latest` based on the `.release.toml` channel (stable -> latest, rc/beta/alpha -> prerelease). The manual override duplicated that mechanism and covered only an edge case (stable-channel version but pre-release flag) that is not useful in practice.

## Fixes

No linked issue. Reverts #1648's prerelease flag only; the rest of #1648 (pinned dependencies, signed releases, docs fixes) remains.

## Approach

`git revert 5515d9517` on top of `main`. Removes the `prerelease` boolean input from `workflow_dispatch` and the `PRERELEASE` env / override branch in the `Create or resume GitHub Release` step. The existing channel-based logic (`--latest` for stable, `--prerelease` otherwise) is untouched and continues to drive release marking as before. Push-triggered and manual `workflow_dispatch` runs now behave identically again, controlled solely by the `.release.toml` channel.

## How Has This Been Tested?

- `release.yml` parses with `yaml.safe_load`; YAML valid.
- actionlint v1.7.12: 0 findings.
- Verified the `workflow_dispatch` inputs block is back to just `target`, and the remaining `prerelease` references in the file are the pre-existing channel-based `--prerelease` flag and the Python prerelease-version parser, neither of which this revert touches.

## Learning (optional, can help others)

The `.release.toml` channel field is the single source of truth for whether a release is a pre-release. Adding a second manual override on top of it creates two paths that can disagree, and the only case the override covers that channel does not is a stable-versioned release marked as pre-release, which is not a real workflow.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - N/A, no UI changes (reverts a CI workflow input).

## AI Assistance

- [x] Yes(Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release publishing by automatically marking stable releases as latest and other release channels as prereleases.
  * Removed the manual prerelease selection option from release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->