### PR TITLE
docs(readme): remove repetition between How It Works and feature sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Or just tell your agent what you want and it figures out the right commands.
 
 ### Agents are portable context packages
 
-An agent bundles 5 component types into a single installable package: **MCP servers**, **skills**, **hooks**, **prompts**, and **sandboxes**. You define the agent once, publish it to the registry, and Observal generates the right config files for whichever supported harness or harness the user runs.
+An agent bundles 5 component types into a single installable package: **MCP servers**, **skills**, **hooks**, **prompts**, and **sandboxes**. You define the agent once, publish it to the registry, and Observal generates the right config files for whichever supported harness the user runs.
 
 ```bash
 observal pull security-auditor --harness pi
@@ -164,15 +164,11 @@ observal pull security-auditor --harness pi
 
 ### The registry is the distribution layer
 
-Browse published agents, see which harnesses they support, check download counts and ratings, and install with one command. Admins review submissions before they go live. Version diffs show exactly what changed between releases, so teams can safely evolve shared context.
+The registry is where agents live. Admins review submissions, version diffs keep changes auditable, and one command installs an agent into any supported harness.
 
-### Insights show what is helping
+### Insights close the loop
 
-Observal turns real usage into reports about which agents, prompts, tools, and workflows are working or getting in the way. Use those insights to improve shared context instead of guessing from anecdotes.
-
-### Session traces provide the evidence
-
-When you need to debug, audit, or understand a result, Observal can replay the full coding session: user prompts, thinking blocks, assistant responses, and tool calls with their inputs and outputs. The traces support registry and insight workflows rather than defining the product.
+Real usage data flows back as reports: what's helping, what's getting in the way, and where to improve. Session traces provide the underlying evidence for debugging and auditing.
 
 ---
 
@@ -224,7 +220,7 @@ See [Insights LLM Setup](docs/insights-setup.md) for configuration.
 
 ![Review queue with agent detail](docs/img/review.png)
 
-**Version diffs show exactly what changed between releases:**
+**Side-by-side version diffs before approving a new release:**
 
 ![Side-by-side diff of v1.0.0 vs v2.0.0](docs/img/review-diff.png)
 


### PR DESCRIPTION
## Purpose / Description

The README had clear repetition between the "How Observal works" section and the feature sections that followed it. Each feature was described twice: once in prose under How It Works, then again with a screenshot caption in the feature section.

- "The registry is the distribution layer" described browsing agents, harnesses, download counts, installing, and version diffs. Then "Agent Registry" repeated: "Browse, search, and install agents with harness compatibility badges."
- "Insights show what is helping" described reports on what's working. Then "Agent Insights" repeated: "analyze usage patterns... what's working, what's hindering."
- "Session traces provide the evidence" described replaying sessions. Then "Session Replay" repeated: "Full session overview with token counts, models, tools."

## Fixes

No linked issue.

## Approach

Condense the three "How Observal works" subsections (registry, insights, traces) to short conceptual descriptions that explain the *why* without listing features. The screenshot sections below (Agent Registry, Agent Insights, Session Replay) now carry the feature details and visuals without overlap. Also fixed a duplicate "harness or harness" typo in the agents subsection.

## How Has This Been Tested?

Read the edited README section to confirm the flow: How It Works gives a concise mental model, then the feature sections expand with screenshots. No repeated phrases remain.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
  - N/A, markdown text edit only.

## AI Assistance

- [x] Yes(Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Observal agents, registry distribution, and usage insights work.
  * Simplified descriptions of session replay and registry capabilities.
  * Updated review guidance to describe version comparisons as side-by-side diffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->