### PR TITLE
fix(release): resolve release tags to SHAs to survive background tag pruning

### DIFF
--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -142,12 +142,17 @@ def test_latest_tag_chooses_highest_stable_even_when_detached(monkeypatch):
 
 def test_release_cutoff_uses_manifest_with_old_tag_fallback(monkeypatch):
     cutoff = "b" * 40
+    old_tag_sha = "a" * 40
 
     def fake_run(*args, **kwargs):
         if args[:3] == ("git", "show", "v1.10.8:.release.toml"):
             return f'cutoff = "{cutoff}"\n'
         if args[:3] == ("git", "show", "v1.10.7:.release.toml"):
             raise ReleaseError("missing manifest")
+        # No .release.toml at the tag: the fallback resolves the tag to a
+        # commit SHA so later git log ranges don't depend on the tag ref.
+        if args[:3] == ("git", "rev-parse", "v1.10.7^{commit}"):
+            return old_tag_sha
         if args[:3] == ("git", "cat-file", "-e"):
             return ""
         raise AssertionError(args)
@@ -155,7 +160,7 @@ def test_release_cutoff_uses_manifest_with_old_tag_fallback(monkeypatch):
     monkeypatch.setattr(release, "run", fake_run)
 
     assert release_cutoff("v1.10.8") == cutoff
-    assert release_cutoff("v1.10.7") == "v1.10.7"
+    assert release_cutoff("v1.10.7") == old_tag_sha
 
 
 def test_release_discovery_skips_prior_release_metadata(monkeypatch):

--- a/tools/release.py
+++ b/tools/release.py
@@ -487,7 +487,7 @@ def ensure_preflight(upstream: str) -> None:
     if run("git", "branch", "--show-current") != "main":
         raise ReleaseError("Releases must be prepared from main")
     run("gh", "auth", "status")
-    run("git", "fetch", upstream, "main", "--tags")
+    run("git", "fetch", upstream, "main", "--tags", "--force", "--no-prune-tags")
     if run("git", "rev-parse", "HEAD") != run("git", "rev-parse", f"{upstream}/main"):
         raise ReleaseError(f"Local main must exactly match {upstream}/main")
 
@@ -504,7 +504,10 @@ def release_cutoff(tag: str) -> str:
     try:
         manifest = tomllib.loads(run("git", "show", f"{tag}:.release.toml"))
     except ReleaseError:
-        return tag
+        # No .release.toml at this tag (older release). Resolve the tag to a
+        # commit SHA immediately so subsequent git log ranges don't depend on
+        # the tag ref surviving background fetches with fetch.pruneTags.
+        return run("git", "rev-parse", f"{tag}^{{commit}}")
     except tomllib.TOMLDecodeError as exc:
         raise ReleaseError(f"Invalid release manifest in {tag}: {exc}") from exc
     cutoff = manifest.get("cutoff")
@@ -601,6 +604,9 @@ def prepare(preview_only: bool, upstream: str = "upstream", fork: str = "origin"
     repo = f"{owner}/{name}"
     fork_owner, _ = repository(fork)
     branch = f"{upstream}/main"
+    # Re-fetch tags in case a background process (e.g. lazygit with
+    # fetch.pruneTags) pruned them between ensure_preflight and here.
+    run("git", "fetch", upstream, "--tags", "--force", "--no-prune-tags")
     previous_tag = latest_tag()
     previous_cutoff = release_cutoff(previous_tag)
     changes = discover_changes(repo, previous_cutoff, branch)


### PR DESCRIPTION
## Purpose / Description

`make release` (via `tools/release.py`) fails with `unknown revision 'v1.10.7'` when a background process (lazygit) runs `git fetch --prune` with the global `fetch.prune = true` and `fetch.pruneTags = true` config, pruning the tag ref between `ensure_preflight`'s fetch and the later `git log v1.10.7..cutoff` call. The release tool returned the tag name instead of a SHA, so the range depended on the tag ref surviving.

## Fixes

No linked issue. Reported during a release attempt.

## Approach

Three fixes in `tools/release.py`:

1. `ensure_preflight` fetch now uses `--force --no-prune-tags` so the release tool's own fetch does not prune tags, overriding the global `fetch.pruneTags = true`.
2. Re-fetch tags with `--no-prune-tags --force` right before `latest_tag()` to recover any tags pruned by background processes after `ensure_preflight`.
3. `release_cutoff` now resolves the tag to a commit SHA in the fallback path (when no `.release.toml` exists at the tag, which is the case for `v1.10.7` and older releases). Subsequent `git log` ranges use the SHA, not the tag name, so they no longer depend on the tag ref surviving.

The root cause is that `release_cutoff` returned the tag name (`v1.10.7`) instead of a SHA when `.release.toml` was absent. Resolving to a SHA immediately after reading the tag makes the tool immune to background tag pruning.

## How Has This Been Tested?

- Reproduced the original failure: `git log v1.10.7..HEAD` fails after `lazygit` prunes the tag. `git log <SHA>..HEAD` succeeds with the resolved SHA regardless of tag pruning.
- Verified `release_cutoff`'s fallback now returns the commit SHA (`05521570f`) instead of the tag name.
- Python syntax check passes.
- Confirmed `--no-prune-tags` prevents tag pruning even with `fetch.prune = true` and `fetch.pruneTags = true` in global config.

## Learning (optional, can help others)

`fetch.prune = true` and `fetch.pruneTags = true` in `~/.gitconfig` make every `git fetch` prune tags that don't exist on the fetched remote. Background tools like `lazygit` that fetch periodically can prune tags between two commands in a script. Resolving refs to SHAs as early as possible avoids depending on ref survival.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - N/A, no UI changes (release tooling fix).

## AI Assistance

- [x] Yes(Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preparation reliability by fetching updated tags before determining the latest release.
  * Added support for older releases without release configuration by using the associated commit.
  * Improved handling of tag updates to prevent outdated release information during preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->