### PR TITLE
fix(cli): avoid duplicate Observal skills in Pi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 SrihariLegend <sriharilegend23@gmail.com> -->
 <!-- SPDX-FileCopyrightText: 2026 DoomsCoder <vedantkakade05@gmail.com> -->
+<!-- SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Changelog
@@ -83,6 +84,7 @@ All notable changes to this project will be documented in this file.
 - move the inbox filter rail to the right
 - require explicit Kiro session identity and keep aged recovery non-final
 - keep intentional CLI downgrades pinned when targeting legacy releases ([#1672](https://github.com/Observal/Observal/pull/1672))
+- avoid duplicate bundled Observal skill conflicts when Codex and Pi are installed together ([#1601](https://github.com/Observal/Observal/issues/1601))
 
 ## [1.11.0] - 2026-08-02
 

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
 # SPDX-FileCopyrightText: 2026 Vishnu Muthiah <vishnu.muthiah04@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """observal doctor: diagnose and patch harness settings for Observal session telemetry.
@@ -230,31 +231,9 @@ def doctor(
 
 def _check_observal_skill_missing() -> list[str]:
     """Return list of harness display names where the observal skill is not installed."""
-    from observal_shared.harness_registry import HARNESS_REGISTRY
+    from observal_cli.skill_installer import missing_observal_skill_harnesses
 
-    skill_source = Path(__file__).parent / "skills" / "observal" / "SKILL.md"
-    if not skill_source.exists():
-        return []
-
-    _extra_user_paths: dict[str, str] = {"kiro": "~/.kiro/skills/{name}/SKILL.md"}
-    missing: list[str] = []
-
-    for harness, spec in HARNESS_REGISTRY.items():
-        skill_spec = spec.get("skills") or {}
-        user_path = skill_spec.get("user") or _extra_user_paths.get(harness)
-        if not user_path:
-            continue
-
-        resolved = user_path.replace("{name}", "observal")
-        dest = Path(resolved.replace("~", str(Path.home())))
-        ide_config_dir = Path.home() / spec.get("config_dir", "")
-        if not ide_config_dir.exists():
-            continue
-
-        if not dest.exists():
-            missing.append(spec["display_name"])
-
-    return missing
+    return missing_observal_skill_harnesses()
 
 
 def _check_observal_config(issues: list, warnings: list):

--- a/observal_cli/harness/__init__.py
+++ b/observal_cli/harness/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """CLI-side harness adapter protocol, registry, and orchestrator.
@@ -12,6 +13,7 @@ from __future__ import annotations
 
 from observal_cli.harness.protocol import (
     METHOD_FEATURE_MAP,
+    BundledSkillPlan,
     DiscoveredAgent,
     DiscoveredHook,
     DiscoveredMcp,
@@ -26,6 +28,7 @@ from observal_shared.harness_registry import HARNESS_REGISTRY
 
 __all__ = [
     "METHOD_FEATURE_MAP",
+    "BundledSkillPlan",
     "DiscoveredAgent",
     "DiscoveredHook",
     "DiscoveredMcp",
@@ -56,6 +59,7 @@ def register_adapter(adapter: HarnessAdapter) -> None:
         "harness_name",
         "scan_home",
         "is_installed",
+        "plan_bundled_skill_install",
         "scan_project",
         "get_hook_spec",
         "generate_hook_config",

--- a/observal_cli/harness/base.py
+++ b/observal_cli/harness/base.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """Base adapter with feature-flag gating from harness_Registry.
@@ -15,6 +16,7 @@ from typing import Any
 
 from observal_cli.harness.protocol import (
     METHOD_FEATURE_MAP,
+    BundledSkillPlan,
     HookSpec,
     NotSupportedError,
     ScanResult,
@@ -101,6 +103,22 @@ class BaseAdapter:
             elif (home / marker).exists():
                 return True
         return False
+
+    def plan_bundled_skill_install(
+        self,
+        skill_name: str,
+        home: Path,
+        installed_harnesses: frozenset[str],
+    ) -> BundledSkillPlan | None:
+        """Plan the registry-defined user-scope skill destination."""
+        from observal_shared.harness_registry import HARNESS_REGISTRY
+
+        user_path = (HARNESS_REGISTRY[self.harness_name].get("skills") or {}).get("user")
+        if not user_path:
+            return None
+        resolved = user_path.replace("{name}", skill_name)
+        target = home / resolved[2:] if resolved.startswith("~/") else Path(resolved)
+        return BundledSkillPlan(target=target)
 
     def resolve_session_source(self, event: dict[str, Any], home: Path | None = None) -> SessionSource | None:
         """Resolve a hook payload to a session source when the harness supports it."""

--- a/observal_cli/harness/pi.py
+++ b/observal_cli/harness/pi.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """Pi harness adapter for scanning and hook detection."""
@@ -9,6 +10,7 @@ import json
 from pathlib import Path
 
 from observal_cli.harness import (
+    BundledSkillPlan,
     DiscoveredMcp,
     DiscoveredSkill,
     HookSpec,
@@ -27,13 +29,28 @@ class PiAdapter(BaseAdapter):
     Hooks are delivered as the observal-pi package.
     """
 
-    home_markers = (".pi/agent",)
+    home_markers = (".pi",)
     managed_agent_profiles = ("user:AGENTS.md",)
     managed_skills = ("user:skills/{name}/SKILL.md",)
 
     @property
     def harness_name(self) -> str:
         return "pi"
+
+    def plan_bundled_skill_install(
+        self,
+        skill_name: str,
+        home: Path,
+        installed_harnesses: frozenset[str],
+    ) -> BundledSkillPlan:
+        """Share bundled skills with Codex instead of creating Pi duplicates."""
+        native = home / ".pi" / "agent" / "skills" / skill_name / "SKILL.md"
+        shared = home / ".agents" / "skills" / skill_name / "SKILL.md"
+        return BundledSkillPlan(
+            target=shared if "codex" in installed_harnesses else native,
+            reuse_candidates=(shared,),
+            cleanup_candidates=(native,),
+        )
 
     # ── Scanning ──────────────────────────────────────────────
 

--- a/observal_cli/harness/protocol.py
+++ b/observal_cli/harness/protocol.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """harness adapter protocol definition.
@@ -126,6 +127,15 @@ class HookSpec:
 
 
 @dataclass(frozen=True)
+class BundledSkillPlan:
+    """Destination and safe reuse or cleanup candidates for one bundled skill."""
+
+    target: Path
+    reuse_candidates: tuple[Path, ...] = ()
+    cleanup_candidates: tuple[Path, ...] = ()
+
+
+@dataclass(frozen=True)
 class SessionSource:
     """A harness session source resolved from a hook or recent-session scan."""
 
@@ -187,6 +197,15 @@ class HarnessAdapter(Protocol):
         Args:
             home: Override home directory (defaults to Path.home()).
         """
+        ...
+
+    def plan_bundled_skill_install(
+        self,
+        skill_name: str,
+        home: Path,
+        installed_harnesses: frozenset[str],
+    ) -> BundledSkillPlan | None:
+        """Return the destination and migration paths for one bundled skill."""
         ...
 
     def scan_project(self, project_dir: Path) -> ScanResult:

--- a/observal_cli/skill_installer.py
+++ b/observal_cli/skill_installer.py
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2026 Kaushik Kumar <kaushikrjpm10@gmail.com>
 # SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com>
 # SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """Install and synchronize the bundled Observal skills."""
@@ -15,9 +16,14 @@ import os
 import shutil
 import stat
 import tempfile
+from dataclasses import replace
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from rich import print as rprint
+
+if TYPE_CHECKING:
+    from observal_cli.harness import BundledSkillPlan
 
 _SKILL_DIRS = (
     "observal",
@@ -120,48 +126,148 @@ def _bundled_sources() -> dict[str, Path]:
     return sources
 
 
-def _user_harness_dir(user_path: str) -> Path:
-    target = Path(user_path.replace("{name}", "observal").replace("~", str(Path.home())))
-    return next((parent.parent for parent in target.parents if parent.name == "skills"), target.parent)
+def _skills_match(source_dir: Path, skill_file: Path) -> bool:
+    try:
+        source_hash = _directory_hash(source_dir)
+        return source_hash is not None and source_hash == _directory_hash(skill_file.parent)
+    except OSError:
+        return False
+
+
+def _is_unchanged_bundled_copy(source_dir: Path, skill_file: Path) -> bool:
+    """Return whether an older, possibly partial bundle is safe to remove."""
+    candidate_dir = skill_file.parent
+    if not skill_file.is_file() or not candidate_dir.is_dir() or candidate_dir.is_symlink():
+        return False
+    try:
+        for candidate in candidate_dir.rglob("*"):
+            source = source_dir / candidate.relative_to(candidate_dir)
+            if candidate.is_symlink():
+                if not source.is_symlink() or os.readlink(candidate) != os.readlink(source):
+                    return False
+            elif candidate.is_dir():
+                if not source.is_dir() or source.is_symlink():
+                    return False
+            elif candidate.is_file():
+                if not source.is_file() or candidate.read_bytes() != source.read_bytes():
+                    return False
+            else:
+                return False
+    except OSError:
+        return False
+    return True
+
+
+def _installation_plans(home: Path) -> dict[str, dict[str, BundledSkillPlan]]:
+    """Return bundled skill plans for installed harnesses in registry order."""
+    from observal_cli.harness import ensure_loaded, get_all_adapters
+    from observal_shared.harness_registry import HARNESS_REGISTRY
+
+    ensure_loaded()
+    registered = get_all_adapters()
+    adapters = {name: registered[name] for name in HARNESS_REGISTRY if name in registered}
+    installed = frozenset(name for name, adapter in adapters.items() if adapter.is_installed(home))
+    sources = _bundled_sources()
+    plans: dict[str, dict[str, BundledSkillPlan]] = {}
+
+    for harness_name, adapter in adapters.items():
+        if harness_name not in installed:
+            continue
+        harness_plans: dict[str, BundledSkillPlan] = {}
+        for skill_name, source_dir in sources.items():
+            plan = adapter.plan_bundled_skill_install(skill_name, home, installed)
+            if plan is None:
+                continue
+            reusable = next(
+                (candidate for candidate in plan.reuse_candidates if _is_unchanged_bundled_copy(source_dir, candidate)),
+                None,
+            )
+            harness_plans[skill_name] = replace(plan, target=reusable) if reusable else plan
+        if harness_plans:
+            plans[harness_name] = harness_plans
+    return plans
+
+
+def _should_sync(source_dir: Path, plan: BundledSkillPlan, install_missing: bool) -> bool:
+    return (
+        install_missing
+        or plan.target.parent.exists()
+        or plan.target.parent.is_symlink()
+        or any(_is_unchanged_bundled_copy(source_dir, candidate) for candidate in plan.cleanup_candidates)
+    )
+
+
+def _reconcile_observal_skills(home: Path, *, install_missing: bool) -> tuple[list[str], list[str]]:
+    """Synchronize planned destinations and safely remove obsolete duplicates."""
+    sources = _bundled_sources()
+    plans = _installation_plans(home)
+    selected = {
+        harness_name: harness_plans
+        for harness_name, harness_plans in plans.items()
+        if any(_should_sync(sources[name], plan, install_missing) for name, plan in harness_plans.items())
+    }
+    targets: dict[Path, Path] = {}
+    cleanups: set[tuple[Path, Path, Path]] = set()
+    warnings: list[str] = []
+
+    for harness_plans in selected.values():
+        for skill_name, plan in harness_plans.items():
+            source_dir = sources[skill_name]
+            targets[plan.target] = source_dir
+            cleanups.update((candidate, source_dir, plan.target) for candidate in plan.cleanup_candidates)
+
+    for target, source_dir in targets.items():
+        _sync_skill_directory(source_dir, target)
+
+    antigravity_plans = selected.get("antigravity", {})
+    for skill_name, plan in antigravity_plans.items():
+        _remove_antigravity_legacy_files(sources[skill_name], plan.target)
+
+    for candidate, source_dir, target in sorted(cleanups, key=lambda item: str(item[0])):
+        if candidate == target or not (candidate.parent.exists() or candidate.parent.is_symlink()):
+            continue
+        if not _skills_match(source_dir, target):
+            warnings.append(f"Preserved {candidate}: replacement at {target} is unavailable or differs.")
+            continue
+        if not _is_unchanged_bundled_copy(source_dir, candidate):
+            warnings.append(f"Preserved divergent bundled skill copy at {candidate}; review it manually.")
+            continue
+        _remove_path(candidate.parent)
+
+    installed = [
+        harness_name
+        for harness_name, harness_plans in selected.items()
+        if all(_skills_match(sources[name], plan.target) for name, plan in harness_plans.items())
+    ]
+    return installed, warnings
+
+
+def missing_observal_skill_harnesses(home: Path | None = None) -> list[str]:
+    """Return display names for installed harnesses missing the core bundled skill."""
+    from observal_shared.harness_registry import HARNESS_REGISTRY
+
+    return [
+        HARNESS_REGISTRY[harness_name]["display_name"]
+        for harness_name, plans in _installation_plans(home or Path.home()).items()
+        if (core_plan := plans.get("observal")) is not None and not core_plan.target.is_file()
+    ]
 
 
 def sync_observal_skills(*, install_missing: bool = False) -> list[str]:
     """Synchronize installed skill bundles for every detected harness."""
     from observal_shared.harness_registry import HARNESS_REGISTRY
 
-    sources = _bundled_sources()
-    detected: list[str] = []
-    for harness, spec in HARNESS_REGISTRY.items():
-        user_path = (spec.get("skills") or {}).get("user")
-        if not user_path:
-            continue
-        config_dir = Path.home() / spec.get("config_dir", "")
-        if not config_dir.exists() and not _user_harness_dir(user_path).exists():
-            continue
-        targets = {name: Path(user_path.replace("{name}", name).replace("~", str(Path.home()))) for name in sources}
-        has_bundle = any(
-            skill_file.parent.exists() or skill_file.parent.is_symlink() for skill_file in targets.values()
-        )
-        if harness == "antigravity":
-            has_bundle = has_bundle or any(
-                (skill_file.parent.parent / f"{name}.md").is_file() for name, skill_file in targets.items()
-            )
-        if not install_missing and not has_bundle:
-            continue
-        for name, source_dir in sources.items():
-            skill_file = targets[name]
-            _sync_skill_directory(source_dir, skill_file)
-            if harness == "antigravity":
-                _remove_antigravity_legacy_files(source_dir, skill_file)
-        detected.append(spec["display_name"])
-    return detected
+    installed, _warnings = _reconcile_observal_skills(Path.home(), install_missing=install_missing)
+    return [HARNESS_REGISTRY[name]["display_name"] for name in installed]
 
 
 def install_observal_skill() -> None:
     """Install current bundled skills to every detected harness."""
     import json as _json
 
-    installed = sync_observal_skills(install_missing=True)
+    from observal_shared.harness_registry import HARNESS_REGISTRY
+
+    installed, warnings = _reconcile_observal_skills(Path.home(), install_missing=True)
 
     # Kiro-specific: ensure the active agent has skill resources wired up.
     _kiro_skill_resource = "skill://~/.kiro/skills/*/SKILL.md"
@@ -183,5 +289,8 @@ def install_observal_skill() -> None:
             pass
 
     if installed:
-        rprint(f"\n[green]✓ Observal skills synchronized for:[/green] {', '.join(installed)}")
+        display_names = [HARNESS_REGISTRY[name]["display_name"] for name in installed]
+        rprint(f"\n[green]✓ Observal skills synchronized for:[/green] {', '.join(display_names)}")
         rprint('[dim]  LLMs can now use Observal commands directly (for example, "create a PR agent for kiro")[/dim]')
+    for warning in warnings:
+        rprint(f"[yellow]Warning:[/yellow] {warning}")

--- a/tests/test_cli_doctor_commands.py
+++ b/tests/test_cli_doctor_commands.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 0xSHSH <156781261+0xSHSH@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """Behavioral coverage for the doctor CLI commands and untested state branches."""
@@ -212,7 +213,11 @@ class TestConfigAndSkillDiagnosis:
         (tmp_path / ".kiro").mkdir()
         registry = {
             "unsupported": {"display_name": "Unsupported", "config_dir": ".unsupported", "skills": {}},
-            "kiro": {"display_name": "Kiro", "config_dir": ".kiro", "skills": {}},
+            "kiro": {
+                "display_name": "Kiro",
+                "config_dir": ".kiro",
+                "skills": {"user": "~/.kiro/skills/{name}/SKILL.md"},
+            },
             "absent": {
                 "display_name": "Absent",
                 "config_dir": ".absent",

--- a/tests/test_cli_harness_adapters.py
+++ b/tests/test_cli_harness_adapters.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the CLI-side harness adapter protocol and registry."""
@@ -54,6 +55,7 @@ class TestAdapterRegistry:
         required_methods = [
             "scan_home",
             "is_installed",
+            "plan_bundled_skill_install",
             "scan_project",
             "get_hook_spec",
             "generate_hook_config",
@@ -85,6 +87,18 @@ class TestAdapterRegistry:
         assert adapter.is_session_final({"hook_event_name": "Stop"})
         assert adapter.is_session_final({"event": "sessionEnd"})
         assert not adapter.is_session_final({"hook_event_name": "UserPromptSubmit"})
+
+    def test_pi_shares_bundled_skills_with_codex(self, tmp_path):
+        plan = get_adapter("pi").plan_bundled_skill_install("observal", tmp_path, frozenset({"codex", "pi"}))
+
+        assert plan.target == tmp_path / ".agents/skills/observal/SKILL.md"
+        assert plan.cleanup_candidates == (tmp_path / ".pi/agent/skills/observal/SKILL.md",)
+
+    def test_pi_uses_native_bundled_skills_when_isolated(self, tmp_path):
+        plan = get_adapter("pi").plan_bundled_skill_install("observal", tmp_path, frozenset({"pi"}))
+
+        assert plan.target == tmp_path / ".pi/agent/skills/observal/SKILL.md"
+        assert plan.reuse_candidates == (tmp_path / ".agents/skills/observal/SKILL.md",)
 
 
 class TestManagedLayerFiles:

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Annie Chiang <anniechiang.yn@gmail.com>
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for observal_cli.cmd_doctor helpers."""
@@ -7,15 +8,13 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 import typer
 from typer.testing import CliRunner
 
-if TYPE_CHECKING:
-    from pathlib import Path
 from observal_cli.cmd_doctor import (
     _check_antigravity,
     _check_claude_code,
@@ -261,6 +260,19 @@ class TestChecks:
         missing = _check_observal_skill_missing()
 
         assert "Pi" in missing
+
+    def test_shared_observal_skill_satisfies_codex_and_pi(self, tmp_path: Path):
+        (tmp_path / ".codex").mkdir()
+        (tmp_path / ".pi").mkdir()
+        source = Path(__file__).parents[1] / "observal_cli/skills/observal/SKILL.md"
+        shared = tmp_path / ".agents/skills/observal/SKILL.md"
+        shared.parent.mkdir(parents=True)
+        shared.write_bytes(source.read_bytes())
+
+        missing = _check_observal_skill_missing()
+
+        assert "Codex" not in missing
+        assert "Pi" not in missing
 
 
 class TestPatchFunctions:

--- a/tests/test_skill_installer_sync.py
+++ b/tests/test_skill_installer_sync.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Observal Contributors
+# SPDX-FileCopyrightText: 2026 EuanTop <euan@mail.bnu.edu.cn>
 # SPDX-License-Identifier: Apache-2.0
 
 """Hash-based synchronization coverage for bundled Observal skills."""
@@ -9,12 +10,11 @@ import json
 import shutil
 from typing import TYPE_CHECKING
 
+import pytest
 from typer.testing import CliRunner
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 from observal_cli import skill_installer
 from observal_shared.harness_registry import HARNESS_REGISTRY
@@ -109,6 +109,120 @@ def test_every_detected_harness_syncs_all_skill_trees_and_migrates_antigravity(
     drift.write_text("stale", encoding="utf-8")
     skill_installer.sync_observal_skills()
     assert not drift.exists()
+
+
+def _use_test_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    bundled = tmp_path / "bundled"
+    for name in skill_installer._SKILL_DIRS:
+        _write_skill(bundled, name)
+    monkeypatch.setattr(skill_installer, "_SKILLS_BASE", bundled)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return bundled
+
+
+def test_pi_only_installs_native_bundled_skills(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bundled = _use_test_bundle(tmp_path, monkeypatch)
+    (tmp_path / ".pi").mkdir()
+
+    skill_installer.install_observal_skill()
+
+    for name in skill_installer._SKILL_DIRS:
+        assert skill_installer._directory_hash(tmp_path / ".pi/agent/skills" / name) == skill_installer._directory_hash(
+            bundled / name
+        )
+        assert not (tmp_path / ".agents/skills" / name).exists()
+
+
+def test_codex_only_installs_shared_skills_without_antigravity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bundled = _use_test_bundle(tmp_path, monkeypatch)
+    (tmp_path / ".codex").mkdir()
+
+    skill_installer.install_observal_skill()
+
+    for name in skill_installer._SKILL_DIRS:
+        assert skill_installer._directory_hash(tmp_path / ".agents/skills" / name) == skill_installer._directory_hash(
+            bundled / name
+        )
+    assert not (tmp_path / ".pi/agent/skills").exists()
+    assert not (tmp_path / ".gemini/antigravity-cli").exists()
+
+
+def test_codex_and_pi_share_skills_and_remove_matching_native_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bundled = _use_test_bundle(tmp_path, monkeypatch)
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".pi").mkdir()
+    native = tmp_path / ".pi/agent/skills/observal/SKILL.md"
+    native.parent.mkdir(parents=True)
+    native.write_bytes((bundled / "observal/SKILL.md").read_bytes())
+
+    skill_installer.install_observal_skill()
+    shared_inode = (tmp_path / ".agents/skills/observal").stat().st_ino
+    skill_installer.install_observal_skill()
+
+    assert (tmp_path / ".agents/skills/observal").stat().st_ino == shared_inode
+    for name in skill_installer._SKILL_DIRS:
+        assert skill_installer._directory_hash(tmp_path / ".agents/skills" / name) == skill_installer._directory_hash(
+            bundled / name
+        )
+        assert not (tmp_path / ".pi/agent/skills" / name).exists()
+
+
+def test_pi_reuses_an_existing_shared_copy_without_codex(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bundled = _use_test_bundle(tmp_path, monkeypatch)
+    (tmp_path / ".pi").mkdir()
+    shared = tmp_path / ".agents/skills/observal/SKILL.md"
+    shared.parent.mkdir(parents=True)
+    shared.write_bytes((bundled / "observal/SKILL.md").read_bytes())
+
+    skill_installer.install_observal_skill()
+
+    assert skill_installer._directory_hash(shared.parent) == skill_installer._directory_hash(bundled / "observal")
+    assert not (tmp_path / ".pi/agent/skills/observal").exists()
+
+
+def test_divergent_native_copy_and_unrelated_skill_are_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    _use_test_bundle(tmp_path, monkeypatch)
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".pi").mkdir()
+    native = tmp_path / ".pi/agent/skills/observal/SKILL.md"
+    native.parent.mkdir(parents=True)
+    native.write_text("user customization", encoding="utf-8")
+    unrelated = tmp_path / ".pi/agent/skills/custom/SKILL.md"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("custom skill", encoding="utf-8")
+
+    skill_installer.install_observal_skill()
+
+    assert native.read_text(encoding="utf-8") == "user customization"
+    assert unrelated.read_text(encoding="utf-8") == "custom skill"
+    output = capsys.readouterr().out
+    assert "Preserved divergent bundled skill copy" in output
+    assert str(native) in "".join(output.split())
+
+
+def test_failed_shared_sync_keeps_matching_native_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bundled = _use_test_bundle(tmp_path, monkeypatch)
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".pi").mkdir()
+    native = tmp_path / ".pi/agent/skills/observal/SKILL.md"
+    native.parent.mkdir(parents=True)
+    native.write_bytes((bundled / "observal/SKILL.md").read_bytes())
+    shared_dir = tmp_path / ".agents/skills/observal"
+    original_replace = skill_installer._replace_directory
+
+    def fail_shared_sync(source: Path, target: Path) -> None:
+        if target == shared_dir:
+            raise OSError("permission denied")
+        original_replace(source, target)
+
+    monkeypatch.setattr(skill_installer, "_replace_directory", fail_shared_sync)
+
+    with pytest.raises(OSError, match="permission denied"):
+        skill_installer.install_observal_skill()
+
+    assert native.is_file()
 
 
 def test_startup_sync_does_not_install_into_an_unmanaged_harness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Purpose / Description

When Codex and Pi are installed together, Observal installs the same bundled skill family into both `~/.agents/skills` and `~/.pi/agent/skills`. Pi discovers both locations and reports a collision for every Observal skill, even though the copies are identical.

This change lets harness adapters describe where bundled skills belong while keeping detection, reconciliation, full-directory synchronization, cleanup, and reporting in the generic installer.

## Fixes

* Fixes #1601

## Approach

- Add one harness-owned `BundledSkillPlan` contract for the target, reusable copies, and cleanup candidates.
- Keep Pi-native bundled skills for isolated Pi installations, but reuse `~/.agents/skills` when Codex is installed or an identical shared copy already exists.
- Synchronize the complete skill directory before removing any duplicate.
- Remove old Pi-native copies only when every existing file matches the bundled source, including older partial installations that contain only `SKILL.md`.
- Preserve divergent, user-edited, and unrelated Pi skills and report divergent managed copies clearly.
- Keep installation idempotent by hashing complete skill directories before replacement.
- Make `observal doctor` resolve the same adapter plans as the installer.

## How Has This Been Tested?

- `uv run pytest tests/test_skill_installer_sync.py tests/test_cmd_doctor.py tests/test_cli_doctor_commands.py tests/test_cli_harness_adapters.py tests/test_observal_skill.py -q` (`242 passed`)
- `make lint` (passed)
- `uv run ruff format --check .` (`705 files already formatted`)
- `make test` (`8514 passed, 21 skipped`)
- `SKIP=no-commit-to-branch uvx --from pre-commit pre-commit run --files $(git diff --name-only upstream/main...HEAD)` (all applicable hooks passed)
- `git diff --check upstream/main...HEAD` (passed)

`make check` against every repository file still reports existing all-file findings outside this change: end-of-file fixes in `.coderabbit.yaml` and `tests/fixtures/fake_api_keys.json`, the intentional fake private key fixture, and existing Dockerfile hadolint findings. The hook-created unrelated edits were restored.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: not applicable; this is a CLI-only change

## AI Assistance

- [x] Yes (OpenAI Codex and Pi coding agent 0.84.1)
- [x] The generated code was manually reviewed and tested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate bundled Observal skills when Codex and Pi are installed together.
  * Shared compatible skill copies are now reused, while obsolete duplicates are cleaned up safely.
  * Divergent or unavailable replacements are preserved with warnings.
  * Doctor checks now correctly recognize shared skills across supported harnesses.

* **Improvements**
  * Bundled skills are installed in harness-appropriate locations, including shared storage where applicable.
  * Installation results now include clearer success and warning information.
  * Updated Pi home-directory detection improves setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->