### PR TITLE
fix(release): remove duplicate title and contributors section from release notes

### DIFF
--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -281,7 +281,7 @@ def test_human_names_ending_in_bot_are_not_filtered():
     assert [contributor.label for contributor in contributors] == ["@talbot"]
 
 
-def test_release_notes_include_all_contributors_and_first_time_marker():
+def test_release_notes_include_version_and_comparison_link():
     notes = render_release_notes(
         "1.10.8",
         "v1.10.7",
@@ -290,9 +290,8 @@ def test_release_notes_include_all_contributors_and_first_time_marker():
         [Contributor("Hari", "hari"), Contributor("New Person", "new-person", first_time=True)],
     )
 
-    assert "@hari" in notes
-    assert "@new-person (first contribution)" in notes
     assert "v1.10.7...v1.10.8" in notes
+    assert "add safe releases" in notes
 
 
 def test_changelog_uses_only_selected_public_notes():

--- a/tools/release.py
+++ b/tools/release.py
@@ -355,8 +355,6 @@ def render_release_notes(
         "<!-- SPDX-License-Identifier: Apache-2.0 -->",
         # REUSE-IgnoreEnd
         "",
-        f"# Observal v{version}",
-        "",
         f"This release includes {len(changes)} change groups through `{cutoff[:7]}`.",
     ]
     if highlights:
@@ -367,13 +365,6 @@ def render_release_notes(
         regular = [item for item in items if item not in highlights and item not in breaking]
         if regular:
             lines.extend(("", f"## {category}", "", render_entries(regular)))
-    lines.extend(("", "## Contributors", ""))
-    if contributors:
-        for contributor in contributors:
-            suffix = " (first contribution)" if contributor.first_time else ""
-            lines.append(f"- {contributor.label}{suffix}")
-    else:
-        lines.append("- No human contributors detected")
     lines.extend(
         (
             "",


### PR DESCRIPTION
## Purpose / Description

The generated GitHub Release notes had two issues visible on the v1.11.0 release page:

1. **"Observal v1.11.0" appeared twice** at the top. The release job sets the GitHub Release title to `Observal v1.11.0` via `--title`, and the generated `.github/release-notes.md` also started with `# Observal v1.11.0`. GitHub renders both, so the version heading showed up twice.

2. **Contributors section listed the same people twice** (both as `@login` and as plain name). The `all_contributors` function merges commit authors, PR authors, and co-authors, and when a commit email is not the GitHub noreply format, the real name is added as a separate entry alongside the login. For example: `@Haz3-jolt` and `Hari Srinivasan` are the same person.

## Fixes

No linked issue. Cosmetic fix to release notes generation.

## Approach

- Remove the `# Observal v{version}` heading from `render_release_notes` in `tools/release.py`. The release title already displays it on the GitHub Release page.
- Remove the Contributors section entirely from the generated notes. GitHub already shows contributors via the commit history and PR metadata. The section was inaccurate due to the name/login duplication and added no value.
- Updated `test_release_notes_include_all_contributors_and_first_time_marker` to `test_release_notes_include_version_and_comparison_link` since contributor assertions are no longer relevant.

## How Has This Been Tested?

- All 19 tests in `tests/test_release.py` pass.
- ruff check passes on `tools/release.py`.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
  - N/A, release tooling fix.

## AI Assistance

- [x] Yes(Please Specify the tool): pi coding agent
- [x] Was the generated code manually reviewed and tested?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined generated release notes by removing the release title heading and contributors section.
  * Release notes now focus on the comparison link and core release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->