### PR TITLE
fix(release): make pypi, npm, and helm jobs resume-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,7 +460,21 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
 
+      - name: Check if already published
+        id: published
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/observal-cli/$VERSION/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "observal-cli $VERSION is already on PyPI, skipping publish"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to PyPI
+        if: steps.published.outputs.already_published != 'true'
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   # ── Job 5: npm publish (after approval) ────────────────────
@@ -488,7 +502,20 @@ jobs:
           cd packages/pi-extension
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
+      - name: Check if already published
+        id: published
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          if npm view "observal-pi@$VERSION" version 2>/dev/null | grep -qx "$VERSION"; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "observal-pi $VERSION is already on npm, skipping publish"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish observal-pi
+        if: steps.published.outputs.already_published != 'true'
         env:
           CHANNEL: ${{ needs.preflight.outputs.channel }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -549,8 +576,14 @@ jobs:
             --username "${{ github.actor }}" \
             --password-stdin
 
-          helm push "chart-dist/observal-${VERSION}.tgz" "$HELM_OCI_REPO"
+          # Skip if this chart version is already published
+          if helm pull "$HELM_OCI_REPO/observal" --version "$VERSION" --destination /tmp 2>/dev/null; then
+            echo "Chart $VERSION is already on GHCR, skipping push"
+          else
+            helm push "chart-dist/observal-${VERSION}.tgz" "$HELM_OCI_REPO"
+          fi
 
+          # artifacthub metadata is idempotent, always push
           oras push "${HELM_OCI_REF}:artifacthub.io" \
             --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
             infra/helm/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml


### PR DESCRIPTION
## Purpose / Description

The release pipeline can be resumed via `workflow_dispatch` when a job fails partway through. The `tag` and `release` jobs already handle this (tag checks if the tag exists, release checks if the GitHub Release exists). But the `pypi`, `npm`, and `helm-chart` jobs had no resume guard, so re-running after a partial failure tried to publish versions already on the registry, hitting `403 You cannot publish over previously published versions`.

This happened during the v1.11.0 release: npm and PyPI published successfully in the original run, then the `release` job failed on attestation verification (fixed in #1655, already merged). Resuming the pipeline re-ran the `npm` job, which failed with 403 because 1.11.0 was already live.

## Fixes

Fixes the resume failure after https://github.com/Observal/Observal/actions/runs/30763601219

## Approach

Add a pre-publish check to each publish job:
- **pypi**: curl the PyPI JSON API for `observal-cli@$VERSION`, skip the publish step if HTTP 200
- **npm**: `npm view observal-pi@$VERSION`, skip if the version exists
- **helm-chart**: `helm pull` the OCI chart, skip the push if the version exists

The build and artifact upload steps still run (the release job needs those artifacts), only the publish step is gated. This mirrors the resume-safe pattern the `tag` and `release` jobs already use.

## How Has This Been Tested?

- YAML valid, actionlint clean (0 findings).
- Confirmed `observal-pi@1.11.0` is live on npm and `observal-cli@1.11.0` is live on PyPI (both return 200), so the guards will correctly skip on the v1.11.0 resume.
- Will be confirmed end-to-end by the next resume run completing without 403.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
  - N/A, no UI changes (CI workflow fix).

## AI Assistance

- [x] Yes(Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release publishing now skips artifacts when their version already exists, preventing duplicate publication attempts.
  * New package and chart versions continue through the standard publishing process.
  * Artifact Hub metadata continues to be updated on every release run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->