### PR TITLE
fix(init): only stamp alembic HEAD on a genuinely fresh database

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,10 +24,40 @@ asyncio.run(init())
 "
 
 echo "Running database migrations..."
-/app/.venv/bin/python -m alembic upgrade head || {
-    echo "Fresh database detected: stamping current schema version..."
-    /app/.venv/bin/python -m alembic stamp head
-}
+if ! /app/.venv/bin/python -m alembic upgrade head; then
+    # Only stamp on a genuinely fresh database: one with no recorded alembic
+    # revision. A failure on a DB that already has an alembic_version row means
+    # a real migration problem (e.g. DuplicateTableError from a partial run),
+    # and stamping HEAD would silently skip the missing migrations.
+    DB_STATE=$(/app/.venv/bin/python -c "
+import asyncio
+from sqlalchemy import text
+from database import engine
+
+async def check():
+    async with engine.connect() as conn:
+        has_table = await conn.scalar(
+            text(\"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'alembic_version')\")
+        )
+        if not has_table:
+            return 'fresh'
+        rev = await conn.scalar(text('SELECT version_num FROM alembic_version LIMIT 1'))
+        return 'fresh' if not rev else 'existing'
+
+try:
+    print(asyncio.run(check()))
+finally:
+    asyncio.run(engine.dispose())
+")
+    if [ "$DB_STATE" = "fresh" ]; then
+        echo "Fresh database detected: stamping current schema version..."
+        /app/.venv/bin/python -m alembic stamp head
+    else
+        echo "ERROR: alembic upgrade failed on an existing database (revision present)."
+        echo "Refusing to stamp HEAD; resolve the failing migration manually."
+        exit 1
+    fi
+fi
 
 echo "Running ClickHouse migrations..."
 /app/.venv/bin/python -m services.clickhouse.migrations


### PR DESCRIPTION
## Purpose / Description

The `observal-init` container stamps the alembic version to HEAD whenever `alembic upgrade head` fails. This was intended as a "fresh database" shortcut, but the detection was wrong: it fired on **any** migration failure, including `DuplicateTableError` / `DuplicateObjectError` on an existing database.

When that happened, HEAD got stamped without running the intermediate migrations. The schema was left inconsistent: alembic reported `(head)` while tables/columns from the skipped migrations were missing. This caused the Components API to return 500 and required manual `alembic stamp` + `alembic upgrade head` recovery.

This has bitten us on three separate `docker compose pull && docker compose up -d` upgrades (v1.9.2 on 2026-07-02, and again on 2026-08-03 where migrations `017_teams` through `022_user_recommendations` were stamped without running).

## Fixes

No issue tracker link; reported directly from a production incident. Prod did not break, only needed light fixup.

## Approach

In `docker/entrypoint.sh`, the unconditional fallback:

```bash
/app/.venv/bin/python -m alembic upgrade head || {
    /app/.venv/bin/python -m alembic stamp head
}
```

is replaced with a guarded fallback. On upgrade failure, the container queries `alembic_version`:

- **No `alembic_version` table, or no row** → genuinely fresh database → stamp HEAD (the legitimate fresh-install path, since `Base.metadata.create_all` already built the current schema).
- **A revision is already recorded** → existing database with a real migration problem → exit non-zero with a clear error message. Nothing is stamped.

This keeps the fresh-install path working (create_all + stamp HEAD) while making partial/duplicate migration failures fail loudly instead of silently corrupting the schema.

The fresh-database signal is now "no recorded alembic revision", which is what a fresh DB actually looks like, rather than "a migration raised an exception", which is not.

## How Has This Been Tested?

- `bash -n docker/entrypoint.sh` validates shell syntax.
- The embedded Python check snippet was compiled (`compile(src, ..., 'exec')`) to validate its syntax.
- Verified the two branches by reasoning over the reported incidents:
  - Fresh install: `alembic_version` has no row → `DB_STATE=fresh` → stamp HEAD. Unchanged behavior.
  - Existing DB at revision `016` where `017_teams` hits `DuplicateTableError`: `alembic_version` has a row (`016...`) → `DB_STATE=existing` → exit 1, HEAD not stamped.
- No automated test added because this is shell orchestration around external `alembic` calls and a live Postgres; reproducing needs the Docker stack. Existing migration tests are unaffected (they do not exercise `entrypoint.sh`).

Manual reproduction against a running stack, if desired:

```bash
# Simulate a partial migration on an existing DB:
docker compose exec -T observal-api /app/.venv/bin/python -m alembic stamp 016_registry_publish_loop
# Make 017 fail by pre-creating teams, then restart init:
docker compose restart observal-init
# Before fix: init logs "Fresh database detected" and stamps head (BAD).
# After fix: init logs ERROR and exits non-zero (GOOD).
```

## Learning

The root cause was a flawed "fresh database" heuristic: using a migration **failure** as the signal for a fresh DB. A fresh DB is better detected by the absence of an `alembic_version` row. `DuplicateTableError` / `DuplicateObjectError` mean the opposite of fresh, they mean objects already exist, which is an existing DB with a stuck migration.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - N/A: no UI changes, init container shell script only.

## AI Assistance

- [x] Yes (Please Specify the tool): Pi coding agent (Claude).
- [x] Was the generated code manually reviewed and tested?
  - Reviewed; shell and embedded Python syntax validated. Live-stack reproduction not run in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database upgrade recovery by distinguishing fresh databases from existing databases.
  * Fresh databases are initialized at the current schema version when setup encounters an upgrade issue.
  * Existing databases with migration errors now retain the failure for manual resolution instead of being marked as fully up to date.
  * Prevented migration issues from being hidden by automatically applying the latest schema marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->