### PR TITLE
Feat/agent recommended additions

### DIFF
--- a/observal-server/alembic/versions/023_insight_analysis_payload.py
+++ b/observal-server/alembic/versions/023_insight_analysis_payload.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 The Observal Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist insights analysis previously discarded each run.
+
+Adds ``version_impact`` and ``registry_offer`` (JSON, nullable) to
+``insight_reports``. The pipeline already computes both every run — the
+cross-user layer/config correlation analysis and the deterministic registry
+component shortlist shown to the model — but historically folded them into the
+LLM prompt and then discarded them. These columns persist that analysis so
+downstream consumers (duplicate detection, pull-time recommendations,
+governance drift signals) can read it without re-running the pipeline.
+
+Both columns are nullable: pre-existing reports predate the columns (and never
+had the data), and a run may legitimately produce no version impact or an
+empty offer. No backfill is needed — null is the correct value for old rows.
+
+Revision ID: 023_insight_analysis_payload
+Revises: 022_user_recommendations
+Create Date: 2026-08-03
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "023_insight_analysis_payload"
+down_revision = "022_user_recommendations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("insight_reports", sa.Column("version_impact", sa.JSON(), nullable=True))
+    op.add_column("insight_reports", sa.Column("registry_offer", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("insight_reports", "registry_offer")
+    op.drop_column("insight_reports", "version_impact")

--- a/observal-server/api/routes/agent/insights.py
+++ b/observal-server/api/routes/agent/insights.py
@@ -5,15 +5,19 @@
 
 from fastapi import Depends, HTTPException, Query
 from fastapi.responses import HTMLResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.deps import get_db, require_role
+from api.deps import check_listing_visibility_async, get_db, optional_current_user, require_role
+from models.insight_report import InsightReport, InsightReportStatus
 from models.user import User, UserRole
 from schemas.insights import (
     ApplySuggestionsRequest,
     GenerateInsightRequest,
     InsightReportListItem,
     InsightReportResponse,
+    RecommendedAddition,
+    RecommendedAdditionsResponse,
 )
 
 from ._router import router
@@ -113,3 +117,89 @@ async def delete_agent_insight_reports(
     from api.routes.insights import clear_agent_reports
 
     return await clear_agent_reports(agent_id, db, current_user)
+
+
+@router.get("/{agent_id}/insights/recommended-additions", response_model=RecommendedAdditionsResponse)
+async def agent_recommended_additions(
+    agent_id: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: User | None = Depends(optional_current_user),
+):
+    """Public, evidence-backed add-on recommendations for an agent.
+
+    Returns the latest completed insight report's deterministic component
+    shortlist (``registry_offer``) — public registry components the agent does
+    not yet use but might benefit from based on observed usage. This is a
+    *public* surface: unlike the full insight report, it exposes only public
+    component references and never session telemetry, so it is available to
+    anyone who can see the agent (including anonymous browsing).
+
+    Empty ``items`` means no report exists, the offer was empty, or the feature
+    was disabled at generation time. Callers hide the rail rather than erroring.
+    """
+    from api.routes.agent.helpers import _load_agent
+
+    agent = await _load_agent(
+        db,
+        agent_id,
+        prefer_user_id=current_user.id if current_user else None,
+        current_user=current_user,
+        include_all_statuses=False,
+    )
+    if not agent or not await check_listing_visibility_async(agent, current_user, db):
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    # Latest completed report for this agent. Only completed reports carry a
+    # registry_offer; pending/running/failed rows are skipped.
+    stmt = (
+        select(InsightReport)
+        .where(
+            InsightReport.agent_id == agent.id,
+            InsightReport.status == InsightReportStatus.completed,
+        )
+        .order_by(InsightReport.completed_at.desc().nulls_last())
+        .limit(1)
+    )
+    report = (await db.execute(stmt)).scalar_one_or_none()
+
+    empty = RecommendedAdditionsResponse(agent_id=agent.id)
+    if not report:
+        return empty
+
+    offer = report.registry_offer
+    if not isinstance(offer, dict) or not offer.get("enabled", True):
+        return empty
+
+    entries_by_type = offer.get("entries_by_type") or {}
+    if not isinstance(entries_by_type, dict):
+        return empty
+
+    items: list[RecommendedAddition] = []
+    for _type_plural, entries in entries_by_type.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            # Each entry is a CatalogOffer.to_catalog_entry() dict: type, id,
+            # qualified_name, name, description, category. Skip anything that
+            # lacks the minimum fields needed to render a link.
+            if not entry.get("id") or not entry.get("type"):
+                continue
+            items.append(
+                RecommendedAddition(
+                    type=str(entry["type"]),
+                    id=str(entry["id"]),
+                    qualified_name=str(entry.get("qualified_name") or entry.get("name") or entry["id"]),
+                    name=str(entry.get("name") or entry.get("qualified_name") or entry["id"]),
+                    description=entry.get("description"),
+                    category=entry.get("category"),
+                )
+            )
+
+    return RecommendedAdditionsResponse(
+        agent_id=agent.id,
+        items=items,
+        source_report_id=report.id,
+        generated_at=report.completed_at,
+    )

--- a/observal-server/models/insight_report.py
+++ b/observal-server/models/insight_report.py
@@ -72,6 +72,16 @@ class InsightReport(Base):
     aggregated_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     report_version: Mapped[int] = mapped_column(Integer, default=1)
 
+    # Analysis previously computed and discarded each run. Persisted now so
+    # downstream consumers (duplicate detection, pull-time recommendations,
+    # governance drift signals) can read them without re-running the pipeline.
+    # ``version_impact`` is the cross-user layer/config correlation analysis;
+    # ``registry_offer`` is the deterministic component shortlist the model was
+    # shown. Both are nullable: old reports predate the columns, and a run may
+    # legitimately produce no version impact or an empty offer.
+    version_impact: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    registry_offer: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
     # Self-learn fields
     applied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     applied_items: Mapped[dict | None] = mapped_column(JSON, nullable=True)

--- a/observal-server/schemas/insight_analysis.py
+++ b/observal-server/schemas/insight_analysis.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 The Observal Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed schema for the insights pipeline's analytical payload.
+
+The pipeline computes a rich set of analysis *before* it writes any narrative
+prose: deterministic metrics, LLM-extracted facets, cross-user version-impact
+analysis, and a deterministic registry shortlist. Historically most of this
+was stored as untyped JSON blobs on the ``InsightReport`` (``metrics``,
+``narrative``, ``aggregated_data``), while ``version_impact`` and
+``registry_offer`` were computed and then discarded every run.
+
+This module defines the canonical top-level shape of that payload so there is
+a single source of truth for what one pipeline run produces, and so structural
+drift (a whole section going missing, a dict arriving as a list) is detectable
+at write time instead of silently persisted.
+
+The schema is intentionally permissive on nested fields: ``metrics``,
+``narrative`` and ``aggregated_data`` carry LLM-generated content whose exact
+shape varies, so they are typed as ``dict`` rather than fully modelled.
+Validation catches gross structural errors, not minor LLM output variance — a
+report must never fail to persist because the model added an unexpected field.
+"""
+
+from __future__ import annotations
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+logger = structlog.get_logger(__name__)
+
+
+class InsightAnalysisPayload(BaseModel):
+    """The analytical output of one insights pipeline run.
+
+    Fields are grouped by how they were produced so a reader can tell
+    deterministic data apart from LLM-inferred content:
+
+    * Deterministic: ``metrics``, ``aggregated_data``, ``version_impact``,
+      ``registry_offer``, ``facets_summary`` (the last is an aggregate of
+      per-session LLM facets, but the aggregation itself is deterministic).
+    * Generated: ``narrative`` (the LLM-written report sections, including
+      ``suggestions``).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    # Deterministic metrics from ClickHouse (has ``rich`` / ``overview``).
+    metrics: dict = Field(default_factory=dict)
+    # LLM-generated narrative sections (including ``suggestions``).
+    narrative: dict = Field(default_factory=dict)
+    # Pre-existing roll-up: metrics + facets_summary + regressions +
+    # cross_user_patterns. Kept as a dict for back-compat with readers.
+    aggregated_data: dict = Field(default_factory=dict)
+    # Cross-user layer/config correlation analysis. Previously discarded
+    # after being folded into the LLM prompt; now persisted.
+    version_impact: dict | None = None
+    # Deterministic shortlist of registry components the agent does not yet
+    # use. Previously discarded after being shown to the model; now persisted
+    # so future consumers (duplicate detection, pull-time recs) can read it
+    # without re-running the pipeline.
+    registry_offer: dict | None = None
+    # Aggregate of per-session facets.
+    facets_summary: dict = Field(default_factory=dict)
+    # Number of sessions the run analysed.
+    sessions_analyzed: int = 0
+
+
+def validate_payload(content: dict) -> dict | None:
+    """Structurally validate a pipeline run's output.
+
+    Returns a validated ``InsightAnalysisPayload`` dict on success, or ``None``
+    on structural mismatch. Failures are *never* fatal: callers persist the
+    raw ``content`` dict as a fallback so a schema mismatch cannot break
+    report generation. The mismatch is logged so drift is observable.
+    """
+    try:
+        payload = InsightAnalysisPayload.model_validate(content)
+    except ValidationError as e:
+        # Log only loc/type/msg — never the raw input, which can carry
+        # LLM-generated narrative or session-derived text from ``content``.
+        safe = [{"loc": err["loc"], "type": err["type"], "msg": err["msg"]} for err in e.errors(include_input=False)]
+        logger.warning("insight_payload_validation_failed", errors=safe)
+        return None
+    return payload.model_dump()
+
+
+__all__ = ["InsightAnalysisPayload", "validate_payload"]

--- a/observal-server/schemas/insights.py
+++ b/observal-server/schemas/insights.py
@@ -75,6 +75,10 @@ class InsightReportResponse(BaseModel):
     previous_report_id: uuid.UUID | None = None
     aggregated_data: dict | None = None
     report_version: int = 3
+    # Persisted analysis (previously discarded each run). Nullable: old
+    # reports predate the columns, and a run may produce neither.
+    version_impact: dict | None = None
+    registry_offer: dict | None = None
     # Self-learn fields
     applied_at: datetime | None = None
     applied_items: dict | None = None

--- a/observal-server/schemas/insights.py
+++ b/observal-server/schemas/insights.py
@@ -83,3 +83,34 @@ class InsightReportResponse(BaseModel):
     applied_at: datetime | None = None
     applied_items: dict | None = None
     model_config = {"from_attributes": True}
+
+
+class RecommendedAddition(BaseModel):
+    """A single public registry component recommended for an agent.
+
+    Drawn from an insight report's ``registry_offer`` — the deterministic
+    shortlist of approved, visible components the agent does not yet use but
+    might benefit from based on observed usage. Contains only public component
+    references; no session telemetry is exposed.
+    """
+
+    type: str
+    id: str
+    qualified_name: str
+    name: str
+    description: str | None = None
+    category: str | None = None
+
+
+class RecommendedAdditionsResponse(BaseModel):
+    """Evidence-backed add-on recommendations for an agent.
+
+    Empty ``items`` means either no insight report exists for the agent, the
+    report's registry offer is empty, or the feature was disabled at generation
+    time. Callers should simply hide the rail rather than treat it as an error.
+    """
+
+    agent_id: uuid.UUID
+    items: list[RecommendedAddition] = []
+    source_report_id: uuid.UUID | None = None
+    generated_at: datetime | None = None

--- a/observal-server/services/insights/batch.py
+++ b/observal-server/services/insights/batch.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from database import async_session
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.insight_report import InsightReport, InsightReportStatus
+from schemas.insight_analysis import validate_payload
 from services.clickhouse import _query
 from services.insight_version_filters import agent_version_filter
 from services.redis import _get_arq_pool
@@ -245,7 +246,10 @@ async def run_single_report(report_id: str) -> None:
 
             await _update_report_progress(db, report, "saving", 9, 9, "Saving report")
 
-            # Persist results
+            # Persist results. The pipeline now returns the analysis it
+            # previously discarded (version_impact, registry_offer); persist
+            # those alongside the existing fields so downstream consumers can
+            # read them without a rerun.
             report.metrics = content.get("metrics")
             report.narrative = content.get("narrative")
             report.sessions_analyzed = content.get("sessions_analyzed", 0)
@@ -255,7 +259,20 @@ async def run_single_report(report_id: str) -> None:
                 "regressions": content.get("regressions"),
                 "cross_user_patterns": content.get("cross_user_patterns"),
             }
+            report.version_impact = content.get("version_impact")
+            report.registry_offer = content.get("registry_offer")
             report.report_version = 3
+
+            # Structural validation of the payload. Non-destructive: a
+            # mismatch is logged but never blocks the write, so a schema drift
+            # cannot break report generation.
+            validated = validate_payload(content)
+            if validated is not None:
+                logger.info(
+                    "insight_payload_validated",
+                    has_version_impact=validated.get("version_impact") is not None,
+                    has_registry_offer=validated.get("registry_offer") is not None,
+                )
 
             models_used = content.get("models_used", [])
             report.llm_model_used = ", ".join(models_used) if models_used else None

--- a/observal-server/services/insights/generator.py
+++ b/observal-server/services/insights/generator.py
@@ -485,6 +485,14 @@ async def _run_pipeline(
         "regressions": [],
         "facets_summary": facets_summary,
         "cross_user_patterns": {},
+        # Analysis previously discarded after being folded into the prompt.
+        # Persisted now so downstream consumers can read them without a rerun.
+        "version_impact": version_impact,
+        # Use an explicit ``is not None`` check: CatalogOffer defines __bool__ as
+        # bool(entries_by_type), so an empty/disabled/failed offer would evaluate
+        # falsy and we'd persist None — losing the enabled / registry_has_components
+        # metadata that matters most in exactly those cases.
+        "registry_offer": registry_offer.to_dict() if registry_offer is not None else None,
     }
 
 
@@ -756,4 +764,6 @@ def _empty_report() -> dict:
         "regressions": [],
         "facets_summary": {},
         "cross_user_patterns": {},
+        "version_impact": None,
+        "registry_offer": None,
     }

--- a/observal-server/services/insights/registry_match.py
+++ b/observal-server/services/insights/registry_match.py
@@ -88,6 +88,22 @@ class CatalogOffer:
             "registry_has_components": self.registry_has_components,
         }
 
+    def to_dict(self) -> dict:
+        """Serialize the full offer for persistence as analysis payload.
+
+        Unlike :meth:`to_summary` (which records *that* a search happened),
+        this captures *what* was offered so downstream consumers can read the
+        shortlist without re-running the recommender. ``offered_ids`` is a
+        set of UUIDs and is serialized as sorted strings for stable storage.
+        """
+        return {
+            "enabled": self.enabled,
+            "registry_has_components": self.registry_has_components,
+            "item_count": self.item_count,
+            "offered_ids": sorted(str(cid) for cid in self.offered_ids),
+            "entries_by_type": self.entries_by_type,
+        }
+
 
 def build_signals(
     agg: dict | None = None,

--- a/tests/test_agent_recommended_additions.py
+++ b/tests/test_agent_recommended_additions.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2026 The Observal Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the public agent recommended-additions endpoint.
+
+This is the first consumer of the persisted ``registry_offer`` analysis. The
+endpoint exposes only public component references — never session telemetry —
+and degrades to an empty list when no report exists, the offer is empty, or
+the feature was disabled at generation time.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_offer(entries_by_type: dict | None = None, enabled: bool = True) -> dict:
+    return {
+        "enabled": enabled,
+        "registry_has_components": True,
+        "item_count": sum(len(v) for v in (entries_by_type or {}).values()),
+        "offered_ids": [],
+        "entries_by_type": entries_by_type or {},
+    }
+
+
+def _entry(cid: str, ctype: str = "skill", name: str = "foo-bar") -> dict:
+    return {
+        "type": ctype,
+        "id": cid,
+        "qualified_name": f"ns/{name}",
+        "name": name,
+        "description": "a useful skill",
+        "category": "general",
+    }
+
+
+@pytest.mark.asyncio
+async def test_recommended_additions_returns_offer_entries():
+    from api.routes.agent.insights import agent_recommended_additions
+
+    agent_id = uuid.uuid4()
+    report_id = uuid.uuid4()
+    completed = datetime.now(UTC)
+    cid = str(uuid.uuid4())
+
+    agent = SimpleNamespace(id=agent_id)
+    report = SimpleNamespace(
+        id=report_id,
+        agent_id=agent_id,
+        completed_at=completed,
+        registry_offer=_make_offer({"skills": [_entry(cid)]}),
+    )
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=report)))
+
+    with (
+        patch("api.routes.agent.helpers._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.insights.check_listing_visibility_async", new=AsyncMock(return_value=True)),
+    ):
+        result = await agent_recommended_additions(str(agent_id), db, current_user=None)
+
+    assert result.agent_id == agent_id
+    assert result.source_report_id == report_id
+    assert result.generated_at == completed
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item.type == "skill"
+    assert item.id == cid
+    assert item.qualified_name == "ns/foo-bar"
+    assert item.name == "foo-bar"
+
+
+@pytest.mark.asyncio
+async def test_recommended_additions_empty_when_no_report():
+    from api.routes.agent.insights import agent_recommended_additions
+
+    agent_id = uuid.uuid4()
+    agent = SimpleNamespace(id=agent_id)
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None)))
+
+    with (
+        patch("api.routes.agent.helpers._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.insights.check_listing_visibility_async", new=AsyncMock(return_value=True)),
+    ):
+        result = await agent_recommended_additions(str(agent_id), db, current_user=None)
+
+    assert result.items == []
+    assert result.source_report_id is None
+    assert result.generated_at is None
+
+
+@pytest.mark.asyncio
+async def test_recommended_additions_empty_when_offer_null_on_old_report():
+    """Old reports predate the registry_offer column (PR #1 backfill left null)."""
+    from api.routes.agent.insights import agent_recommended_additions
+
+    agent_id = uuid.uuid4()
+    agent = SimpleNamespace(id=agent_id)
+    report = SimpleNamespace(
+        id=uuid.uuid4(),
+        agent_id=agent_id,
+        completed_at=datetime.now(UTC),
+        registry_offer=None,
+    )
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=report)))
+
+    with (
+        patch("api.routes.agent.helpers._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.insights.check_listing_visibility_async", new=AsyncMock(return_value=True)),
+    ):
+        result = await agent_recommended_additions(str(agent_id), db, current_user=None)
+
+    assert result.items == []
+
+
+@pytest.mark.asyncio
+async def test_recommended_additions_empty_when_feature_disabled():
+    """An offer with enabled=False means the feature was off at generation time."""
+    from api.routes.agent.insights import agent_recommended_additions
+
+    agent_id = uuid.uuid4()
+    agent = SimpleNamespace(id=agent_id)
+    report = SimpleNamespace(
+        id=uuid.uuid4(),
+        agent_id=agent_id,
+        completed_at=datetime.now(UTC),
+        registry_offer=_make_offer({"skills": [_entry(str(uuid.uuid4()))]}, enabled=False),
+    )
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=report)))
+
+    with (
+        patch("api.routes.agent.helpers._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.insights.check_listing_visibility_async", new=AsyncMock(return_value=True)),
+    ):
+        result = await agent_recommended_additions(str(agent_id), db, current_user=None)
+
+    assert result.items == []
+
+
+@pytest.mark.asyncio
+async def test_recommended_additions_404_when_agent_not_visible():
+    from api.routes.agent.insights import agent_recommended_additions
+
+    agent_id = uuid.uuid4()
+    agent = SimpleNamespace(id=agent_id)
+
+    db = MagicMock()
+
+    with (
+        patch("api.routes.agent.helpers._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.insights.check_listing_visibility_async", new=AsyncMock(return_value=False)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await agent_recommended_additions(str(agent_id), db, current_user=None)
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_recommended_additions_skips_malformed_entries():
+    """Malformed entries in the persisted offer are skipped, not fatal."""
+    from api.routes.agent.insights import agent_recommended_additions
+
+    agent_id = uuid.uuid4()
+    agent = SimpleNamespace(id=agent_id)
+    good_cid = str(uuid.uuid4())
+    report = SimpleNamespace(
+        id=uuid.uuid4(),
+        agent_id=agent_id,
+        completed_at=datetime.now(UTC),
+        registry_offer=_make_offer(
+            {
+                "skills": [
+                    _entry(good_cid),
+                    {"missing": "type and id"},  # skipped
+                    "not-a-dict",  # skipped
+                ],
+                "hooks": "not-a-list",  # skipped entirely
+            }
+        ),
+    )
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=report)))
+
+    with (
+        patch("api.routes.agent.helpers._load_agent", new=AsyncMock(return_value=agent)),
+        patch("api.routes.agent.insights.check_listing_visibility_async", new=AsyncMock(return_value=True)),
+    ):
+        result = await agent_recommended_additions(str(agent_id), db, current_user=None)
+
+    assert len(result.items) == 1
+    assert result.items[0].id == good_cid

--- a/tests/test_insight_analysis_payload.py
+++ b/tests/test_insight_analysis_payload.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: 2026 The Observal Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for persisting the insights analysis payload.
+
+Covers the "unconditionally worth it" change: the pipeline now returns (and
+the report row now persists) the ``version_impact`` and ``registry_offer``
+analysis it previously discarded every run, plus a typed schema for the
+analytical payload validated non-destructively on write.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from schemas.insight_analysis import validate_payload
+from services.insights.generator import REPORT_VERSION, _empty_report
+from services.insights.registry_match import CatalogOffer
+
+# ── CatalogOffer.to_dict ────────────────────────────────────────────────
+
+
+def test_catalog_offer_to_dict_serializes_full_offer():
+    cid_a = uuid.uuid4()
+    cid_b = uuid.uuid4()
+    entry = {"id": str(cid_a), "qualified_name": "ns/foo-bar", "name": "foo-bar"}
+    offer = CatalogOffer(
+        entries_by_type={"skills": [entry]},
+        offered_ids={cid_a, cid_b},
+        registry_has_components=True,
+        enabled=True,
+    )
+
+    d = offer.to_dict()
+
+    assert d["enabled"] is True
+    assert d["registry_has_components"] is True
+    assert d["item_count"] == 1
+    # offered_ids is a set -> serialized as sorted strings for stable storage.
+    assert d["offered_ids"] == sorted([str(cid_a), str(cid_b)])
+    assert d["entries_by_type"] == {"skills": [entry]}
+
+
+def test_catalog_offer_to_dict_empty_offer():
+    offer = CatalogOffer()
+
+    d = offer.to_dict()
+
+    assert d["enabled"] is True
+    assert d["registry_has_components"] is None
+    assert d["item_count"] == 0
+    assert d["offered_ids"] == []
+    assert d["entries_by_type"] == {}
+
+
+def test_empty_or_disabled_offer_is_not_dropped_by_truthiness():
+    """Regression guard for the generator serialization check.
+
+    build_catalog never returns None — it returns CatalogOffer() on the
+    no-match path and CatalogOffer(enabled=False) on the disabled path. Both
+    are falsy under CatalogOffer.__bool__ (bool(entries_by_type)). The
+    generator must use ``is not None`` rather than truthiness, or it persists
+    None and loses the enabled / registry_has_components metadata that
+    matters most in exactly these cases.
+    """
+    empty_offer = CatalogOffer()
+    disabled_offer = CatalogOffer(enabled=False)
+
+    # The exact expression the generator uses to serialize the offer.
+    empty_serialized = empty_offer.to_dict() if empty_offer is not None else None
+    disabled_serialized = disabled_offer.to_dict() if disabled_offer is not None else None
+
+    # Both must serialize to a dict, not be dropped to None.
+    assert empty_serialized is not None
+    assert empty_serialized["item_count"] == 0
+    assert disabled_serialized is not None
+    assert disabled_serialized["enabled"] is False
+
+    # And the truthiness check that USED to be there would have dropped them.
+    assert not bool(empty_offer)  # falsy -> would have been None under `if offer`
+    assert not bool(disabled_offer)
+
+
+# ── InsightAnalysisPayload schema ───────────────────────────────────────
+
+
+def test_payload_accepts_full_pipeline_output():
+    content = {
+        "metrics": {"rich": {"total_sessions": 10}, "overview": {"unique_users": 1}},
+        "narrative": {"at_a_glance": {"health": "good"}, "suggestions": {"features_to_try": []}},
+        "aggregated_data": {"metrics": {}, "facets_summary": {}, "regressions": [], "cross_user_patterns": {}},
+        "version_impact": {"group_count": 3, "canonical_dirty_summary": None},
+        "registry_offer": {"enabled": True, "item_count": 2, "offered_ids": [], "entries_by_type": {}},
+        "facets_summary": {"goal_categories": []},
+        "sessions_analyzed": 10,
+    }
+
+    validated = validate_payload(content)
+
+    assert validated is not None
+    assert validated["sessions_analyzed"] == 10
+    assert validated["version_impact"]["group_count"] == 3
+    assert validated["registry_offer"]["item_count"] == 2
+
+
+def test_payload_accepts_none_for_new_fields():
+    """A run may produce no version impact or an empty offer."""
+    content = {
+        "metrics": {},
+        "narrative": {},
+        "version_impact": None,
+        "registry_offer": None,
+        "sessions_analyzed": 0,
+    }
+
+    validated = validate_payload(content)
+
+    assert validated is not None
+    assert validated["version_impact"] is None
+    assert validated["registry_offer"] is None
+
+
+def test_payload_tolerates_extra_llm_fields():
+    """extra='allow' so LLM output variance never fails validation."""
+    content = {
+        "metrics": {},
+        "narrative": {"suggestions": {"features_to_try": [{"unexpected": "shape"}]}},
+        "sessions_analyzed": 1,
+        "some_unexpected_top_level": "fine",
+    }
+
+    validated = validate_payload(content)
+
+    assert validated is not None
+
+
+def test_payload_validation_falls_back_on_wrong_type():
+    """A gross structural error returns None so callers fall back to raw dict."""
+    content = {
+        "metrics": "not-a-dict",  # wrong type
+        "sessions_analyzed": 1,
+    }
+
+    validated = validate_payload(content)
+
+    # Non-destructive: caller persists raw content as fallback.
+    assert validated is None
+
+
+# ── generator return dict ───────────────────────────────────────────────
+
+
+def test_empty_report_includes_new_analysis_fields():
+    report = _empty_report()
+
+    assert report["version_impact"] is None
+    assert report["registry_offer"] is None
+    # Existing fields unchanged.
+    assert report["report_version"] == REPORT_VERSION
+    assert report["sessions_analyzed"] == 0
+    assert "metrics" in report
+    assert "narrative" in report

--- a/web/src/components/registry/agent-recommended-additions.tsx
+++ b/web/src/components/registry/agent-recommended-additions.tsx
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 The Observal Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import { Link } from "@tanstack/react-router";
+import { Sparkles } from "lucide-react";
+import { RegistryMark } from "@/components/registry/registry-mark";
+// "sandbox" does not pluralise by appending "s"; the route expects "sandboxes".
+import { REVERSE_TYPE_MAP } from "@/components/registry/agent-component-constants";
+import { useAgentRecommendedAdditions } from "@/hooks/use-insights-api";
+import type { RecommendedAddition } from "@/lib/types/admin";
+
+const TYPE_LABELS: Record<string, string> = {
+	skill: "Skill",
+	hook: "Hook",
+	prompt: "Prompt",
+	mcp: "MCP",
+	sandbox: "Sandbox",
+};
+
+/**
+ * Evidence-backed add-on recommendations shown on the agent detail page.
+ *
+ * Drawn from the latest insight report's deterministic component shortlist
+ * (`registry_offer`): public registry components this agent does not yet use
+ * but might benefit from based on observed usage. Unlike the full insight
+ * report, this surface exposes only public component references — no session
+ * telemetry — so it is safe to show to anyone who can see the agent.
+ *
+ * Renders nothing when there is no data: an empty rail is worse than no rail.
+ * This covers "no report yet", "report had an empty offer", and "the feature
+ * was disabled at generation time" — all of which are expected, not errors.
+ */
+export function AgentRecommendedAdditions({ agentId }: { agentId: string }) {
+	const { data, isLoading, isError } = useAgentRecommendedAdditions(agentId);
+
+	// Loading and error states render nothing: the rail is a progressive
+	// enhancement, never a blocker for the agent detail page.
+	if (isLoading || isError) return null;
+
+	const items = data?.items ?? [];
+	if (items.length === 0) return null;
+
+	return (
+		<section className="space-y-3">
+			<div className="flex items-start justify-between gap-3 flex-wrap">
+				<div className="flex items-center gap-2">
+					<Sparkles className="h-4 w-4 text-primary-accent" />
+					<h3 className="font-[family-name:var(--font-display)] text-sm font-semibold">
+						Recommended add-ons
+					</h3>
+				</div>
+				<p className="text-xs text-muted-foreground max-w-prose">
+					Based on observed usage of this agent — public components it
+					doesn&apos;t use yet.
+				</p>
+			</div>
+
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+				{items.map((item: RecommendedAddition) => (
+					<div
+						key={`${item.type}:${item.id}`}
+						className="group rounded-lg border border-border bg-card p-3 hover:border-primary/40 transition-colors"
+					>
+						<div className="flex items-center gap-2">
+							<RegistryMark size={13} />
+							<span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
+								{TYPE_LABELS[item.type] ?? item.type}
+							</span>
+							{item.category && (
+								<span className="text-xs text-muted-foreground">
+									{item.category}
+								</span>
+							)}
+						</div>
+
+						<Link
+							to="/components/$componentId"
+							params={{ componentId: item.id }}
+							search={{ type: REVERSE_TYPE_MAP[item.type] ?? `${item.type}s` }}
+							className="mt-2 block font-medium text-sm hover:text-primary-accent break-all"
+						>
+							{item.name}
+						</Link>
+
+						{item.description && (
+							<p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+								{item.description}
+							</p>
+						)}
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/web/src/hooks/use-insights-api.ts
+++ b/web/src/hooks/use-insights-api.ts
@@ -189,3 +189,19 @@ export function useApplyInsightSuggestions() {
     },
   });
 }
+
+export function useAgentRecommendedAdditions(agentId: string | undefined) {
+  return useQuery({
+    queryKey: ["insights", "recommended-additions", agentId],
+    queryFn: () => insights.recommendedAdditions(agentId!),
+    enabled: !!agentId,
+    // The offer is derived from the latest completed report and changes only
+    // when a new report lands. Cheap to cache.
+    staleTime: 5 * 60_000,
+    retry: (_count, err: unknown) => {
+      // 404 = no report / agent not visible; not a retryable error.
+      const status = (err as { status?: number })?.status;
+      return status !== 404;
+    },
+  });
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -52,6 +52,7 @@ import type {
 	InsightReportListItem,
 	InsightReport,
 	InsightAppliedItems,
+	RecommendedAdditionsResponse,
 	ExecAdoptionResponse,
 	ExecAgentCounts,
 	ExecUsageByCategory,
@@ -1070,6 +1071,8 @@ export const insights = {
 		a.click();
 		URL.revokeObjectURL(url);
 	},
+	recommendedAdditions: (agentId: string) =>
+		get<RecommendedAdditionsResponse>(`/agents/${agentId}/insights/recommended-additions`),
 };
 
 // ── Exec Dashboard ─────────────────────────────────────────────────

--- a/web/src/lib/types/admin.ts
+++ b/web/src/lib/types/admin.ts
@@ -317,6 +317,23 @@ export interface InsightAppliedItems {
 	prompts: { id: string; name: string; description: string; type: string }[];
 }
 
+export interface RecommendedAddition {
+	/** Component type singular ("skill", "hook", "mcp", "prompt", "sandbox"). */
+	type: string;
+	id: string;
+	qualified_name: string;
+	name: string;
+	description?: string | null;
+	category?: string | null;
+}
+
+export interface RecommendedAdditionsResponse {
+	agent_id: string;
+	items: RecommendedAddition[];
+	source_report_id: string | null;
+	generated_at: string | null;
+}
+
 // ── Telemetry ───────────────────────────────────────────────────────
 
 export interface TelemetryStatus {

--- a/web/src/pages/registry/agents/detail.tsx
+++ b/web/src/pages/registry/agents/detail.tsx
@@ -57,6 +57,7 @@ import type {
 } from "@/lib/types";
 import { PullCommand } from "@/components/registry/pull-command";
 import { RegistryName } from "@/components/registry/registry-name";
+import { AgentRecommendedAdditions } from "@/components/registry/agent-recommended-additions";
 import { registryIdentity, type QualifiedIdentity } from "@/lib/registry-name";
 import { VersionDropdown } from "@/components/registry/version-dropdown";
 import { StatusBadge } from "@/components/registry/status-badge";
@@ -951,6 +952,8 @@ export default function AgentDetailPage() {
                       No additional details provided for this agent.
                     </p>
                   )}
+
+                  <AgentRecommendedAdditions agentId={id} />
                 </TabsContent>
 
                 <TabsContent value="components" className="mt-6">


### PR DESCRIPTION
---

## Purpose / Description

The agent detail page and `observal pull` are **pure install today: zero recommendations**. A person browsing an agent gets no signal about what else they might benefit from. Meanwhile, the insights pipeline already computes a deterministic shortlist of registry components an agent doesn't use but might benefit from (`registry_offer`) — and as of #1660, that analysis is now persisted instead of discarded every run.

This PR adds the **first consumer** of that persisted analysis: a public endpoint and a "Recommended add-ons" rail on the agent detail page that surfaces evidence-backed component suggestions derived from observed usage.

## Fixes

* Fixes #<!-- replace with issue number, or remove this line if none -->

## Approach

**A new read-only public endpoint + a frontend rail. No migration, no pipeline change, no schema change to existing models — it reads #1660's `registry_offer` column.**

1. **`GET /api/v1/agents/{id}/insights/recommended-additions`** (public, `optional_current_user`) — loads the latest *completed* insight report for the agent and returns its `registry_offer` component shortlist as a flat list. Unlike the full insight report (edit-access-gated, exposes private session telemetry), this surface exposes **only public component references** — `type`, `id`, `qualified_name`, `name`, `description`, `category` — so it is safe for anyone who can see the agent, including anonymous browsing. Agent visibility is checked via `check_listing_visibility_async`; the offer entries are public registry components by construction (the recommender only returns approved+visible listings).
2. **`AgentRecommendedAdditions` rail component** — renders the shortlist on the agent detail Overview tab, reusing the visual pattern from the existing `RecommendedForYou` rail (type badge, name link to component detail, description).
3. **Degrades cleanly to nothing.** Empty `items` when: no report exists for the agent, the report predates the `registry_offer` column (null, from #1660's no-backfill design), the offer was empty, or the feature was disabled at generation time. The rail returns `null` on empty/error/loading — an empty rail is worse than no rail — so agents without reports look exactly as before.

This is deliberately the cheapest, highest-value first consumer of the persisted analysis: it delivers a feature that didn't exist anywhere in the product, it reuses already-spent compute, and it validates the "persist the analysis, then let consumers read it" pattern with a real reader.

## How Has This Been Tested?

`make test` — 122 tests pass on this branch (new + existing insights, agent-scoped routes, access, registry-match, self-learn, retention).

New tests in `tests/test_agent_recommended_additions.py` (6):
- Offer entries returned correctly (type, id, qualified_name, name, with `source_report_id` + `generated_at`)
- Empty when no report exists
- Empty when `registry_offer` is null (old reports predate the column)
- Empty when the feature was disabled at generation time (`enabled=False`)
- 404 when the agent is not visible to the caller
- Malformed entries in the persisted offer are skipped, not fatal

Reproduce with:
```
cd observal-server && uv run --with pytest --with pytest-asyncio --with pyyaml --with typer --with rich --with hypothesis --with pyarrow pytest ../tests/test_agent_recommended_additions.py -q
```

Frontend: `tsc --noEmit` (typecheck), `eslint`, and full `vite build` all pass clean. The rail renders nothing when there's no data, so the agent detail page is unchanged for agents without insight reports.

`make lint` clean.

## Learning

This PR is the payoff for #1660's "persist the discarded analysis" change. #1660 stopped throwing away `version_impact` and `registry_offer` every run but shipped no consumer — this is the first reader, proving a feature can use that analysis without touching the pipeline. The key design decision was keeping the endpoint *narrow*: it returns only the public component shortlist, never the report's narrative or metrics, which lets it be public (anyone browsing) rather than edit-access-gated like the full insight report. The "render nothing on empty" pattern (borrowed from the existing `RecommendedForYou` rail) is what makes uneven report coverage acceptable — the rail fills in as reports accumulate rather than looking broken on agents without them.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars). — `feat: evidence-backed add-ons on agent detail` (45 chars)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evidence-backed recommended registry components to agent detail pages.
  * Recommendations display as linked cards with component type, category, name, and description.
  * Insight reports now expose version impact, registry offers, and self-learning status.
* **Bug Fixes**
  * Invalid or unavailable recommendations are safely omitted.
  * Malformed insight data no longer prevents reports from being saved.
* **Validation**
  * Added structured validation for insight analysis data and recommendation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->