### PR TITLE
feat(goose): add Goose as a first-class harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Agents are the primary entity. Each agent bundles 5 component types: MCP servers
 
 ## harness capability support
 
-Nine harnesses are registered in `packages/observal-shared/observal_shared/harness_registry.py`. Support is per-capability, not a single tier. Verify against the registry before relying on this table.
+Ten harnesses are registered in `packages/observal-shared/observal_shared/harness_registry.py`. Support is per-capability, not a single tier. Verify against the registry before relying on this table.
 
 | Harness | Hook spec | Session parser | Capabilities | Harness-specific e2e |
 |---|---|---|---|---|
@@ -32,8 +32,9 @@ Nine harnesses are registered in `packages/observal-shared/observal_shared/harne
 | Copilot CLI | yes | `copilot-cli` | hooks, mcp_servers, skills, prompts | no |
 | OpenCode | yes | `opencode` | hooks, mcp_servers, skills | no |
 | Antigravity | yes | `antigravity` | hooks, mcp_servers, skills | no |
+| Goose | yes | `goose` | hooks, mcp_servers, skills | no |
 
-Every harness now resolves a session parser, so `observal reconcile` works across all nine. Hook specs in `observal_cli/harness_specs/` exist for seven; Cursor and Pi have none. Only Kiro has harness-specific Playwright coverage.
+Every harness now resolves a session parser, so `observal reconcile` works across all ten. Hook specs in `observal_cli/harness_specs/` exist for eight; Cursor and Pi have none. Only Kiro has harness-specific Playwright coverage.
 
 See `docs/adding-a-harness.md` for the complete guide to adding or promoting a harness.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ See `docs/adding-a-harness.md` for the complete guide to adding or promoting a h
 
 ```
 observal_cli/          Python CLI (Typer)
-  harness/             CLI-side harness adapters (protocol.py, base.py, 9 adapters)
-  harness_specs/       Hook specs (7: claude_code, kiro, codex, copilot, copilot_cli, opencode, antigravity)
+  harness/             CLI-side harness adapters (protocol.py, base.py, 10 adapters)
+  harness_specs/       Hook specs (8: claude_code, kiro, codex, copilot, copilot_cli, opencode, antigravity, goose)
   skills/              Bundled skills installed on login (observal, observal-admin, etc.)
 
 observal-server/       FastAPI server
@@ -54,7 +54,7 @@ observal-server/       FastAPI server
   services/            Business logic
     clickhouse/        ClickHouse subpackage (client, schema, insert, query)
     harness/           Server-side harness adapters (config generation)
-    session_parsers/   Per-harness JSONL parsers (8 modules covering all 9 harnesses)
+    session_parsers/   Per-harness JSONL parsers (9 modules covering all 10 harnesses)
     audit/             Compliance audit system (loguru-based)
     config/            Config generation helpers (mcp_builder, skill_builder)
     insights/          Insight engine (report generation, facets, sections, HTML export)
@@ -157,7 +157,7 @@ observal
 ├── admin                    # settings, set, users, review (list/show/approve/reject)
 ├── self                     # upgrade, downgrade, rollback, status
 │   └── uninstall            #   tear down Docker stack and config
-├── doctor                   # diagnose + patch harness settings for all 9 harnesses
+├── doctor                   # diagnose + patch harness settings for all 10 harnesses
 │   ├── patch / cleanup      #   install or remove telemetry hooks
 │   └── support              #   diagnostic bundle with redaction
 └── server                   # start, stop, restart, status, logs, install, reset, config

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Observal supports Claude Code, Cursor, Kiro, Pi, Copilot, Codex, OpenCode, and o
 | Codex |
 | OpenCode |
 | Antigravity CLI |
+| Goose |
 
 One command to install any agent into any supported harness. The config files are generated per-harness automatically.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -65,6 +65,7 @@
 
 * [Copilot](integrations/copilot.md)
 * [Cursor](integrations/cursor.md)
+* [Goose](integrations/goose.md)
 * [Kiro](integrations/kiro.md)
 * [OpenCode](integrations/opencode.md)
 

--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -18,7 +18,7 @@ observal agent pull <agent-reference> --harness <harness> [OPTIONS]
 | Argument / option | Description |
 | --- | --- |
 | `<agent-reference>` | Agent UUID, `namespace/slug`, unique bare name, `@alias`, or row number from last `agent list` |
-| `--harness <harness>` | Target harness: `cursor`, `kiro`, `claude-code`, `codex`, `copilot`, `copilot-cli`, `opencode`, `antigravity`, `pi` |
+| `--harness <harness>` | Target harness: `cursor`, `kiro`, `claude-code`, `codex`, `copilot`, `copilot-cli`, `opencode`, `antigravity`, `goose`, `pi` |
 
 ## Options
 

--- a/docs/cli/scan.md
+++ b/docs/cli/scan.md
@@ -19,7 +19,7 @@ observal scan [--harness <harness>]
 
 | Option | Description |
 | --- | --- |
-| `--harness <harness>` | Scope to one harness: `cursor`, `kiro`, `claude-code`, `codex`, `copilot`, `copilot-cli`, `opencode`, `antigravity`, `pi` |
+| `--harness <harness>` | Scope to one harness: `cursor`, `kiro`, `claude-code`, `codex`, `copilot`, `copilot-cli`, `opencode`, `antigravity`, `goose`, `pi` |
 
 If you run `observal scan` with no flags, it auto-detects every installed harness and scans each in turn.
 
@@ -31,6 +31,7 @@ If you run `observal scan` with no flags, it auto-detects every installed harnes
    * Cursor: `.cursor/mcp.json`
    * Copilot: `.vscode/mcp.json`
    * Antigravity: `.agents/mcp_config.json` or `~/.gemini/antigravity-cli/mcp_config.json`
+   * Goose: `~/.config/goose/config.yaml` (the `extensions` key)
    * Copilot CLI: `~/.copilot/mcp-config.json`
 2. Lists every MCP server found and its direct command or URL.
 3. Reports installed session telemetry hooks.

--- a/docs/integrations/goose.md
+++ b/docs/integrations/goose.md
@@ -1,0 +1,309 @@
+<!-- SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Goose
+
+[Goose](https://goose-docs.ai/) is a first-class Observal harness integration.
+Observal can install Goose custom agents, configure MCP extensions, expose
+skills, install a Goose hook plugin, and collect Goose session telemetry.
+
+Supported Goose versions: **1.10.0 and later** (the release that moved session
+storage to SQLite), verified against **goose 1.45.0**. Goose CLI and Goose
+Desktop share the same configuration, skills, agents, plugins, and session
+database, so a single install covers both.
+
+---
+
+## Overview
+
+Goose custom agents are Markdown files with YAML frontmatter. Project agents
+live in `.agents/agents/`, user agents in `~/.agents/agents/`.
+
+MCP servers are Goose *extensions*. Goose reads them from a single user-level
+`config.yaml`, so Observal merges its extensions into that file and leaves every
+other key — providers, models, global settings — untouched.
+
+Session telemetry uses a Goose hook plugin. `observal doctor patch --harness
+goose` writes `~/.agents/plugins/observal/`, containing a `plugin.json` manifest
+and a `hooks/hooks.json` file. The hooks run
+`observal_cli.hooks.session_push --harness goose`, which reads Goose's SQLite
+session store and pushes new records through Observal's shared acknowledged
+delivery pipeline.
+
+---
+
+## Supported capabilities
+
+| Capability | Support |
+|---|---|
+| Agent profiles | Project and user scope |
+| Hook bridge | Goose plugin (`hooks/hooks.json`) |
+| Hook events | `SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd` |
+| MCP servers | `extensions` in `~/.config/goose/config.yaml` |
+| MCP transports | `stdio` and `streamable_http` |
+| Agent prompt | Registry prompts are written into the generated Goose agent file |
+| Skills | `.agents/skills/{name}/SKILL.md` and `~/.agents/skills/{name}/SKILL.md` |
+| Session parsing | SQLite session store mirrored to JSONL |
+| Telemetry | Hook push plus `observal reconcile` |
+| Model selection | Registry-backed Goose model catalog |
+
+---
+
+## Setup
+
+### 1. Install the Observal CLI
+
+```bash
+uv tool install observal-cli
+# or: pipx install observal-cli
+```
+
+### 2. Authenticate
+
+```bash
+observal auth login
+```
+
+### 3. Pull an agent into Goose
+
+```bash
+observal agent pull <agent-name> --harness goose
+```
+
+Goose's default scope is user scope, so the agent is written to
+`~/.agents/agents/{name}.md`. To install into the current project:
+
+```bash
+observal agent pull <agent-name> --harness goose --scope project
+```
+
+MCP extensions are always written to `~/.config/goose/config.yaml`, because
+that is the only file Goose reads extensions from.
+
+### 4. Install or refresh the Goose hook plugin
+
+```bash
+observal doctor patch --harness goose
+```
+
+Restart your Goose session afterwards so the plugin is discovered.
+
+### 5. Check what is installed
+
+```bash
+observal scan --harness goose
+observal doctor
+```
+
+---
+
+## Config paths
+
+| Purpose | Project scope | User scope |
+|---|---|---|
+| Agent profile | `.agents/agents/{name}.md` | `~/.agents/agents/{name}.md` |
+| MCP extensions | — | `~/.config/goose/config.yaml` |
+| Skill definition | `.agents/skills/{name}/SKILL.md` | `~/.agents/skills/{name}/SKILL.md` |
+| Hook plugin | `.agents/plugins/observal/` | `~/.agents/plugins/observal/` |
+| Session database | — | `~/.local/share/goose/sessions/sessions.db` |
+| Observal credentials | `~/.observal/config.json` | `~/.observal/config.json` |
+| Observal lockfile | `~/.observal/lockfile.json` | `~/.observal/lockfile.json` |
+
+User-scope locations follow Goose's own resolution order:
+
+1. `$GOOSE_PATH_ROOT` when set to an absolute path — config becomes
+   `$GOOSE_PATH_ROOT/config`, data `$GOOSE_PATH_ROOT/data`, and skills, agents
+   and plugins move to `$GOOSE_PATH_ROOT/.agents/`.
+2. `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME` when set.
+3. `~/.config/goose` and `~/.local/share/goose`.
+
+On Windows, Goose reads `%APPDATA%\Block\goose\config\config.yaml` and
+`%APPDATA%\Block\goose\data\sessions\sessions.db`. Scanning, `doctor`, and
+session reading resolve those locations automatically. `observal agent pull`
+still writes the documented Unix paths, so Windows users should move the
+generated `config.yaml` extensions into the `%APPDATA%` config by hand.
+
+---
+
+## Agent profile format
+
+```markdown
+---
+name: my-agent
+description: Reviews code for correctness and risk
+model: gpt-5.5
+---
+
+You are a Goose agent with the following specialization...
+```
+
+Only `name` is required by Goose. `model` is emitted when the install resolves a
+model from the Goose model catalog.
+
+---
+
+## Extension format
+
+Observal writes MCP servers as Goose extensions:
+
+```yaml
+extensions:
+  filesystem:
+    type: stdio
+    name: filesystem
+    enabled: true
+    cmd: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    envs: {}
+    env_keys: []
+    timeout: 300
+  remote-tools:
+    type: streamable_http
+    name: remote-tools
+    enabled: true
+    uri: https://example.com/mcp
+    headers: {}
+    envs: {}
+    env_keys: []
+    timeout: 300
+```
+
+Observal writes MCP servers as `stdio` or `streamable_http` extensions and only
+ever touches the entries it owns. `observal scan` additionally reports legacy
+`sse` extensions. Goose's `builtin`, `platform` and `frontend` extensions run
+in-process and `inline_python` carries code rather than a command, so none of
+them are reported or rewritten.
+
+---
+
+## Hook plugin spec
+
+`~/.agents/plugins/observal/hooks/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart":     [{ "hooks": [{ "type": "command", "command": "...", "timeout": 30 }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "...", "timeout": 30 }] }],
+    "Stop":             [{ "hooks": [{ "type": "command", "command": "...", "timeout": 30 }] }],
+    "SessionEnd":       [{ "hooks": [{ "type": "command", "command": "...", "timeout": 30 }] }]
+  }
+}
+```
+
+Rules deliberately omit `matcher`: Goose treats `matcher` as a regular
+expression, so a bare `"*"` would be invalid and the rule would be skipped.
+
+Goose runs every hook through `sh -c` on all platforms, passes the event JSON on
+stdin, waits for the command, and enforces the rule's `timeout`. The Observal
+hook therefore only reads Goose's database and appends to the local outbox; the
+network upload is handed to a detached worker so a slow or unreachable Observal
+server can never stall a Goose turn.
+
+The hook writes nothing to stdout and never exits `2`, so it can never block a
+`PreToolUse` tool call or a `Stop` turn boundary. `doctor patch` preserves any
+non-Observal rules you add to the same plugin.
+
+Goose records each discovered plugin under a `plugins` map in `config.yaml`
+keyed by its absolute path, so the plugin activates itself on the next session.
+
+To disable the plugin without removing it, add it to `disabledPlugins` in
+`~/.config/goose/settings.json`. To remove it entirely:
+
+```bash
+observal doctor cleanup --harness goose
+```
+
+### Hook payload coverage
+
+Verified against goose 1.45.0:
+
+| Event | `working_dir` | Notes |
+|---|---|---|
+| `SessionStart` | no | Fires once per session |
+| `UserPromptSubmit` | no | Carries the prompt in `message` |
+| `Stop` | yes | Fires at the end of **every turn**, not the session |
+| `SessionEnd` | no | Emitted by the goose **CLI** only |
+
+Because most events omit `working_dir`, Observal reads the session's working
+directory from `sessions.working_dir` instead, which keeps agent attribution and
+layer hashing correct on every event.
+
+---
+
+## Session push behavior
+
+Goose stores sessions in SQLite rather than JSONL, so the CLI projects each
+session onto an append-only JSONL mirror at
+`~/.observal/sessions/goose/<session_id>.jsonl`. Everything downstream — the
+durable outbox, acknowledged delivery, checkpoint recovery, and the final
+SHA-256 audit — is the shared engine used by every other harness.
+
+1. A hook event resolves the Goose session id from the payload.
+2. `sessions.db` is opened through a `file:...?mode=ro` URI with a busy timeout,
+   so Observal never writes to, migrates, or checkpoints Goose's database, and
+   never blocks a Goose session that is writing concurrently.
+3. Rows newer than the mirror's cursor are appended as JSONL records. The mirror
+   only grows, which keeps previously acknowledged byte offsets valid.
+4. The batch is spooled to the local outbox and a detached worker performs the
+   upload, so the hook returns in milliseconds regardless of server health.
+5. `SessionEnd` appends a `session_end` boundary carrying the session's token
+   and cost totals, then finalizes delivery with an integrity hash.
+6. Delegated (subagent) sessions linked by `parent_session_id` are mirrored and
+   delivered alongside their parent.
+
+Mirror records:
+
+| Record | Meaning |
+|---|---|
+| `{"type": "session", ...}` | Session metadata: name, working directory, provider, model, parent session |
+| `{"type": "message", ...}` | One `messages` row: role, content blocks, per-message token usage |
+| `{"type": "session_end", ...}` | Final boundary with accumulated token and cost totals |
+
+Goose content blocks are parsed into trace events: `text`, `thinking`,
+`redactedThinking`, `toolRequest`, `toolResponse` (including failures),
+`toolConfirmationRequest`, and `error`.
+
+### Backfilling existing sessions
+
+```bash
+observal reconcile --harness goose
+observal reconcile --harness goose --since 720 --dry-run
+```
+
+Reconcile reads the same read-only database, mirrors any session updated within
+the window, and drains it through the outbox.
+
+---
+
+## Caveats
+
+**The hook plugin is shared per machine.** It is installed by `doctor patch`,
+not by each agent pull.
+
+**MCP extensions are user scope only.** Goose reads extensions from one
+`config.yaml`, so `--scope project` still writes extensions to the user config.
+Agents and skills honour the requested scope. Goose rewrites that same file when
+it registers plugins, and neither Goose nor Observal preserves YAML comments in
+it.
+
+**Goose Desktop sessions finalize later.** Only the goose CLI emits
+`SessionEnd`. Desktop sessions are still captured turn by turn through `Stop`;
+their final integrity audit runs from background recovery or
+`observal reconcile`.
+
+**`observal scan` does not follow `GOOSE_PATH_ROOT`.** Scan gates each harness on
+a fixed home directory, so it reports nothing when Goose is relocated. Pull,
+doctor, layer snapshots, and session capture all follow the relocated paths.
+
+**Legacy JSONL sessions are not imported.** Goose imports pre-1.10 `.jsonl`
+files into `sessions.db` on upgrade, and Observal reads the database, so those
+sessions are covered. Leftover `.jsonl` files on disk are ignored.
+
+**Rewritten conversations replay.** `goose session --resume --edit` rewrites a
+session's messages. The mirror is append-only, so the rewritten history is
+appended rather than replacing what was already delivered.
+
+**Late writes land on the next event.** If Goose persists a message after the
+`SessionEnd` hook has read the database, that row is delivered by the next hook
+event or by `observal reconcile`.

--- a/docs/integrations/goose.md
+++ b/docs/integrations/goose.md
@@ -292,10 +292,6 @@ it.
 their final integrity audit runs from background recovery or
 `observal reconcile`.
 
-**`observal scan` does not follow `GOOSE_PATH_ROOT`.** Scan gates each harness on
-a fixed home directory, so it reports nothing when Goose is relocated. Pull,
-doctor, layer snapshots, and session capture all follow the relocated paths.
-
 **Legacy JSONL sessions are not imported.** Goose imports pre-1.10 `.jsonl`
 files into `sessions.db` on upgrade, and Observal reads the database, so those
 sessions are covered. Leftover `.jsonl` files on disk are ignored.

--- a/docs/self-hosting/miscellaneous.md
+++ b/docs/self-hosting/miscellaneous.md
@@ -33,7 +33,7 @@ Restrict which harnesses are available in the platform. When set, only the liste
 | `cursor,claude_code,pi` | Only Cursor, Claude Code, and Pi appear in dropdowns |
 | `kiro,cursor` | Only Kiro and Cursor are available |
 
-**Format:** Comma-separated harness identifiers. Valid identifiers: `cursor`, `claude_code`, `kiro`, `pi`, `copilot`, `copilot_cli`, `codex`, `opencode`, `gemini_cli`, `antigravity`
+**Format:** Comma-separated harness identifiers. Valid identifiers: `cursor`, `claude_code`, `kiro`, `pi`, `copilot`, `copilot_cli`, `codex`, `opencode`, `gemini_cli`, `antigravity`, `goose`
 
 **When to set:** Your deployment standardizes on specific harnesses and you don't want users confused by irrelevant options. Also useful for reducing noise in the registry when agents only need to support a subset of harnesses.
 

--- a/observal-server/services/harness/goose.py
+++ b/observal-server/services/harness/goose.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Goose harness adapter for agent config generation.
+
+Emits, per install:
+- a custom agent markdown file (``.agents/agents/<name>.md``)
+- MCP servers as goose ``extensions`` merged into ``config.yaml``
+- skill components installed through the shared skill installer
+- an Observal goose plugin (``plugin.json`` + ``hooks/hooks.json``) carrying the
+  session telemetry hooks and any registry hook components
+"""
+
+from __future__ import annotations
+
+import json
+
+import yaml
+from loguru import logger as optic
+
+from observal_shared.harness_registry import HARNESS_REGISTRY
+from services.harness import BaseHarnessAdapter, ConfigContext, McpConfigContext, register_adapter
+from services.harness.helpers import (
+    _collect_hook_script_files,
+    _merge_hook_components_into_config,
+)
+
+_GOOSE_SESSION_PUSH_CMD = "python3 -m observal_cli.hooks.session_push --harness goose"
+# Mirrors observal_cli.harness_specs.goose_hooks_spec; the CLI cannot be imported here.
+_GOOSE_HOOK_EVENTS = ("SessionStart", "UserPromptSubmit", "Stop", "SessionEnd")
+_HOOK_TIMEOUT_SECONDS = 30
+_DEFAULT_EXTENSION_TIMEOUT = 300
+_PLUGIN_DIR = ".agents/plugins/observal"
+_PLUGIN_MANIFEST = {
+    "name": "observal",
+    "version": "1.0.0",
+    "description": "Observal session telemetry and hook components for goose",
+}
+
+
+def _goose_hooks_config(platform: str = "") -> dict:
+    """Build the Observal plugin ``hooks/hooks.json`` content.
+
+    Rules omit ``matcher`` so they run for every event of that type; goose
+    treats ``matcher`` as a regular expression, not a glob.
+    """
+    command = (
+        "python -m observal_cli.hooks.session_push --harness goose" if platform == "win32" else _GOOSE_SESSION_PUSH_CMD
+    )
+    return {
+        "hooks": {
+            event: [{"hooks": [{"type": "command", "command": command, "timeout": _HOOK_TIMEOUT_SECONDS}]}]
+            for event in _GOOSE_HOOK_EVENTS
+        }
+    }
+
+
+def _agent_markdown(name: str, description: str, model: str | None, body: str) -> str:
+    """Render a goose custom agent file: YAML frontmatter plus instructions."""
+    frontmatter: dict = {"name": name, "description": description}
+    if model:
+        frontmatter["model"] = model
+    rendered = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True, default_flow_style=False)
+    return f"---\n{rendered}---\n\n{body}"
+
+
+class GooseAdapter(BaseHarnessAdapter):
+    """Goose harness adapter."""
+
+    @property
+    def harness_name(self) -> str:
+        return "goose"
+
+    def agent_mcp_entry(self, ctx: McpConfigContext) -> dict:
+        """Return a goose ``extensions`` entry for one MCP server."""
+        if ctx.url:
+            entry: dict = {
+                "type": "streamable_http",
+                "name": ctx.name,
+                "enabled": True,
+                "uri": ctx.url,
+                "headers": ctx.headers or {},
+            }
+        else:
+            entry = {
+                "type": "stdio",
+                "name": ctx.name,
+                "enabled": True,
+                "cmd": ctx.command,
+                "args": list(ctx.args),
+            }
+        entry["envs"] = dict(ctx.server_env or {})
+        entry["env_keys"] = []
+        entry["timeout"] = _DEFAULT_EXTENSION_TIMEOUT
+        return entry
+
+    def format_mcp_config(self, ctx: McpConfigContext) -> dict:
+        return {"extensions": {ctx.name: self.agent_mcp_entry(ctx)}}
+
+    def format_hook_component(self, command: str) -> dict:
+        return {"hooks": [{"type": "command", "command": command}]}
+
+    def format_hook_install_snippet(self, event: str, handler_type: str, command: str, timeout: int | None) -> dict:
+        entry: dict = {"type": "command", "command": command}
+        if timeout:
+            entry["timeout"] = timeout
+        return {
+            "hooks": {event: [{"hooks": [entry]}]},
+            "_note": f"Add to {_PLUGIN_DIR}/hooks/hooks.json",
+        }
+
+    def format_hook_telemetry(self, hook_listing, server_url: str, platform: str) -> dict:
+        return _goose_hooks_config(platform)
+
+    def format_config(self, ctx: ConfigContext) -> dict:
+        optic.debug("format_config: agent={}", ctx.safe_name)
+        spec = HARNESS_REGISTRY["goose"]
+        options = ctx.options
+        scope = options.get("scope", spec["default_scope"])
+        description = (getattr(ctx.agent, "description", "") or ctx.safe_name).replace("\n", " ").strip()[:200]
+
+        result: dict = {
+            "agent_profile": {
+                "path": spec["agent_profile"][scope].format(name=ctx.safe_name),
+                "content": _agent_markdown(
+                    ctx.safe_name,
+                    description,
+                    options.get("_resolved_model"),
+                    ctx.rules_content,
+                ),
+            },
+            "scope": scope,
+        }
+
+        extensions = {name: self._as_extension(name, entry) for name, entry in ctx.mcp_configs.items()}
+        if extensions:
+            result["mcp_config"] = {
+                "path": spec["mcp_config"]["user"],
+                "content": {spec["mcp_servers_key"]: extensions},
+            }
+
+        hooks_content = _goose_hooks_config(ctx.platform)
+        _merge_hook_components_into_config(hooks_content, ctx.hook_configs, "goose")
+        hooks_path = spec["hooks"][scope]
+        result["hooks_config"] = {
+            "path": hooks_path,
+            "content": hooks_content,
+            "merge": True,
+        }
+
+        hook_files = [
+            {
+                "path": hooks_path.replace("hooks/hooks.json", "plugin.json"),
+                "content": json.dumps(_PLUGIN_MANIFEST, indent=2) + "\n",
+            }
+        ]
+        hook_files.extend(_collect_hook_script_files(ctx.hook_configs, ctx.hook_listings, "goose"))
+        result["hook_files"] = hook_files
+
+        if ctx.skill_configs:
+            result["skill_components"] = ctx.skill_configs
+
+        warnings = list(ctx.compatibility_warnings)
+        warnings.extend(options.get("_model_warnings") or [])
+        if warnings:
+            result["_warnings"] = warnings
+
+        return result
+
+    @staticmethod
+    def _as_extension(name: str, entry: dict) -> dict:
+        """Normalise external and sandbox MCP entries into goose extension shape."""
+        if entry.get("type") in ("stdio", "streamable_http"):
+            return entry
+        extension: dict = {
+            "type": "stdio",
+            "name": name,
+            "enabled": True,
+            "cmd": entry.get("command"),
+            "args": list(entry.get("args") or []),
+            "envs": dict(entry.get("env") or {}),
+            "env_keys": [],
+            "timeout": _DEFAULT_EXTENSION_TIMEOUT,
+        }
+        if entry.get("url"):
+            extension.update({"type": "streamable_http", "uri": entry["url"], "headers": entry.get("headers") or {}})
+            extension.pop("cmd", None)
+            extension.pop("args", None)
+        return extension
+
+
+register_adapter(GooseAdapter())

--- a/observal-server/services/harness/load_all.py
+++ b/observal-server/services/harness/load_all.py
@@ -13,6 +13,7 @@ from services.harness import codex as _codex  # noqa: F401
 from services.harness import copilot as _copilot  # noqa: F401
 from services.harness import copilot_cli as _copilot_cli  # noqa: F401
 from services.harness import cursor as _cursor  # noqa: F401
+from services.harness import goose as _goose  # noqa: F401
 from services.harness import kiro as _kiro  # noqa: F401
 from services.harness import opencode as _opencode  # noqa: F401
 from services.harness import pi as _pi  # noqa: F401

--- a/observal-server/services/session_ingest.py
+++ b/observal-server/services/session_ingest.py
@@ -75,6 +75,31 @@ def _usage_antigravity(parsed: dict) -> dict:
     }
 
 
+def _usage_goose(parsed: dict) -> dict:
+    """Goose: per-message counts live in metadata.usage (camelCase)."""
+    metadata = parsed.get("metadata")
+    usage = metadata.get("usage") if isinstance(metadata, dict) else None
+    inference = metadata.get("inference") if isinstance(metadata, dict) else None
+    if not isinstance(usage, dict):
+        usage = {}
+    if not isinstance(inference, dict):
+        inference = {}
+
+    def count(key: str) -> int:
+        try:
+            return int(usage.get(key) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    return {
+        "input_tokens": count("inputTokens"),
+        "output_tokens": count("outputTokens"),
+        "cache_read_tokens": count("cacheReadTokens"),
+        "cache_write_tokens": count("cacheWriteTokens"),
+        "model": str(inference.get("resolvedModel") or inference.get("requestedModel") or ""),
+    }
+
+
 def _usage_codex(parsed: dict) -> dict:
     """Codex: event_msg/token_count has payload.info.total_token_usage."""
     payload = parsed.get("payload", {})
@@ -135,6 +160,7 @@ _USAGE_EXTRACTORS: dict[str, _UsageFn] = {
     "codex": _usage_codex,
     "kiro": _usage_claude_code,
     "cursor": _usage_claude_code,
+    "goose": _usage_goose,
     "pi": _usage_pi,
     "copilot-cli": _usage_copilot_cli,
     "copilot": _usage_copilot_cli,
@@ -166,12 +192,18 @@ def _uuid_antigravity(parsed: dict) -> tuple[str | None, str | None]:
     return None, None
 
 
+def _uuid_goose(parsed: dict) -> tuple[str | None, str | None]:
+    """Goose: message_id identifies a row; boundaries fall back to the session id."""
+    return parsed.get("message_id") or parsed.get("session_id"), parsed.get("parent_session_id")
+
+
 _UuidFn = Callable[[dict], "tuple[str | None, str | None]"]
 
 _UUID_EXTRACTORS: dict[str, _UuidFn] = {
     "claude-code": _uuid_default,
     "kiro": _uuid_default,
     "cursor": _uuid_default,
+    "goose": _uuid_goose,
     "opencode": _uuid_default,
     "pi": _uuid_pi,
     "antigravity": _uuid_antigravity,

--- a/observal-server/services/session_parsers/__init__.py
+++ b/observal-server/services/session_parsers/__init__.py
@@ -28,6 +28,7 @@ from .claude_code import parse_rows as _parse_claude_code
 from .codex import parse_rows as _parse_codex
 from .copilot_cli import parse_rows as _parse_copilot_cli
 from .cursor import parse_rows as _parse_cursor
+from .goose import parse_rows as _parse_goose
 from .kiro import parse_rows as _parse_kiro
 from .opencode import parse_rows as _parse_opencode
 from .pi import parse_rows as _parse_pi
@@ -40,6 +41,7 @@ _PARSERS: dict[str, _ParseFn] = {
     "codex": _parse_codex,
     "copilot-cli": _parse_copilot_cli,
     "cursor": _parse_cursor,
+    "goose": _parse_goose,
     "kiro": _parse_kiro,
     "opencode": _parse_opencode,
     "pi": _parse_pi,

--- a/observal-server/services/session_parsers/goose.py
+++ b/observal-server/services/session_parsers/goose.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Goose session parser.
+
+Goose persists sessions in SQLite, so the CLI adapter projects each session
+onto an append-only JSONL mirror (see ``observal_cli.sessions.goose``).  Every
+mirrored line is one of:
+
+``{"type": "session", ...}``      session metadata boundary
+``{"type": "message", ...}``      a ``messages`` row: role, content blocks, metadata
+``{"type": "session_end", ...}``  final boundary with the session's usage totals
+
+Content blocks use goose's camelCase tags: ``text``, ``image``, ``toolRequest``,
+``toolResponse``, ``thinking``, ``redactedThinking``, ``toolConfirmationRequest``,
+``frontendToolRequest``, ``actionRequired``, ``systemNotification`` and ``error``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .base import basic_event, pick_timestamp, strip_ansi
+
+_MAX_BODY = 120
+_MAX_RESPONSE = 2000
+
+
+def parse_rows(rows: list[dict]) -> list[dict]:
+    """Parse mirrored Goose session rows into normalised frontend events."""
+    events: list[dict] = []
+    # Maps a goose tool id -> index of its tool_call event, for merge-on-result.
+    tool_index: dict[str, int] = {}
+
+    for row in rows:
+        raw_line = row.get("raw_line", "")
+        harness = row.get("harness", "goose")
+        if not raw_line:
+            events.append(basic_event(row))
+            continue
+        try:
+            line = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError):
+            events.append(basic_event(row))
+            continue
+        if not isinstance(line, dict):
+            events.append(basic_event(row))
+            continue
+
+        ts = pick_timestamp(line.get("timestamp"), row.get("timestamp", ""), row.get("ingested_at", ""))
+        record_type = line.get("type", "")
+
+        if record_type == "session":
+            events.append(_session_event(line, ts, harness))
+        elif record_type == "session_end":
+            events.append(_session_end_event(line, ts, harness))
+        elif record_type == "message":
+            _handle_message(line, ts, harness, events, tool_index)
+        else:
+            events.append(basic_event(row))
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Boundary events
+# ---------------------------------------------------------------------------
+
+
+def _session_event(line: dict, ts: str, harness: str) -> dict:
+    attributes = {
+        key: str(line.get(key) or "")
+        for key in ("working_dir", "session_type", "provider", "model", "goose_mode")
+        if line.get(key)
+    }
+    if line.get("parent_session_id"):
+        attributes["parent_session_id"] = str(line["parent_session_id"])
+    return {
+        "timestamp": ts,
+        "event_name": "hook_sessionstart",
+        "body": str(line.get("name") or line.get("session_id") or "")[:_MAX_BODY],
+        "attributes": attributes,
+        "service_name": harness,
+    }
+
+
+def _session_end_event(line: dict, ts: str, harness: str) -> dict:
+    usage = line.get("usage") if isinstance(line.get("usage"), dict) else {}
+    attributes = {
+        name: str(usage[key])
+        for key, name in (
+            ("inputTokens", "input_tokens"),
+            ("outputTokens", "output_tokens"),
+            ("totalTokens", "total_tokens"),
+            ("cost", "cost"),
+        )
+        if usage.get(key)
+    }
+    return {
+        "timestamp": ts,
+        "event_name": "hook_stop",
+        "body": "",
+        "attributes": attributes,
+        "service_name": harness,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Message events
+# ---------------------------------------------------------------------------
+
+
+def _handle_message(
+    line: dict,
+    ts: str,
+    harness: str,
+    events: list[dict],
+    tool_index: dict[str, int],
+) -> None:
+    content = line.get("content")
+    if not isinstance(content, list):
+        return
+    role = str(line.get("role") or "")
+    token_attrs = _token_attributes(line.get("metadata"))
+
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type", "")
+
+        if block_type == "text":
+            text = strip_ansi(str(block.get("text") or ""))
+            if not text.strip():
+                continue
+            if role == "user":
+                events.append(_event(ts, harness, "hook_userpromptsubmit", text, {"tool_input": text}))
+            else:
+                attributes: dict[str, str] = {"tool_response": text[:_MAX_RESPONSE]}
+                attributes.update(token_attrs)
+                token_attrs = {}  # consumed by the first assistant text block
+                events.append(_event(ts, harness, "hook_assistant_response", text, attributes))
+
+        elif block_type == "thinking":
+            thinking = strip_ansi(str(block.get("thinking") or ""))
+            if thinking.strip():
+                events.append(
+                    _event(
+                        ts, harness, "hook_assistant_thinking", thinking, {"tool_response": thinking[:_MAX_RESPONSE]}
+                    )
+                )
+
+        elif block_type == "redactedThinking":
+            events.append(_event(ts, harness, "hook_assistant_thinking", "[redacted]", {}))
+
+        elif block_type in ("toolRequest", "frontendToolRequest"):
+            tool_id = str(block.get("id") or "")
+            name, arguments, error = _tool_call(block.get("toolCall"))
+            attributes = {"tool_name": name, "tool_input": json.dumps(arguments), "tool_use_id": tool_id}
+            if error:
+                attributes["tool_status"] = "error"
+                attributes["tool_response"] = error[:_MAX_RESPONSE]
+            tool_index[tool_id] = len(events)
+            events.append(_event(ts, harness, "hook_posttooluse", name, attributes))
+
+        elif block_type == "toolResponse":
+            _merge_tool_response(block, ts, harness, events, tool_index)
+
+        elif block_type == "toolConfirmationRequest":
+            tool_name = str(block.get("toolName") or "")
+            events.append(
+                _event(
+                    ts,
+                    harness,
+                    "hook_pretooluse",
+                    tool_name,
+                    {"tool_name": tool_name, "tool_input": json.dumps(block.get("arguments") or {})},
+                )
+            )
+
+        elif block_type == "error":
+            message = str(block.get("message") or block.get("msg") or "")
+            events.append(_event(ts, harness, "hook_error", message, {"tool_response": message[:_MAX_RESPONSE]}))
+
+    if token_attrs:
+        # A tool-only assistant turn still reports usage; surface it standalone.
+        events.append(_event(ts, harness, "hook_token_usage", "", token_attrs))
+
+
+def _event(ts: str, harness: str, event_name: str, body: str, attributes: dict[str, str]) -> dict:
+    return {
+        "timestamp": ts,
+        "event_name": event_name,
+        "body": body[:_MAX_BODY],
+        "attributes": attributes,
+        "service_name": harness,
+    }
+
+
+def _token_attributes(metadata: Any) -> dict[str, str]:
+    """Extract per-message token counts and the resolved model from metadata."""
+    if not isinstance(metadata, dict):
+        return {}
+    usage = metadata.get("usage")
+    attributes: dict[str, str] = {}
+    if isinstance(usage, dict):
+        for key, name in (
+            ("inputTokens", "input_tokens"),
+            ("outputTokens", "output_tokens"),
+            ("cacheReadTokens", "cache_read_tokens"),
+            ("cacheWriteTokens", "cache_creation_tokens"),
+            ("cost", "cost"),
+        ):
+            if usage.get(key):
+                attributes[name] = str(usage[key])
+    inference = metadata.get("inference")
+    if isinstance(inference, dict):
+        model = inference.get("resolvedModel") or inference.get("requestedModel")
+        if model:
+            attributes["model"] = str(model)
+    return attributes
+
+
+def _tool_call(tool_call: Any) -> tuple[str, dict, str]:
+    """Return ``(name, arguments, error)`` from a goose ``toolCall`` envelope."""
+    if not isinstance(tool_call, dict):
+        return "", {}, ""
+    if tool_call.get("status") == "error" or "error" in tool_call:
+        return "", {}, str(tool_call.get("error") or "")
+    value = tool_call.get("value")
+    if not isinstance(value, dict):
+        return "", {}, ""
+    arguments = value.get("arguments")
+    return str(value.get("name") or ""), arguments if isinstance(arguments, dict) else {}, ""
+
+
+def _merge_tool_response(block: dict, ts: str, harness: str, events: list[dict], tool_index: dict[str, int]) -> None:
+    """Attach a tool result to its request, or emit it standalone when orphaned."""
+    tool_id = str(block.get("id") or "")
+    text, failed = _tool_result_text(block.get("toolResult"))
+    index = tool_index.get(tool_id)
+    if index is not None and index < len(events):
+        target = events[index]
+        target["attributes"]["tool_response"] = text[:_MAX_RESPONSE]
+        if failed:
+            target["attributes"]["tool_status"] = "error"
+        return
+    attributes = {"tool_use_id": tool_id, "tool_response": text[:_MAX_RESPONSE]}
+    if failed:
+        attributes["tool_status"] = "error"
+    events.append(_event(ts, harness, "hook_posttooluse", text, attributes))
+
+
+def _tool_result_text(tool_result: Any) -> tuple[str, bool]:
+    """Return ``(text, failed)`` for a goose ``toolResult`` envelope.
+
+    Handles both the current ``CallToolResult`` shape (``value.content`` plus
+    ``value.isError``) and the legacy shape where ``value`` is the content list.
+    """
+    if not isinstance(tool_result, dict):
+        return "", False
+    if tool_result.get("status") == "error" or "error" in tool_result:
+        return str(tool_result.get("error") or ""), True
+    value = tool_result.get("value")
+    if isinstance(value, dict):
+        return _content_text(value.get("content")), bool(value.get("isError"))
+    return _content_text(value), False
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = [str(item.get("text") or "") for item in content if isinstance(item, dict) and item.get("type") == "text"]
+    return "\n".join(part for part in parts if part)

--- a/observal-server/services/session_parsers/goose.py
+++ b/observal-server/services/session_parsers/goose.py
@@ -160,7 +160,8 @@ def _handle_message(
             if error:
                 attributes["tool_status"] = "error"
                 attributes["tool_response"] = error[:_MAX_RESPONSE]
-            tool_index[tool_id] = len(events)
+            if tool_id:
+                tool_index[tool_id] = len(events)
             events.append(_event(ts, harness, "hook_posttooluse", name, attributes))
 
         elif block_type == "toolResponse":
@@ -238,7 +239,7 @@ def _merge_tool_response(block: dict, ts: str, harness: str, events: list[dict],
     """Attach a tool result to its request, or emit it standalone when orphaned."""
     tool_id = str(block.get("id") or "")
     text, failed = _tool_result_text(block.get("toolResult"))
-    index = tool_index.get(tool_id)
+    index = tool_index.get(tool_id) if tool_id else None
     if index is not None and index < len(events):
         target = events[index]
         target["attributes"]["tool_response"] = text[:_MAX_RESPONSE]

--- a/observal-server/services/session_parsers/ingest_classify.py
+++ b/observal-server/services/session_parsers/ingest_classify.py
@@ -735,6 +735,111 @@ def _tool_info_antigravity(parsed: dict) -> tuple[str | None, str | None]:
 
 
 # ---------------------------------------------------------------------------
+# Goose classifier
+# ---------------------------------------------------------------------------
+
+# goose content block tags, in the order they decide a line's event type.
+_GOOSE_THINKING_BLOCKS = frozenset({"thinking", "redactedThinking"})
+_GOOSE_REQUEST_BLOCKS = frozenset({"toolRequest", "frontendToolRequest", "toolConfirmationRequest"})
+
+
+def _goose_block_types(parsed: dict) -> list[str]:
+    content = parsed.get("content")
+    if not isinstance(content, list):
+        return []
+    return [block.get("type", "") for block in content if isinstance(block, dict)]
+
+
+def _classify_goose(parsed: dict) -> str | None:
+    """Classify one line of a mirrored goose session.
+
+    The mirror carries ``session`` / ``session_end`` boundaries plus one
+    ``message`` record per row of goose's ``messages`` table.
+    """
+    record_type = parsed.get("type", "")
+    if record_type in ("session", "session_end"):
+        return "system"
+    if record_type != "message":
+        return "system"
+
+    blocks = _goose_block_types(parsed)
+    if not blocks:
+        return None  # empty message row carries no signal
+    if any(block in _GOOSE_THINKING_BLOCKS for block in blocks):
+        return "thinking"
+    if any(block in _GOOSE_REQUEST_BLOCKS for block in blocks):
+        return "tool_call"
+    if "toolResponse" in blocks:
+        return "tool_result"
+    return "user_prompt" if parsed.get("role") == "user" else "assistant_text"
+
+
+def _goose_tool_call_text(block: dict) -> str:
+    call = block.get("toolCall") if isinstance(block.get("toolCall"), dict) else {}
+    value = call.get("value") if isinstance(call.get("value"), dict) else {}
+    name = value.get("name") or block.get("toolName") or ""
+    return f"[tool_use: {name}]" if name else ""
+
+
+def _goose_tool_result_text(block: dict) -> str:
+    result = block.get("toolResult") if isinstance(block.get("toolResult"), dict) else {}
+    if "error" in result:
+        return str(result.get("error") or "")
+    value = result.get("value")
+    content = value.get("content") if isinstance(value, dict) else value
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return " ".join(
+        str(item.get("text") or "") for item in content if isinstance(item, dict) and item.get("type") == "text"
+    )
+
+
+def _preview_goose(parsed: dict, event_type: str) -> str:
+    try:
+        record_type = parsed.get("type", "")
+        if record_type == "session":
+            return f"[session: {parsed.get('name') or parsed.get('session_id') or ''}]"[:_PREVIEW_MAX]
+        if record_type == "session_end":
+            return "[session end]"
+        content = parsed.get("content")
+        if not isinstance(content, list):
+            return ""
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type", "")
+            if block_type == "text":
+                parts.append(str(block.get("text") or ""))
+            elif block_type == "thinking":
+                parts.append(str(block.get("thinking") or ""))
+            elif block_type == "redactedThinking":
+                parts.append("[redacted thinking]")
+            elif block_type in _GOOSE_REQUEST_BLOCKS:
+                parts.append(_goose_tool_call_text(block))
+            elif block_type == "toolResponse":
+                parts.append(_goose_tool_result_text(block))
+        return " ".join(part for part in parts if part)[:_PREVIEW_MAX]
+    except Exception:
+        return ""
+
+
+def _tool_info_goose(parsed: dict) -> tuple[str | None, str | None]:
+    content = parsed.get("content")
+    if not isinstance(content, list):
+        return None, None
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") not in _GOOSE_REQUEST_BLOCKS:
+            continue
+        call = block.get("toolCall") if isinstance(block.get("toolCall"), dict) else {}
+        value = call.get("value") if isinstance(call.get("value"), dict) else {}
+        return value.get("name") or block.get("toolName"), block.get("id")
+    return None, None
+
+
+# ---------------------------------------------------------------------------
 # Registry  -- add new parsers here, update harness_registry.py session_parser key
 # ---------------------------------------------------------------------------
 
@@ -750,6 +855,7 @@ _CLASSIFIERS: dict[str, _Classifier] = {
     "copilot-cli": (_classify_copilot_cli, _preview_copilot_cli, _tool_info_copilot_cli),
     "kiro": (_classify_kiro, _preview_kiro, _tool_info_kiro),
     "cursor": (_classify_cursor, _preview_cursor, _tool_info_cursor),
+    "goose": (_classify_goose, _preview_goose, _tool_info_goose),
     "opencode": (_classify_claude_code, _preview_claude_code, _tool_info_claude_code),
     "pi": (_classify_pi, _preview_pi, _tool_info_pi),
     "antigravity": (_classify_antigravity, _preview_antigravity, _tool_info_antigravity),
@@ -886,6 +992,7 @@ _TS_EXTRACTORS: dict[str, object] = {
     "codex": _ts_claude_code,  # Codex uses same timestamp format as Claude Code
     "kiro": _ts_kiro,
     "cursor": _ts_cursor,
+    "goose": _ts_claude_code,  # mirrored goose records carry an ISO `timestamp`
     "opencode": _ts_claude_code,
     "pi": _ts_pi,
     "copilot-cli": _ts_copilot_cli,
@@ -931,6 +1038,7 @@ _EXTRA_ROWS_HANDLERS: dict[str, _ExtraRowsFn] = {
     "claude-code": _no_extra_rows,
     "codex": _no_extra_rows,
     "cursor": _no_extra_rows,
+    "goose": _no_extra_rows,
     "opencode": _no_extra_rows,
     "pi": _no_extra_rows,
     "copilot-cli": _no_extra_rows,

--- a/observal-server/services/session_parsers/ingest_classify.py
+++ b/observal-server/services/session_parsers/ingest_classify.py
@@ -765,12 +765,14 @@ def _classify_goose(parsed: dict) -> str | None:
     blocks = _goose_block_types(parsed)
     if not blocks:
         return None  # empty message row carries no signal
-    if any(block in _GOOSE_THINKING_BLOCKS for block in blocks):
-        return "thinking"
-    if any(block in _GOOSE_REQUEST_BLOCKS for block in blocks):
-        return "tool_call"
-    if "toolResponse" in blocks:
-        return "tool_result"
+    # First significant block wins, as in _classify_claude_code.
+    for block in blocks:
+        if block in _GOOSE_THINKING_BLOCKS:
+            return "thinking"
+        if block in _GOOSE_REQUEST_BLOCKS:
+            return "tool_call"
+        if block == "toolResponse":
+            return "tool_result"
     return "user_prompt" if parsed.get("role") == "user" else "assistant_text"
 
 

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -127,7 +127,11 @@ def doctor(
     rprint("[cyan]Checking Antigravity...[/cyan]")
     _check_antigravity(issues, warnings)
 
-    # 11. Check if observal skill is installed
+    # 11. Check Goose
+    rprint("[cyan]Checking Goose...[/cyan]")
+    _check_goose(issues, warnings)
+
+    # 12. Check if observal skill is installed
     skill_missing = _check_observal_skill_missing()
     if skill_missing:
         warnings.append(
@@ -626,6 +630,37 @@ def _check_antigravity(issues: list, warnings: list):
         )
 
 
+def _check_goose(issues: list, warnings: list):
+    """Check that the Observal hook plugin is installed for Goose."""
+    optic.debug("_check_goose")
+    from observal_cli.harness_specs.goose_hooks_spec import GOOSE_HOOK_EVENTS, build_hooks, hooks_file
+    from observal_cli.shared.utils import resolve_goose_config_dir, resolve_goose_data_dir
+
+    if not resolve_goose_config_dir().is_dir() and not resolve_goose_data_dir().is_dir():
+        rprint("  [dim]Goose not detected[/dim]")
+        return
+
+    hooks_path = hooks_file()
+    missing = "Goose session push hooks not installed. Run `observal doctor patch --harness goose` to inject them."
+    if not hooks_path.exists():
+        warnings.append(missing)
+        return
+
+    data = _load_json(hooks_path)
+    if data is None:
+        issues.append(f"{hooks_path}: not valid JSON.")
+        return
+
+    installed = data.get("hooks", {}) if isinstance(data.get("hooks"), dict) else {}
+    desired = build_hooks()["hooks"]
+    stale = [event for event in GOOSE_HOOK_EVENTS if installed.get(event) != desired[event]]
+    if stale:
+        warnings.append(
+            f"Goose session push hooks are missing or stale for: {', '.join(stale)}. "
+            "Run `observal doctor patch --harness goose` to update them."
+        )
+
+
 # ── Cleanup command ──────────────────────────────────────────
 
 
@@ -635,7 +670,7 @@ def doctor_cleanup(
         None,
         "--harness",
         "-i",
-        help="Target harness only (claude-code, kiro, cursor, codex, copilot, copilot-cli, opencode, antigravity, pi). Default: all.",
+        help="Target harness only (claude-code, kiro, cursor, codex, copilot, copilot-cli, opencode, antigravity, goose, pi). Default: all.",
     ),
     exclude: list[str] = typer.Option(
         [],
@@ -984,6 +1019,27 @@ def _cleanup_opencode(dry_run: bool) -> bool:
     rprint(f"  {verb} {plugin_path}")
     if not dry_run:
         plugin_path.unlink()
+
+    return True
+
+
+def _cleanup_goose(dry_run: bool) -> bool:
+    """Remove the Observal hook plugin from ~/.agents/plugins/observal/."""
+    import shutil
+
+    from observal_cli.harness_specs.goose_hooks_spec import plugin_dir
+
+    rprint("[cyan]Goose[/cyan]")
+    path = plugin_dir()
+
+    if not path.is_dir():
+        rprint("  [dim]No observal plugin found - skipping[/dim]")
+        return False
+
+    verb = "Would remove" if dry_run else "Removed"
+    rprint(f"  {verb} {path}")
+    if not dry_run:
+        shutil.rmtree(path)
 
     return True
 
@@ -1580,4 +1636,61 @@ def _patch_opencode(dry_run: bool) -> bool:
         else "Installed"
     )
     rprint(f"  {verb} plugin at {plugin_path}")
+    return True
+
+
+def _patch_goose(dry_run: bool) -> bool:
+    """Install the Observal hook plugin into ~/.agents/plugins/observal/."""
+    optic.debug("_patch_goose: dry_run={}", dry_run)
+    from observal_cli.harness_specs.goose_hooks_spec import (
+        build_hooks,
+        build_plugin_manifest,
+        hooks_file,
+        manifest_file,
+    )
+    from observal_cli.shared.utils import (
+        is_observal_hook_entry,
+        resolve_goose_config_dir,
+        resolve_goose_data_dir,
+    )
+
+    rprint("[cyan]Goose - session push hooks[/cyan]")
+
+    if not resolve_goose_config_dir().is_dir() and not resolve_goose_data_dir().is_dir():
+        rprint("  [dim]Goose not detected - skipping[/dim]")
+        return False
+
+    hooks_path = hooks_file()
+    manifest_path = manifest_file()
+    desired = build_hooks()["hooks"]
+
+    existing: dict = _load_json(hooks_path) or {} if hooks_path.exists() else {}
+    existing_hooks = existing.get("hooks", {})
+    if not isinstance(existing_hooks, dict):
+        existing_hooks = {}
+
+    # Keep any hook rules the user added to this plugin, replace only ours.
+    merged = dict(existing_hooks)
+    for event, rules in desired.items():
+        kept = [
+            rule
+            for rule in merged.get(event, [])
+            if isinstance(rule, dict)
+            and not any(is_observal_hook_entry(h) for h in rule.get("hooks", []) if isinstance(h, dict))
+        ]
+        merged[event] = kept + rules
+
+    manifest = build_plugin_manifest()
+    manifest_current = _load_json(manifest_path) if manifest_path.exists() else None
+    if merged == existing_hooks and manifest_current == manifest:
+        rprint("  [dim]Already up to date[/dim]")
+        return False
+
+    if not dry_run:
+        hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+        hooks_path.write_text(json.dumps({**existing, "hooks": merged}, indent=2) + "\n")
+
+    verb = "Would install" if dry_run else "Installed"
+    rprint(f"  {verb} hook plugin at {hooks_path.parent.parent}")
     return True

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -630,6 +630,25 @@ def _check_antigravity(issues: list, warnings: list):
         )
 
 
+def _goose_event_current(installed_rules: object, desired_rules: list) -> bool:
+    """Return True when *installed_rules* already carries every desired Observal handler.
+
+    ``_patch_goose`` keeps foreign rules alongside ours, so comparing the whole
+    rule list would report a permanently stale hook.
+    """
+    if not isinstance(installed_rules, list):
+        return False
+    present = [
+        handler
+        for rule in installed_rules
+        if isinstance(rule, dict)
+        for handler in rule.get("hooks", [])
+        if isinstance(handler, dict)
+    ]
+    wanted = [handler for rule in desired_rules for handler in rule.get("hooks", [])]
+    return all(handler in present for handler in wanted)
+
+
 def _check_goose(issues: list, warnings: list):
     """Check that the Observal hook plugin is installed for Goose."""
     optic.debug("_check_goose")
@@ -647,13 +666,13 @@ def _check_goose(issues: list, warnings: list):
         return
 
     data = _load_json(hooks_path)
-    if data is None:
-        issues.append(f"{hooks_path}: not valid JSON.")
+    if not isinstance(data, dict):
+        issues.append(f"{hooks_path}: not valid JSON object.")
         return
 
-    installed = data.get("hooks", {}) if isinstance(data.get("hooks"), dict) else {}
+    installed = data.get("hooks") if isinstance(data.get("hooks"), dict) else {}
     desired = build_hooks()["hooks"]
-    stale = [event for event in GOOSE_HOOK_EVENTS if installed.get(event) != desired[event]]
+    stale = [event for event in GOOSE_HOOK_EVENTS if not _goose_event_current(installed.get(event), desired[event])]
     if stale:
         warnings.append(
             f"Goose session push hooks are missing or stale for: {', '.join(stale)}. "
@@ -1024,10 +1043,11 @@ def _cleanup_opencode(dry_run: bool) -> bool:
 
 
 def _cleanup_goose(dry_run: bool) -> bool:
-    """Remove the Observal hook plugin from ~/.agents/plugins/observal/."""
+    """Remove Observal hook rules from ~/.agents/plugins/observal/, keeping foreign ones."""
     import shutil
 
-    from observal_cli.harness_specs.goose_hooks_spec import plugin_dir
+    from observal_cli.harness_specs.goose_hooks_spec import hooks_file, plugin_dir
+    from observal_cli.shared.utils import is_observal_hook_entry
 
     rprint("[cyan]Goose[/cyan]")
     path = plugin_dir()
@@ -1035,6 +1055,32 @@ def _cleanup_goose(dry_run: bool) -> bool:
     if not path.is_dir():
         rprint("  [dim]No observal plugin found - skipping[/dim]")
         return False
+
+    hooks_path = hooks_file()
+    data = _load_json(hooks_path) if hooks_path.is_file() else None
+    data = data if isinstance(data, dict) else {}
+    existing_hooks = data.get("hooks") if isinstance(data.get("hooks"), dict) else {}
+
+    # _patch_goose preserves user rules in this plugin, so cleanup must not delete them.
+    foreign = {}
+    for event, rules in existing_hooks.items():
+        if not isinstance(rules, list):
+            continue
+        kept = [
+            rule
+            for rule in rules
+            if isinstance(rule, dict)
+            and not any(is_observal_hook_entry(h) for h in rule.get("hooks", []) if isinstance(h, dict))
+        ]
+        if kept:
+            foreign[event] = kept
+
+    if foreign:
+        verb = "Would remove" if dry_run else "Removed"
+        rprint(f"  {verb} Observal hooks from {hooks_path} (kept {len(foreign)} foreign event(s))")
+        if not dry_run:
+            hooks_path.write_text(json.dumps({**data, "hooks": foreign}, indent=2) + "\n")
+        return True
 
     verb = "Would remove" if dry_run else "Removed"
     rprint(f"  {verb} {path}")
@@ -1664,7 +1710,9 @@ def _patch_goose(dry_run: bool) -> bool:
     manifest_path = manifest_file()
     desired = build_hooks()["hooks"]
 
-    existing: dict = _load_json(hooks_path) or {} if hooks_path.exists() else {}
+    existing = _load_json(hooks_path) if hooks_path.exists() else None
+    if not isinstance(existing, dict):
+        existing = {}
     existing_hooks = existing.get("hooks", {})
     if not isinstance(existing_hooks, dict):
         existing_hooks = {}

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -293,6 +293,38 @@ def _dict_to_toml(d: dict) -> str:
     return "\n".join(lines)
 
 
+def _merge_yaml_config(path: Path, content: dict, root_key: str, *, existed: bool, merge: bool) -> str:
+    """Write a YAML config, merging one section into the file already on disk.
+
+    Goose keeps providers, global settings, and MCP extensions in a single
+    ``config.yaml``, so an install must only touch its own section. An existing
+    file that cannot be parsed is left untouched rather than overwritten.
+    """
+    import yaml
+
+    existing: dict = {}
+    if existed:
+        try:
+            loaded = yaml.safe_load(path.read_text()) or {}
+        except (yaml.YAMLError, OSError, UnicodeDecodeError) as exc:
+            optic.warning("cannot merge into {}: {}", path, exc)
+            return "skipped (unreadable YAML)"
+        if not isinstance(loaded, dict):
+            optic.warning("cannot merge into {}: top level is not a mapping", path)
+            return "skipped (unexpected YAML)"
+        existing = loaded
+
+    if merge and existed:
+        section = existing.get(root_key)
+        incoming = content.get(root_key, {})
+        existing[root_key] = {**section, **incoming} if isinstance(section, dict) else incoming
+        payload = existing
+    else:
+        payload = {**existing, **content}
+    path.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=True))
+    return "merged" if existed else "created"
+
+
 def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> str:
     """Write content to a file path, creating parent dirs as needed.
 
@@ -315,6 +347,8 @@ def _write_file(path: Path, content: str | dict, *, merge_mcp: bool = False) -> 
                 return "merged"
             else:
                 path.write_text(toml_str)
+        elif path.suffix in (".yaml", ".yml"):
+            return _merge_yaml_config(path, content, root_key, existed=existed, merge=merge_mcp)
         else:
             if merge_mcp and existed:
                 try:

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -43,7 +43,6 @@ _HARNESS_HOME_DIRS: dict[str, str] = {
     "opencode": "~/.config/opencode",
     "antigravity": "~/.gemini",
     "cursor": "~/.cursor",
-    "goose": "~/.config/goose",
     "pi": "~/.pi/agent",
 }
 
@@ -98,8 +97,17 @@ def register_scan(app: typer.Typer):
         ide_status: list[tuple[str, str]] = []  # (name, hooks)
 
         for ide_name, adapter in adapters.items():
-            home_label = _HARNESS_HOME_DIRS.get(ide_name, "")
-            home_dir = Path(home_label.replace("~", str(home))) if home_label else None
+            # Adapters that relocate with env vars resolve their own home; the rest
+            # use the static table above.
+            resolved_home = adapter.resolve_home_dir()
+            if resolved_home is not None:
+                home_dir = resolved_home
+                home_label = str(resolved_home)
+                scan_arg = None
+            else:
+                home_label = _HARNESS_HOME_DIRS.get(ide_name, "")
+                home_dir = Path(home_label.replace("~", str(home))) if home_label else None
+                scan_arg = home
 
             # Skip if home dir doesn't exist
             if home_dir and not home_dir.is_dir():
@@ -109,7 +117,7 @@ def register_scan(app: typer.Typer):
             scan_ctx = nullcontext() if output == "json" else spinner(f"Scanning {home_label or ide_name}...")
             with scan_ctx:
                 try:
-                    home_result = adapter.scan_home(home)
+                    home_result = adapter.scan_home(scan_arg)
                 except NotSupportedError:
                     home_result = type("R", (), {"mcps": [], "skills": [], "hooks": [], "agents": []})()
 

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -43,6 +43,7 @@ _HARNESS_HOME_DIRS: dict[str, str] = {
     "opencode": "~/.config/opencode",
     "antigravity": "~/.gemini",
     "cursor": "~/.cursor",
+    "goose": "~/.config/goose",
     "pi": "~/.pi/agent",
 }
 

--- a/observal_cli/harness/base.py
+++ b/observal_cli/harness/base.py
@@ -57,6 +57,13 @@ class BaseAdapter:
     def harness_name(self) -> str:
         raise NotImplementedError("Subclasses must define harness_name")
 
+    def resolve_home_dir(self) -> Path | None:
+        """Return the harness home directory, for adapters that resolve their own layout.
+
+        ``None`` means the caller should fall back to its static path table.
+        """
+        return None
+
     def scan_home(self, home: Path | None = None) -> ScanResult:
         _check_feature(self.harness_name, "scan_home")
         return ScanResult()

--- a/observal_cli/harness/goose.py
+++ b/observal_cli/harness/goose.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Goose harness adapter.
+
+Discovery surfaces, resolved through ``observal_cli.shared.utils`` so that
+``GOOSE_PATH_ROOT``, XDG overrides, and Windows layouts are all honoured:
+
+  MCP servers  ``extensions:`` in ``<config-dir>/config.yaml``
+  Skills       ``<agents-home>/skills/<name>/SKILL.md`` and ``.agents/skills/...``
+  Agents       ``<agents-home>/agents/<name>.md`` and ``.agents/agents/...``
+  Hooks        ``<agents-home>/plugins/<plugin>/hooks/hooks.json`` and project plugins
+
+Sessions live in a SQLite database, so ``observal_cli.sessions.goose`` projects
+them onto append-only JSONL mirrors that the shared delivery engine consumes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from observal_cli.harness import (
+    DiscoveredAgent,
+    DiscoveredHook,
+    DiscoveredMcp,
+    DiscoveredSkill,
+    HookSpec,
+    ScanResult,
+    SessionSource,
+    register_adapter,
+)
+from observal_cli.harness.base import BaseAdapter
+from observal_cli.shared.utils import (
+    first_content_line,
+    parse_frontmatter_field,
+    resolve_goose_agents_home,
+    resolve_goose_config_dir,
+    resolve_goose_data_dir,
+)
+
+# goose extension types backed by an MCP server Observal can describe. `builtin`,
+# `platform` and `frontend` are in-process, and `inline_python` carries code, not a command.
+_COMMAND_TYPES = frozenset({"stdio"})
+_REMOTE_TYPES = frozenset({"streamable_http", "sse"})
+
+
+class GooseAdapter(BaseAdapter):
+    """Adapter for goose (CLI and Desktop share the same on-disk state)."""
+
+    home_markers = (".config/goose", ".local/share/goose")
+    managed_agent_profiles = ("user:agents/{name}.md", "project:.agents/agents/{name}.md")
+    managed_skills = ("user:skills/{name}/SKILL.md", "project:.agents/skills/{name}/SKILL.md")
+
+    @property
+    def harness_name(self) -> str:
+        return "goose"
+
+    def is_installed(self, home: Path | None = None) -> bool:
+        """Detect goose from its config or data directory on any platform."""
+        if super().is_installed(home):
+            return True
+        if home is not None and home != Path.home():
+            return False
+        return resolve_goose_config_dir().is_dir() or resolve_goose_data_dir().is_dir()
+
+    # ── Sessions ──────────────────────────────────────────────────────
+
+    def resolve_session_source(self, event: dict[str, Any], home: Path | None = None) -> SessionSource | None:
+        from observal_cli.sessions.goose import export_session, resolve_session_id
+
+        session_id = resolve_session_id(event, home=home)
+        if not session_id:
+            return None
+        finalize = self.is_session_final(event) or bool(event.get("_observal_lookup_only"))
+        mirrored = export_session(session_id, home=home, finalize=finalize)
+        if mirrored is None:
+            return None
+        # goose omits working_dir on SessionStart, UserPromptSubmit and SessionEnd.
+        cwd = str(event.get("working_dir") or event.get("cwd") or "") or mirrored.working_dir
+        return SessionSource(self.harness_name, session_id, mirrored.path, cwd=cwd)
+
+    def discover_session_sources(
+        self,
+        home: Path | None = None,
+        since_hours: int = 168,
+    ) -> list[SessionSource]:
+        from observal_cli.sessions.goose import export_session, list_recent_sessions, mirror_path
+
+        cutoff = time.time() - since_hours * 3600
+        sources: list[SessionSource] = []
+        for session in list_recent_sessions(cutoff, home=home):
+            path = mirror_path(session.session_id, home)
+            # Re-reading the database is only worth it when goose wrote after the last export.
+            if not path.is_file() or path.stat().st_mtime <= session.updated_epoch:
+                mirrored = export_session(session.session_id, home=home)
+                if mirrored is None:
+                    continue
+                path = mirrored.path
+            sources.append(
+                SessionSource(
+                    self.harness_name,
+                    session.session_id,
+                    path,
+                    cwd=session.working_dir,
+                    parent_session_id=session.parent_session_id,
+                )
+            )
+        return sources
+
+    def related_session_sources(self, source: SessionSource, home: Path | None = None) -> list[SessionSource]:
+        """Return delegated (subagent) sessions goose linked to this one."""
+        from observal_cli.sessions.goose import export_session, read_child_session_ids
+
+        children: list[SessionSource] = []
+        for child_id, working_dir in read_child_session_ids(source.session_id, home=home):
+            mirrored = export_session(child_id, home=home)
+            if mirrored is None:
+                continue
+            children.append(
+                SessionSource(
+                    self.harness_name,
+                    child_id,
+                    mirrored.path,
+                    cwd=working_dir or mirrored.working_dir or source.cwd,
+                    parent_session_id=source.session_id,
+                )
+            )
+        return children
+
+    def defer_session_delivery(self) -> bool:
+        """goose awaits hooks inside its agent loop, so never block them on network IO."""
+        return True
+
+    def is_session_final(self, event: dict[str, Any]) -> bool:
+        """Only ``SessionEnd`` closes a goose session; ``Stop`` ends a single turn."""
+        return str(event.get("event") or event.get("hook_event_name") or "").lower() == "sessionend"
+
+    # ── Scanning ──────────────────────────────────────────────────────
+
+    def scan_home(self, home: Path | None = None) -> ScanResult:
+        """Discover MCPs, skills, agents, and hooks from the user's goose setup."""
+        config_dir = resolve_goose_config_dir(home)
+        agents_root = resolve_goose_agents_home(home)
+        if not config_dir.is_dir() and not agents_root.is_dir():
+            return ScanResult()
+        return ScanResult(
+            mcps=self._scan_mcps(config_dir / "config.yaml", "goose:global"),
+            skills=self._scan_skills(agents_root / "skills", "goose:skills"),
+            hooks=self._scan_plugins(agents_root / "plugins", "goose:plugins"),
+            agents=self._scan_agents(agents_root / "agents", "goose:agents"),
+        )
+
+    def scan_project(self, project_dir: Path) -> ScanResult:
+        """Discover project-scoped skills, agents, and hook plugins under ``.agents/``."""
+        agents_root = project_dir / ".agents"
+        if not agents_root.is_dir():
+            return ScanResult()
+        return ScanResult(
+            skills=self._scan_skills(agents_root / "skills", "goose:project"),
+            hooks=self._scan_plugins(agents_root / "plugins", "goose:project"),
+            agents=self._scan_agents(agents_root / "agents", "goose:project"),
+        )
+
+    def extract_mcp_servers(self, config: dict) -> dict:
+        """Return goose's ``extensions`` map, which is its MCP server registry."""
+        extensions = config.get("extensions")
+        return extensions if isinstance(extensions, dict) else {}
+
+    # ── Hooks ─────────────────────────────────────────────────────────
+
+    def get_hook_spec(self) -> HookSpec:
+        from observal_cli.harness_specs.goose_hooks_spec import GOOSE_HOOK_EVENTS
+
+        return HookSpec(
+            events=list(GOOSE_HOOK_EVENTS),
+            format="plugin",
+            markers=["observal", "OBSERVAL"],
+        )
+
+    def generate_hook_config(
+        self,
+        observal_url: str,
+        api_key: str,
+        agent_id: str | None = None,
+    ) -> dict[str, Any]:
+        from observal_cli.harness_specs.goose_hooks_spec import build_hooks
+
+        return build_hooks()
+
+    def detect_hooks(self, config_dir: Path) -> str:
+        """Report whether the Observal goose hook plugin is installed.
+
+        *config_dir* is treated as an optional ``.agents`` root so callers (and
+        tests) can point at a sandbox; the real user plugin location is used as
+        the fallback.
+        """
+        from observal_cli.harness_specs.goose_hooks_spec import GOOSE_HOOK_EVENTS, PLUGIN_NAME, hooks_file
+
+        candidates = [config_dir / "plugins" / PLUGIN_NAME / "hooks" / "hooks.json", hooks_file()]
+        path = next((candidate for candidate in candidates if candidate.is_file()), None)
+        if path is None:
+            return "missing"
+        try:
+            hooks = json.loads(path.read_text()).get("hooks", {})
+        except (json.JSONDecodeError, OSError, AttributeError):
+            return "missing"
+        installed = sum(1 for event in GOOSE_HOOK_EVENTS if self._event_has_observal_hook(hooks.get(event)))
+        if installed == len(GOOSE_HOOK_EVENTS):
+            return "installed"
+        return "partial" if installed else "missing"
+
+    def patch_hooks(self, dry_run: bool) -> bool:
+        from observal_cli.cmd_doctor import _patch_goose
+
+        return _patch_goose(dry_run)
+
+    def cleanup_hooks(self, dry_run: bool) -> bool:
+        from observal_cli.cmd_doctor import _cleanup_goose
+
+        return _cleanup_goose(dry_run)
+
+    # ── Private helpers ───────────────────────────────────────────────
+
+    @staticmethod
+    def _event_has_observal_hook(rules: Any) -> bool:
+        from observal_cli.shared.utils import is_observal_hook_entry
+
+        if not isinstance(rules, list):
+            return False
+        return any(
+            is_observal_hook_entry(handler)
+            for rule in rules
+            if isinstance(rule, dict)
+            for handler in rule.get("hooks", [])
+            if isinstance(handler, dict)
+        )
+
+    def _scan_mcps(self, config_file: Path, source: str) -> list[DiscoveredMcp]:
+        """Read goose ``extensions`` and keep the ones backed by an MCP server."""
+        if not config_file.is_file():
+            return []
+        try:
+            config = yaml.safe_load(config_file.read_text()) or {}
+        except (yaml.YAMLError, OSError, UnicodeDecodeError):
+            return []
+        if not isinstance(config, dict):
+            return []
+        mcps: list[DiscoveredMcp] = []
+        for name, entry in self.extract_mcp_servers(config).items():
+            if not isinstance(entry, dict):
+                continue
+            entry_type = str(entry.get("type") or "")
+            if entry_type not in _COMMAND_TYPES and entry_type not in _REMOTE_TYPES:
+                continue  # builtin, platform, frontend and inline_python have no command to record
+            args = entry.get("args") or []
+            mcps.append(
+                DiscoveredMcp(
+                    name=str(entry.get("name") or name),
+                    command=entry.get("cmd") or entry.get("command"),
+                    args=list(args) if isinstance(args, list) else [],
+                    url=entry.get("uri") or entry.get("url"),
+                    description=f"Goose extension: {entry.get('display_name') or name}",
+                    source=source,
+                )
+            )
+        return mcps
+
+    def _scan_skills(self, skills_dir: Path, source: str) -> list[DiscoveredSkill]:
+        if not skills_dir.is_dir():
+            return []
+        skills: list[DiscoveredSkill] = []
+        for skill_md in sorted(skills_dir.glob("*/SKILL.md")):
+            description = ""
+            try:
+                content = skill_md.read_text(errors="ignore")
+                description = parse_frontmatter_field(content, "description") or first_content_line(content)
+            except OSError:
+                pass
+            skills.append(
+                DiscoveredSkill(
+                    name=skill_md.parent.name,
+                    description=description or f"Skill: {skill_md.parent.name}",
+                    source=source,
+                )
+            )
+        return skills
+
+    def _scan_agents(self, agents_dir: Path, source: str) -> list[DiscoveredAgent]:
+        if not agents_dir.is_dir():
+            return []
+        agents: list[DiscoveredAgent] = []
+        for agent_md in sorted(agents_dir.glob("*.md")):
+            content = ""
+            try:
+                content = agent_md.read_text(errors="ignore")
+            except OSError:
+                pass
+            name = parse_frontmatter_field(content, "name") or agent_md.stem
+            agents.append(
+                DiscoveredAgent(
+                    name=name,
+                    description=parse_frontmatter_field(content, "description") or f"Agent: {name}",
+                    model_name=parse_frontmatter_field(content, "model") or "",
+                    prompt=content[:500],
+                    source_file=str(agent_md),
+                )
+            )
+        return agents
+
+    def _scan_plugins(self, plugins_dir: Path, source: str) -> list[DiscoveredHook]:
+        """Discover hook rules declared by goose plugins."""
+        if not plugins_dir.is_dir():
+            return []
+        hooks: list[DiscoveredHook] = []
+        for hooks_json in sorted(plugins_dir.glob("*/hooks/hooks.json")):
+            plugin_name = hooks_json.parent.parent.name
+            try:
+                declared = json.loads(hooks_json.read_text()).get("hooks", {})
+            except (json.JSONDecodeError, OSError, AttributeError):
+                continue
+            if not isinstance(declared, dict):
+                continue
+            for event, rules in declared.items():
+                if not isinstance(rules, list):
+                    continue
+                for rule in rules:
+                    if not isinstance(rule, dict):
+                        continue
+                    for handler in rule.get("hooks", []):
+                        if not isinstance(handler, dict):
+                            continue
+                        hooks.append(
+                            DiscoveredHook(
+                                name=plugin_name,
+                                event=event,
+                                handler_type=handler.get("type", "command"),
+                                handler_config=handler,
+                                description=f"Goose plugin hook: {plugin_name} ({event})",
+                                source=source,
+                            )
+                        )
+        return hooks
+
+
+register_adapter(GooseAdapter())

--- a/observal_cli/harness/goose.py
+++ b/observal_cli/harness/goose.py
@@ -48,6 +48,8 @@ from observal_cli.shared.utils import (
 _COMMAND_TYPES = frozenset({"stdio"})
 _REMOTE_TYPES = frozenset({"streamable_http", "sse"})
 
+_SESSION_PUSH_MODULE = "observal_cli.hooks.session_push"
+
 
 class GooseAdapter(BaseAdapter):
     """Adapter for goose (CLI and Desktop share the same on-disk state)."""
@@ -142,6 +144,18 @@ class GooseAdapter(BaseAdapter):
 
     # ── Scanning ──────────────────────────────────────────────────────
 
+    def resolve_home_dir(self) -> Path | None:
+        """Return the config dir, or the data dir when only that one exists.
+
+        Goose honours ``GOOSE_PATH_ROOT``, XDG and ``%APPDATA%``, so scanning must
+        not assume ``~/.config/goose``.
+        """
+        config_dir = resolve_goose_config_dir()
+        if config_dir.is_dir():
+            return config_dir
+        data_dir = resolve_goose_data_dir()
+        return data_dir if data_dir.is_dir() else config_dir
+
     def scan_home(self, home: Path | None = None) -> ScanResult:
         """Discover MCPs, skills, agents, and hooks from the user's goose setup."""
         config_dir = resolve_goose_config_dir(home)
@@ -218,6 +232,31 @@ class GooseAdapter(BaseAdapter):
         from observal_cli.cmd_doctor import _patch_goose
 
         return _patch_goose(dry_run)
+
+    def rewrite_hooks(self, content: dict, agent_id: str) -> dict:
+        """Point pulled session-push hooks at this machine's interpreter.
+
+        The server cannot know the local interpreter path, whether it needs
+        quoting, or whether ``observal_cli`` is importable without a
+        ``PYTHONPATH``, so the command is replaced with the one ``doctor``
+        installs and compares against.
+        """
+        from observal_cli.harness_specs.goose_hooks_spec import hook_command
+
+        hooks = content.get("hooks")
+        if not isinstance(hooks, dict):
+            return content
+        command = hook_command()
+        for rules in hooks.values():
+            if not isinstance(rules, list):
+                continue
+            for rule in rules:
+                if not isinstance(rule, dict):
+                    continue
+                for handler in rule.get("hooks", []):
+                    if isinstance(handler, dict) and _SESSION_PUSH_MODULE in str(handler.get("command", "")):
+                        handler["command"] = command
+        return content
 
     def cleanup_hooks(self, dry_run: bool) -> bool:
         from observal_cli.cmd_doctor import _cleanup_goose

--- a/observal_cli/harness/load_all.py
+++ b/observal_cli/harness/load_all.py
@@ -9,6 +9,7 @@ from observal_cli.harness import codex as _codex  # noqa: F401
 from observal_cli.harness import copilot as _copilot  # noqa: F401
 from observal_cli.harness import copilot_cli as _copilot_cli  # noqa: F401
 from observal_cli.harness import cursor as _cursor  # noqa: F401
+from observal_cli.harness import goose as _goose  # noqa: F401
 from observal_cli.harness import kiro as _kiro  # noqa: F401
 from observal_cli.harness import opencode as _opencode  # noqa: F401
 from observal_cli.harness import pi as _pi  # noqa: F401

--- a/observal_cli/harness_specs/goose_hooks_spec.py
+++ b/observal_cli/harness_specs/goose_hooks_spec.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Goose hook specification for session telemetry.
+
+Goose follows the Open Plugins hooks spec: hooks are declared by a plugin
+directory that goose discovers from ``~/.agents/plugins/<name>/`` (user) or
+``<project>/.agents/plugins/<name>/`` (project).  Each plugin carries a
+``plugin.json`` manifest and a ``hooks/hooks.json`` file::
+
+    {"hooks": {"<Event>": [{"hooks": [{"type": "command", "command": "...", "timeout": 30}]}]}}
+
+Omitting ``matcher`` runs the rule for every event of that type; ``matcher`` is
+a regular expression, so a bare ``"*"`` would be silently skipped by goose.
+
+Events used for telemetry:
+  SessionStart      establishes the session boundary
+  UserPromptSubmit  flushes newly persisted rows at the start of a turn
+  Stop              flushes the turn once goose finishes it
+  SessionEnd        final flush and integrity audit
+
+The hook command never writes to stdout, so goose's ``PreToolUse``/``Stop``
+block signals are never triggered and telemetry can never deny a tool call.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from pathlib import Path
+
+from observal_cli.shared.utils import resolve_goose_agents_home
+
+PLUGIN_NAME = "observal"
+
+GOOSE_HOOK_EVENTS = (
+    "SessionStart",
+    "UserPromptSubmit",
+    "Stop",
+    "SessionEnd",
+)
+
+# goose defaults to 30s; keep it explicit so a slow first spool cannot be killed.
+HOOK_TIMEOUT_SECONDS = 30
+
+_PKG_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+
+
+def plugin_dir(home: Path | None = None) -> Path:
+    """Return the user-scope Observal plugin directory goose discovers."""
+    return resolve_goose_agents_home(home) / "plugins" / PLUGIN_NAME
+
+
+def hooks_file(home: Path | None = None) -> Path:
+    """Return the user-scope ``hooks/hooks.json`` path for the Observal plugin."""
+    return plugin_dir(home) / "hooks" / "hooks.json"
+
+
+def manifest_file(home: Path | None = None) -> Path:
+    """Return the user-scope ``plugin.json`` path for the Observal plugin."""
+    return plugin_dir(home) / "plugin.json"
+
+
+def _python_cmd() -> str:
+    """Return the python invocation, adding PYTHONPATH when the CLI is not importable.
+
+    goose always runs hook commands through ``sh -c`` (on every platform), so
+    this is POSIX shell syntax and the interpreter path is quoted.
+    """
+    interpreter = shlex.quote(sys.executable)
+    try:
+        import importlib.util
+
+        if importlib.util.find_spec("observal_cli") is not None:
+            return interpreter
+    except Exception:
+        pass
+    return f"PYTHONPATH={shlex.quote(_PKG_ROOT)} {interpreter}"
+
+
+def hook_command() -> str:
+    """Return the shell command goose runs for every Observal hook event."""
+    return f"{_python_cmd()} -m observal_cli.hooks.session_push --harness goose"
+
+
+def build_plugin_manifest() -> dict:
+    """Return the ``plugin.json`` manifest for the Observal goose plugin."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        plugin_version = version("observal-cli")
+    except PackageNotFoundError:
+        plugin_version = "0.0.0"
+    return {
+        "name": PLUGIN_NAME,
+        "version": plugin_version,
+        "description": "Observal session telemetry for goose",
+    }
+
+
+def build_hooks() -> dict:
+    """Return the ``hooks/hooks.json`` content for the Observal goose plugin."""
+    command = hook_command()
+    return {
+        "hooks": {
+            event: [{"hooks": [{"type": "command", "command": command, "timeout": HOOK_TIMEOUT_SECONDS}]}]
+            for event in GOOSE_HOOK_EVENTS
+        }
+    }

--- a/observal_cli/layer.py
+++ b/observal_cli/layer.py
@@ -227,6 +227,38 @@ HARNESS_LAYER_CONFIGS: dict[str, dict[str, list[tuple[str, list[str]]]]] = {
             ),
         ],
     },
+    "goose": {
+        "user": [
+            (
+                "~/.agents",
+                [
+                    "agents/*.md",
+                    "skills/*/SKILL.md",
+                    "plugins/*/plugin.json",
+                    "plugins/*/hooks/hooks.json",
+                ],
+            ),
+            (
+                "~/.config/goose",
+                [
+                    "config.yaml",
+                    ".goosehints",
+                ],
+            ),
+        ],
+        "project": [
+            (
+                ".",
+                [
+                    ".agents/agents/*.md",
+                    ".agents/skills/*/SKILL.md",
+                    ".agents/plugins/*/plugin.json",
+                    ".agents/plugins/*/hooks/hooks.json",
+                    ".goosehints",
+                ],
+            ),
+        ],
+    },
     "copilot-cli": {
         "user": [
             (

--- a/observal_cli/sessions/goose.py
+++ b/observal_cli/sessions/goose.py
@@ -145,10 +145,7 @@ def _read_message_rows(connection: sqlite3.Connection, session_id: str, after_ro
         return []
     optional = [name for name in ("message_id", "metadata_json") if name in available]
     columns = ["id", "role", "content_json", "created_timestamp", *optional]
-    query = (
-        f"SELECT {', '.join(columns)} FROM messages "
-        "WHERE session_id = ? AND id > ? ORDER BY id"
-    )
+    query = f"SELECT {', '.join(columns)} FROM messages WHERE session_id = ? AND id > ? ORDER BY id"
     return connection.execute(query, (session_id, after_row_id)).fetchall()
 
 

--- a/observal_cli/sessions/goose.py
+++ b/observal_cli/sessions/goose.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Goose session helpers: read ``sessions.db`` and mirror it as JSONL.
+
+Goose 1.10+ keeps every CLI and Desktop session in a single SQLite database at
+``<data-dir>/sessions/sessions.db``.  Observal's delivery engine
+(``observal_cli.sessions.base``) is byte-offset based, so this module projects
+each Goose session onto an append-only JSONL mirror under
+``~/.observal/sessions/goose/<session_id>.jsonl``.  The mirror is what the
+shared spool, acknowledgement, checkpoint-recovery and final-hash protocol
+operate on, so Goose needs no bespoke transport.
+
+Reads are strictly non-mutating: the database is opened through a
+``file:...?mode=ro`` URI so SQLite never creates, migrates or checkpoints
+Goose's WAL, and a busy timeout keeps a concurrently writing Goose from
+turning a read into an error.
+
+Mirror records (one JSON object per line):
+
+``{"type": "session", ...}``      session metadata, always the first record
+``{"type": "message", ...}``      one row of the ``messages`` table
+``{"type": "session_end", ...}``  final boundary with the session's usage totals
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from loguru import logger as optic
+
+from observal_cli.shared.utils import resolve_goose_data_dir
+
+# Goose stores message timestamps in seconds, but rows imported from other
+# formats can carry milliseconds. This is the same threshold Goose itself uses.
+_MILLISECOND_TIMESTAMP_THRESHOLD = 10_000_000_000
+
+# Bounded tail read used to recover the mirror's export cursor.
+_CURSOR_TAIL_BYTES = 64 * 1024
+
+_SESSION_COLUMNS = (
+    "id",
+    "name",
+    "description",
+    "session_type",
+    "working_dir",
+    "created_at",
+    "updated_at",
+    "total_tokens",
+    "input_tokens",
+    "output_tokens",
+    "accumulated_total_tokens",
+    "accumulated_input_tokens",
+    "accumulated_output_tokens",
+    "accumulated_cost",
+    "provider_name",
+    "model_config_json",
+    "goose_mode",
+    "parent_session_id",
+    "schedule_id",
+)
+
+_REQUIRED_MESSAGE_COLUMNS = frozenset({"id", "role", "content_json", "created_timestamp"})
+
+
+class MirroredSession(NamedTuple):
+    """A session's JSONL mirror plus the working directory Goose recorded for it."""
+
+    path: Path
+    working_dir: str
+
+
+class GooseSession(NamedTuple):
+    """One row of Goose's ``sessions`` table, as needed for discovery."""
+
+    session_id: str
+    working_dir: str
+    parent_session_id: str | None
+    updated_epoch: float
+
+
+# ---------------------------------------------------------------------------
+# Locations
+# ---------------------------------------------------------------------------
+
+
+def find_sessions_db(home: Path | None = None) -> Path:
+    """Return the path to Goose's session database (which may not exist)."""
+    return resolve_goose_data_dir(home) / "sessions" / "sessions.db"
+
+
+def mirror_dir(home: Path | None = None) -> Path:
+    """Return the directory holding Observal's Goose session mirrors."""
+    return (home or Path.home()) / ".observal" / "sessions" / "goose"
+
+
+def mirror_path(session_id: str, home: Path | None = None) -> Path:
+    """Return the mirror file for one Goose session."""
+    return mirror_dir(home) / f"{_safe_session_id(session_id)}.jsonl"
+
+
+def _safe_session_id(session_id: str) -> str:
+    """Keep a Goose session id usable as a filename on every platform."""
+    return "".join(char if char.isalnum() or char in "-_." else "_" for char in session_id)[:128]
+
+
+# ---------------------------------------------------------------------------
+# Read-only database access
+# ---------------------------------------------------------------------------
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    """Open ``sessions.db`` read-only so Goose's own writes are never blocked."""
+    connection = sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True, timeout=5.0)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def _table_columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    try:
+        return {row["name"] for row in connection.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
+def _read_session_row(connection: sqlite3.Connection, session_id: str) -> dict[str, Any] | None:
+    available = _table_columns(connection, "sessions")
+    if "id" not in available:
+        return None
+    columns = [name for name in _SESSION_COLUMNS if name in available]
+    query = f"SELECT {', '.join(columns)} FROM sessions WHERE id = ?"
+    row = connection.execute(query, (session_id,)).fetchone()
+    return dict(row) if row is not None else None
+
+
+def _read_message_rows(connection: sqlite3.Connection, session_id: str, after_row_id: int) -> list[sqlite3.Row]:
+    available = _table_columns(connection, "messages")
+    if not available >= _REQUIRED_MESSAGE_COLUMNS:
+        return []
+    optional = [name for name in ("message_id", "metadata_json") if name in available]
+    columns = ["id", "role", "content_json", "created_timestamp", *optional]
+    query = (
+        f"SELECT {', '.join(columns)} FROM messages "
+        "WHERE session_id = ? AND id > ? ORDER BY id"
+    )
+    return connection.execute(query, (session_id, after_row_id)).fetchall()
+
+
+def list_recent_sessions(cutoff_epoch: float, home: Path | None = None) -> list[GooseSession]:
+    """Return sessions updated since *cutoff*, most recently updated first.
+
+    Returns an empty list when Goose is not installed or its database cannot
+    be read.
+    """
+    db_path = find_sessions_db(home)
+    if not db_path.is_file():
+        return []
+    try:
+        with closing(_connect(db_path)) as connection:
+            available = _table_columns(connection, "sessions")
+            if "id" not in available:
+                return []
+            parent = "parent_session_id" if "parent_session_id" in available else "NULL AS parent_session_id"
+            query = (
+                f"SELECT id, working_dir, {parent}, "
+                "CAST(strftime('%s', updated_at) AS INTEGER) AS updated_epoch FROM sessions "
+                "WHERE updated_at >= datetime(?, 'unixepoch') ORDER BY updated_at DESC"
+            )
+            rows = connection.execute(query, (int(cutoff_epoch),)).fetchall()
+    except (sqlite3.Error, OSError) as exc:
+        optic.debug("could not list goose sessions from {}: {}", db_path, exc)
+        return []
+    return [
+        GooseSession(row["id"], row["working_dir"] or "", row["parent_session_id"], row["updated_epoch"] or 0)
+        for row in rows
+    ]
+
+
+def read_child_session_ids(session_id: str, home: Path | None = None) -> list[tuple[str, str]]:
+    """Return ``(session_id, working_dir)`` for delegated/subagent children."""
+    db_path = find_sessions_db(home)
+    if not session_id or not db_path.is_file():
+        return []
+    try:
+        with closing(_connect(db_path)) as connection:
+            if "parent_session_id" not in _table_columns(connection, "sessions"):
+                return []
+            rows = connection.execute(
+                "SELECT id, working_dir FROM sessions WHERE parent_session_id = ? ORDER BY id",
+                (session_id,),
+            ).fetchall()
+    except (sqlite3.Error, OSError) as exc:
+        optic.debug("could not read goose child sessions for {}: {}", session_id, exc)
+        return []
+    return [(row["id"], row["working_dir"] or "") for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Mirror state
+# ---------------------------------------------------------------------------
+
+
+def _loads(raw: Any, fallback: Any) -> Any:
+    if not isinstance(raw, str) or not raw:
+        return fallback
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return fallback
+
+
+def _scan_state(blob: bytes) -> tuple[int, bool]:
+    """Return the highest ``row_id`` and whether ``session_end`` appears in *blob*."""
+    row_id = 0
+    has_end = False
+    for line in blob.split(b"\n"):
+        record = _loads(line.decode("utf-8", errors="replace"), None)
+        if not isinstance(record, dict):
+            continue
+        if isinstance(record.get("row_id"), int):
+            row_id = max(row_id, record["row_id"])
+        elif record.get("type") == "session_end":
+            has_end = True
+    return row_id, has_end
+
+
+def _mirror_state(path: Path) -> tuple[int, bool]:
+    """Return the export cursor and finalisation flag recorded in a mirror.
+
+    Reads a bounded tail first; only an inconclusive tail (a single record
+    larger than the window) escalates to reading the whole mirror.
+    """
+    if not path.is_file():
+        return 0, False
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as mirror:
+            mirror.seek(max(0, size - _CURSOR_TAIL_BYTES))
+            state = _scan_state(mirror.read())
+            if state[0] or size <= _CURSOR_TAIL_BYTES:
+                return state
+            mirror.seek(0)
+            return _scan_state(mirror.read())
+    except OSError as exc:
+        optic.warning("could not read goose session mirror {}: {}", path, exc)
+        return 0, False
+
+
+# ---------------------------------------------------------------------------
+# Record building
+# ---------------------------------------------------------------------------
+
+
+def _iso_timestamp(created: Any) -> str:
+    """Convert a Goose ``created_timestamp`` to an ISO-8601 UTC string."""
+    try:
+        epoch = float(created)
+    except (TypeError, ValueError):
+        return ""
+    if epoch > _MILLISECOND_TIMESTAMP_THRESHOLD:
+        epoch /= 1000.0
+    try:
+        return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    except (OverflowError, OSError, ValueError):
+        return ""
+
+
+def _sql_timestamp(value: Any) -> str:
+    """Normalise a SQLite ``TIMESTAMP`` column to an ISO-8601 UTC string."""
+    if not value:
+        return ""
+    text = str(value).strip().replace(" ", "T")
+    return text if text.endswith("Z") or "+" in text else f"{text}Z"
+
+
+def _session_record(session: dict[str, Any]) -> dict[str, Any]:
+    model_config = _loads(session.get("model_config_json"), {})
+    if not isinstance(model_config, dict):
+        model_config = {}
+    return {
+        "type": "session",
+        "session_id": session.get("id", ""),
+        "name": session.get("name") or session.get("description") or "",
+        "session_type": session.get("session_type") or "user",
+        "working_dir": session.get("working_dir") or "",
+        "parent_session_id": session.get("parent_session_id"),
+        "schedule_id": session.get("schedule_id"),
+        "goose_mode": session.get("goose_mode") or "",
+        "provider": session.get("provider_name") or "",
+        "model": model_config.get("model_name") or model_config.get("model") or "",
+        "timestamp": _sql_timestamp(session.get("created_at")),
+    }
+
+
+def _session_end_record(session: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "session_end",
+        "session_id": session.get("id", ""),
+        "timestamp": _sql_timestamp(session.get("updated_at")),
+        "usage": {
+            "inputTokens": session.get("accumulated_input_tokens") or session.get("input_tokens") or 0,
+            "outputTokens": session.get("accumulated_output_tokens") or session.get("output_tokens") or 0,
+            "totalTokens": session.get("accumulated_total_tokens") or session.get("total_tokens") or 0,
+            "cost": session.get("accumulated_cost"),
+        },
+    }
+
+
+def _message_record(row: sqlite3.Row, session_id: str) -> dict[str, Any]:
+    keys = row.keys()
+    return {
+        "type": "message",
+        "row_id": row["id"],
+        "session_id": session_id,
+        "message_id": row["message_id"] if "message_id" in keys else None,
+        "role": row["role"],
+        "timestamp": _iso_timestamp(row["created_timestamp"]),
+        "content": _loads(row["content_json"], []),
+        "metadata": _loads(row["metadata_json"], {}) if "metadata_json" in keys else {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def export_session(session_id: str, home: Path | None = None, *, finalize: bool = False) -> MirroredSession | None:
+    """Append new Goose rows for *session_id* to its JSONL mirror.
+
+    Returns the mirror and the working directory Goose recorded for the
+    session, or None when nothing is readable yet.  The mirror only ever
+    grows, which is what keeps the shared engine's byte offsets and
+    acknowledged checkpoints valid across calls.
+    """
+    if not session_id:
+        return None
+    db_path = find_sessions_db(home)
+    path = mirror_path(session_id, home)
+    existing = MirroredSession(path, "") if path.is_file() else None
+    if not db_path.is_file():
+        optic.debug("goose session database not found at {}", db_path)
+        return existing
+
+    exported_row_id, already_final = _mirror_state(path)
+    try:
+        with closing(_connect(db_path)) as connection:
+            session = _read_session_row(connection, session_id)
+            if session is None:
+                optic.debug("goose session {} is not in {}", session_id, db_path)
+                return existing
+            new_rows = _read_message_rows(connection, session_id, exported_row_id)
+            records = [_message_record(row, session_id) for row in new_rows]
+    except (sqlite3.Error, OSError) as exc:
+        optic.warning("could not read goose session {}: {}", session_id, exc)
+        return existing
+
+    mirrored = MirroredSession(path, str(session.get("working_dir") or ""))
+    if not path.is_file():
+        records.insert(0, _session_record(session))
+    if finalize and not already_final:
+        records.append(_session_end_record(session))
+    if not records:
+        return mirrored
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as mirror:
+            for record in records:
+                mirror.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        optic.error("could not write goose session mirror {}: {}", path, exc)
+        return existing
+    return mirrored
+
+
+def resolve_session_id(event: dict[str, Any], home: Path | None = None) -> str:
+    """Return the session id for a Goose hook payload.
+
+    Goose sends ``session_id`` on every hook event.  The last seen id is cached
+    so an out-of-band finalize or a payload that omits it still resolves.
+    """
+    session_id = str(event.get("session_id") or event.get("sessionId") or "")
+    state_file = (home or Path.home()) / ".observal" / ".goose-session"
+    if session_id:
+        try:
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(json.dumps({"session_id": session_id}))
+        except OSError:
+            pass
+        return session_id
+    try:
+        cached = _loads(state_file.read_text(), {})
+    except OSError:
+        return ""
+    return str(cached.get("session_id", "")) if isinstance(cached, dict) else ""

--- a/observal_cli/shared/utils.py
+++ b/observal_cli/shared/utils.py
@@ -131,6 +131,61 @@ def resolve_antigravity_config_dir(home: Path | None = None) -> Path | None:
     return None
 
 
+def resolve_goose_config_dir(home: Path | None = None) -> Path:
+    """Return Goose's configuration directory (``config.yaml`` lives here)."""
+    root = _goose_path_root()
+    if root is not None:
+        return root / "config"
+    return _goose_dir(home, "config", "XDG_CONFIG_HOME", (".config",))
+
+
+def resolve_goose_data_dir(home: Path | None = None) -> Path:
+    """Return Goose's data directory (``sessions/sessions.db`` lives here)."""
+    root = _goose_path_root()
+    if root is not None:
+        return root / "data"
+    return _goose_dir(home, "data", "XDG_DATA_HOME", (".local", "share"))
+
+
+def resolve_goose_agents_home(home: Path | None = None) -> Path:
+    """Return the ``.agents`` root Goose discovers skills, agents, and plugins from."""
+    root = _goose_path_root()
+    if root is not None:
+        return root / ".agents"
+    return (home or Path.home()) / ".agents"
+
+
+def _goose_path_root() -> Path | None:
+    """Return ``$GOOSE_PATH_ROOT`` when set to an absolute path, as Goose requires."""
+    import os
+
+    raw = os.environ.get("GOOSE_PATH_ROOT", "")
+    root = Path(raw) if raw else None
+    return root if root is not None and root.is_absolute() else None
+
+
+def _goose_dir(home: Path | None, windows_leaf: str, xdg_var: str, unix_parts: tuple[str, ...]) -> Path:
+    """Resolve one Goose directory the way ``etcetera``'s app strategy does.
+
+    Unix follows XDG (``~/.config/goose``, ``~/.local/share/goose``); Windows
+    uses ``%APPDATA%\\Block\\goose\\<leaf>``.  Passing *home* pins the result to
+    the Unix layout under that directory so callers stay hermetic.
+    """
+    if home is not None:
+        return home.joinpath(*unix_parts, "goose")
+    import os
+    import sys
+
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Block" / "goose" / windows_leaf
+    xdg_root = os.environ.get(xdg_var)
+    if xdg_root:
+        return Path(xdg_root) / "goose"
+    return Path.home().joinpath(*unix_parts, "goose")
+
+
 def extract_mcp_servers(config: dict, harness: str = "") -> dict:
     """Extract the MCP server map from an harness config dict.
 

--- a/observal_cli/skills/observal/SKILL.md
+++ b/observal_cli/skills/observal/SKILL.md
@@ -54,7 +54,7 @@ When pulling for Pi, the CLI downloads the agent into an isolated profile using 
 **Crucial:** After pulling, run `/agent <local-profile-name>` inside Pi using the exact local profile name printed by the CLI.
 
 **Flags:**
-- `--harness` (required): `claude-code`, `kiro`, `cursor`, `vscode`, `codex`, `copilot`, `copilot-cli`, `opencode`, `antigravity`, `pi`
+- `--harness` (required): `claude-code`, `kiro`, `cursor`, `vscode`, `codex`, `copilot`, `copilot-cli`, `opencode`, `antigravity`, `goose`, `pi`
 - `--version <semver>`: install a specific version (e.g. `1.2.0`). Omit for latest.
 - `--scope user|project`: install scope for harnesses that support user or project installs
 - `--model <name>` or `--model <harness>=<name>`: override saved model (repeatable)

--- a/packages/observal-shared/observal_shared/harness_models/goose.json
+++ b/packages/observal-shared/observal_shared/harness_models/goose.json
@@ -1,0 +1,72 @@
+{
+  "harness": "goose",
+  "models": [
+    {
+      "id": "claude-opus-4-8",
+      "kind": "exact",
+      "label": "Claude Opus 4.8",
+      "provider": "anthropic"
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "kind": "exact",
+      "label": "Claude Sonnet 4.6",
+      "provider": "anthropic"
+    },
+    {
+      "id": "claude-haiku-4-5",
+      "kind": "exact",
+      "label": "Claude Haiku 4.5",
+      "provider": "anthropic"
+    },
+    {
+      "id": "gpt-5.5",
+      "kind": "exact",
+      "label": "GPT-5.5",
+      "provider": "openai"
+    },
+    {
+      "id": "gpt-5.4",
+      "kind": "exact",
+      "label": "GPT-5.4",
+      "provider": "openai"
+    },
+    {
+      "id": "gemini-3.1-pro",
+      "kind": "exact",
+      "label": "Gemini 3.1 Pro",
+      "provider": "google"
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "kind": "exact",
+      "label": "Gemini 3.5 Flash",
+      "provider": "google"
+    },
+    {
+      "id": "claude-<model-id>",
+      "kind": "provider_source",
+      "label": "Anthropic model from the configured goose provider",
+      "provider": "anthropic"
+    },
+    {
+      "id": "gpt-<model-id>",
+      "kind": "provider_source",
+      "label": "OpenAI model from the configured goose provider",
+      "provider": "openai"
+    },
+    {
+      "id": "gemini-<model-id>",
+      "kind": "provider_source",
+      "label": "Google model from the configured goose provider",
+      "provider": "google"
+    },
+    {
+      "id": "grok-<model-id>",
+      "kind": "provider_source",
+      "label": "xAI model from the configured goose provider",
+      "provider": "xai"
+    }
+  ],
+  "updated_at": "2026-08-07"
+}

--- a/packages/observal-shared/observal_shared/harness_models/goose.json.license
+++ b/packages/observal-shared/observal_shared/harness_models/goose.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+SPDX-License-Identifier: Apache-2.0

--- a/packages/observal-shared/observal_shared/harness_registry.py
+++ b/packages/observal-shared/observal_shared/harness_registry.py
@@ -304,6 +304,46 @@ HARNESS_REGISTRY: dict[str, dict] = {
         },
         "config_dir": ".agents",
     },
+    "goose": {
+        "display_name": "Goose",
+        "capabilities": {"skills", "hooks", "mcp_servers"},
+        "session_parser": "goose",
+        "scopes": ["project", "user"],
+        "default_scope": "user",
+        "scope_labels": ("project (.agents/agents/)", "user (~/.agents/agents/)"),
+        "agent_profile": {
+            "project": ".agents/agents/{name}.md",
+            "user": "~/.agents/agents/{name}.md",
+        },
+        "agent_profile_format": "yaml_frontmatter",
+        # Goose only reads extensions from its single user-level config file.
+        "mcp_config": {
+            "project": None,
+            "user": "~/.config/goose/config.yaml",
+        },
+        "mcp_servers_key": "extensions",
+        "home_mcp_config": "~/.config/goose/config.yaml",
+        "skills": {
+            "project": ".agents/skills/{name}/SKILL.md",
+            "user": "~/.agents/skills/{name}/SKILL.md",
+        },
+        "skill_format": "yaml_frontmatter",
+        "hook_type": "plugin",
+        "hooks": {
+            "project": ".agents/plugins/observal/hooks/hooks.json",
+            "user": "~/.agents/plugins/observal/hooks/hooks.json",
+        },
+        "hook_scripts_dir": ".agents/plugins/observal/scripts",
+        "hook_events_map": {
+            "PreToolUse": "PreToolUse",
+            "PostToolUse": "PostToolUse",
+            "Stop": "Stop",
+            "SessionStart": "SessionStart",
+            "SessionEnd": "SessionEnd",
+            "UserPromptSubmit": "UserPromptSubmit",
+        },
+        "config_dir": ".config/goose",
+    },
     "pi": {
         "display_name": "Pi",
         "capabilities": {"skills", "hooks", "mcp_servers"},
@@ -357,6 +397,7 @@ _GUIDANCE_FILES = {
     ],
     "opencode": ["opencode.json", "~/.config/opencode/opencode.json"],
     "antigravity": ["AGENTS.md", "GEMINI.md"],
+    "goose": [".goosehints", "~/.config/goose/.goosehints", "AGENTS.md"],
     "pi": ["AGENTS.md", "~/.pi/agent/AGENTS.md", ".pi/SYSTEM.md", ".pi/APPEND_SYSTEM.md"],
 }
 

--- a/scripts/refresh_harness_models.py
+++ b/scripts/refresh_harness_models.py
@@ -286,6 +286,40 @@ STATIC: dict[str, list[dict]] = {
             "kind": "provider_source",
         },
     ],
+    "goose": [
+        {"id": "claude-opus-4-8", "label": "Claude Opus 4.8", "provider": "anthropic", "kind": "exact"},
+        {"id": "claude-sonnet-4-6", "label": "Claude Sonnet 4.6", "provider": "anthropic", "kind": "exact"},
+        {"id": "claude-haiku-4-5", "label": "Claude Haiku 4.5", "provider": "anthropic", "kind": "exact"},
+        {"id": "gpt-5.5", "label": "GPT-5.5", "provider": "openai", "kind": "exact"},
+        {"id": "gpt-5.4", "label": "GPT-5.4", "provider": "openai", "kind": "exact"},
+        {"id": "gemini-3.1-pro", "label": "Gemini 3.1 Pro", "provider": "google", "kind": "exact"},
+        {"id": "gemini-3.5-flash", "label": "Gemini 3.5 Flash", "provider": "google", "kind": "exact"},
+        # goose stores the bare provider model name, so BYO models are matched by family prefix.
+        {
+            "id": "claude-<model-id>",
+            "label": "Anthropic model from the configured goose provider",
+            "provider": "anthropic",
+            "kind": "provider_source",
+        },
+        {
+            "id": "gpt-<model-id>",
+            "label": "OpenAI model from the configured goose provider",
+            "provider": "openai",
+            "kind": "provider_source",
+        },
+        {
+            "id": "gemini-<model-id>",
+            "label": "Google model from the configured goose provider",
+            "provider": "google",
+            "kind": "provider_source",
+        },
+        {
+            "id": "grok-<model-id>",
+            "label": "xAI model from the configured goose provider",
+            "provider": "xai",
+            "kind": "provider_source",
+        },
+    ],
 }
 
 

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -23,6 +23,7 @@ from observal_cli.cmd_doctor import (
     _check_copilot,
     _check_copilot_cli,
     _check_cursor,
+    _check_goose,
     _check_kiro,
     _check_observal_config,
     _check_observal_skill_missing,
@@ -33,6 +34,7 @@ from observal_cli.cmd_doctor import (
     _cleanup_copilot,
     _cleanup_copilot_cli,
     _cleanup_cursor,
+    _cleanup_goose,
     _cleanup_kiro,
     _cleanup_opencode,
     _cleanup_pi,
@@ -42,6 +44,7 @@ from observal_cli.cmd_doctor import (
     _patch_copilot,
     _patch_copilot_cli,
     _patch_cursor,
+    _patch_goose,
     _patch_kiro,
     _patch_opencode,
     _patch_pi,
@@ -69,6 +72,16 @@ def write_json(path: Path, data: dict) -> None:
 
 def read_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def goose_home(isolated_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin goose's environment-derived directories to the isolated home."""
+    monkeypatch.delenv("GOOSE_PATH_ROOT", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    (isolated_home / ".config/goose").mkdir(parents=True)
+    return isolated_home
 
 
 class TestHookIdentification:
@@ -180,6 +193,43 @@ class TestChecks:
         _check_antigravity([], warnings)
 
         assert any("Antigravity session push hooks not installed" in warning for warning in warnings)
+
+    def test_goose_is_silent_when_not_installed(self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        warnings: list[str] = []
+
+        _check_goose([], warnings)
+
+        assert warnings == []
+
+    def test_goose_warns_when_the_hook_plugin_is_missing(self, goose_home: Path):
+        warnings: list[str] = []
+
+        _check_goose([], warnings)
+
+        assert any("Goose session push hooks not installed" in warning for warning in warnings)
+
+    def test_goose_warns_when_hooks_are_stale(self, goose_home: Path):
+        write_json(
+            goose_home / ".agents/plugins/observal/hooks/hooks.json",
+            {"hooks": {"SessionEnd": [{"hooks": [{"type": "command", "command": "old"}]}]}},
+        )
+        warnings: list[str] = []
+
+        _check_goose([], warnings)
+
+        assert any("missing or stale" in warning for warning in warnings)
+
+    def test_goose_reports_invalid_hook_json_as_an_issue(self, goose_home: Path):
+        hooks_path = goose_home / ".agents/plugins/observal/hooks/hooks.json"
+        hooks_path.parent.mkdir(parents=True)
+        hooks_path.write_text("{ not json", encoding="utf-8")
+        issues: list[str] = []
+
+        _check_goose(issues, [])
+
+        assert any("not valid JSON" in issue for issue in issues)
 
     def test_observal_skill_missing_reports_detected_harnesses(self, tmp_path: Path):
         (tmp_path / ".pi/agent").mkdir(parents=True)
@@ -310,6 +360,29 @@ class TestPatchFunctions:
         assert "observal-telemetry" in read_json(config_dir / "hooks.json")
         assert _patch_antigravity(dry_run=False) is False
 
+    def test_patch_goose_installs_plugin_and_preserves_foreign_hooks(self, goose_home: Path):
+        hooks_path = goose_home / ".agents/plugins/observal/hooks/hooks.json"
+        write_json(hooks_path, {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "foreign"}]}]}})
+
+        assert _patch_goose(dry_run=False) is True
+
+        assert read_json(goose_home / ".agents/plugins/observal/plugin.json")["name"] == "observal"
+        rules = read_json(hooks_path)["hooks"]
+        assert rules["Stop"][0]["hooks"][0]["command"] == "foreign"
+        assert any("--harness goose" in handler["command"] for rule in rules["SessionEnd"] for handler in rule["hooks"])
+        assert _patch_goose(dry_run=False) is False
+
+    def test_patch_goose_skips_when_goose_is_not_installed(self, isolated_home: Path, monkeypatch):
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
+        assert _patch_goose(dry_run=False) is False
+        assert not (isolated_home / ".agents").exists()
+
+    def test_patch_goose_dry_run_writes_nothing(self, goose_home: Path):
+        assert _patch_goose(dry_run=True) is True
+        assert not (goose_home / ".agents").exists()
+
     def test_doctor_yes_runs_supported_patch_command(self, tmp_path: Path):
         (tmp_path / ".cursor").mkdir()
         with (
@@ -425,5 +498,20 @@ class TestCleanupFunctions:
         plugin_path.write_text("plugin", encoding="utf-8")
 
         assert _cleanup_opencode(dry_run=False) is True
-
         assert not plugin_path.exists()
+
+    def test_cleanup_goose_removes_the_hook_plugin(self, goose_home: Path):
+        plugin_dir = goose_home / ".agents/plugins/observal"
+        write_json(plugin_dir / "hooks/hooks.json", {"hooks": {}})
+        write_json(plugin_dir / "plugin.json", {"name": "observal"})
+
+        assert _cleanup_goose(dry_run=False) is True
+        assert not plugin_dir.exists()
+        assert _cleanup_goose(dry_run=False) is False
+
+    def test_cleanup_goose_dry_run_keeps_the_plugin(self, goose_home: Path):
+        plugin_dir = goose_home / ".agents/plugins/observal"
+        write_json(plugin_dir / "hooks/hooks.json", {"hooks": {}})
+
+        assert _cleanup_goose(dry_run=True) is True
+        assert plugin_dir.exists()

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -80,6 +80,7 @@ def goose_home(isolated_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.delenv("GOOSE_PATH_ROOT", raising=False)
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)  # goose reads %APPDATA% on Windows
     (isolated_home / ".config/goose").mkdir(parents=True)
     return isolated_home
 
@@ -197,6 +198,7 @@ class TestChecks:
     def test_goose_is_silent_when_not_installed(self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("APPDATA", raising=False)
         warnings: list[str] = []
 
         _check_goose([], warnings)
@@ -230,6 +232,28 @@ class TestChecks:
         _check_goose(issues, [])
 
         assert any("not valid JSON" in issue for issue in issues)
+
+    def test_goose_reports_a_non_object_hook_root_as_an_issue(self, goose_home: Path):
+        hooks_path = goose_home / ".agents/plugins/observal/hooks/hooks.json"
+        hooks_path.parent.mkdir(parents=True)
+        hooks_path.write_text("[1]", encoding="utf-8")
+        issues: list[str] = []
+
+        _check_goose(issues, [])
+
+        assert any("not valid JSON" in issue for issue in issues)
+
+    def test_goose_is_not_stale_when_foreign_rules_sit_beside_ours(self, goose_home: Path):
+        write_json(
+            goose_home / ".agents/plugins/observal/hooks/hooks.json",
+            {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "foreign"}]}]}},
+        )
+        _patch_goose(dry_run=False)
+        warnings: list[str] = []
+
+        _check_goose([], warnings)
+
+        assert warnings == []
 
     def test_observal_skill_missing_reports_detected_harnesses(self, tmp_path: Path):
         (tmp_path / ".pi/agent").mkdir(parents=True)
@@ -375,6 +399,7 @@ class TestPatchFunctions:
     def test_patch_goose_skips_when_goose_is_not_installed(self, isolated_home: Path, monkeypatch):
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("APPDATA", raising=False)
 
         assert _patch_goose(dry_run=False) is False
         assert not (isolated_home / ".agents").exists()
@@ -515,3 +540,13 @@ class TestCleanupFunctions:
 
         assert _cleanup_goose(dry_run=True) is True
         assert plugin_dir.exists()
+
+    def test_cleanup_goose_preserves_foreign_hook_rules(self, goose_home: Path):
+        hooks_path = goose_home / ".agents/plugins/observal/hooks/hooks.json"
+        write_json(hooks_path, {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "foreign"}]}]}})
+        _patch_goose(dry_run=False)
+
+        assert _cleanup_goose(dry_run=False) is True
+
+        rules = read_json(hooks_path)["hooks"]
+        assert rules == {"Stop": [{"hooks": [{"type": "command", "command": "foreign"}]}]}

--- a/tests/test_goose_adapter.py
+++ b/tests/test_goose_adapter.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Goose harness adapters (CLI scanning + server config generation)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from observal_cli.harness import ensure_loaded, get_adapter
+from observal_cli.harness.goose import GooseAdapter
+from observal_shared.harness_registry import HARNESS_REGISTRY
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _load_adapters(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("GOOSE_PATH_ROOT", raising=False)
+    ensure_loaded()
+
+
+def _write_config(home: Path, extensions: dict, extra: dict | None = None) -> Path:
+    config_dir = home / ".config" / "goose"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    path = config_dir / "config.yaml"
+    path.write_text(yaml.safe_dump({**(extra or {}), "extensions": extensions}))
+    return path
+
+
+# ── Registry ──────────────────────────────────────────────────────────────────
+
+
+def test_goose_registry_entry_is_complete():
+    spec = HARNESS_REGISTRY["goose"]
+    required = {
+        "display_name",
+        "capabilities",
+        "scopes",
+        "default_scope",
+        "agent_profile",
+        "mcp_config",
+        "mcp_servers_key",
+        "skills",
+        "hooks",
+        "hook_events_map",
+        "session_parser",
+    }
+    assert required <= set(spec)
+    assert spec["mcp_servers_key"] == "extensions"
+    assert spec["session_parser"] == "goose"
+    assert spec["hook_type"] == "plugin"
+    assert spec["mcp_config"]["user"] == "~/.config/goose/config.yaml"
+    assert spec["skills"]["user"] == "~/.agents/skills/{name}/SKILL.md"
+    assert spec["agent_profile"]["user"] == "~/.agents/agents/{name}.md"
+
+
+def test_goose_adapters_are_registered():
+    from services.harness import ensure_loaded as server_loaded
+    from services.harness import get_adapter as server_adapter
+
+    server_loaded()
+    assert get_adapter("goose").harness_name == "goose"
+    assert server_adapter("goose").harness_name == "goose"
+
+
+# ── Detection ─────────────────────────────────────────────────────────────────
+
+
+def test_is_installed_requires_a_goose_directory(tmp_path: Path):
+    adapter = GooseAdapter()
+    assert adapter.is_installed(tmp_path) is False
+    (tmp_path / ".config" / "goose").mkdir(parents=True)
+    assert adapter.is_installed(tmp_path) is True
+
+
+def test_is_installed_accepts_the_data_directory(tmp_path: Path):
+    (tmp_path / ".local" / "share" / "goose").mkdir(parents=True)
+    assert GooseAdapter().is_installed(tmp_path) is True
+
+
+# ── Scanning ──────────────────────────────────────────────────────────────────
+
+
+def test_scan_home_empty(tmp_path: Path):
+    result = GooseAdapter().scan_home(tmp_path)
+    assert result.mcps == []
+    assert result.skills == []
+    assert result.hooks == []
+    assert result.agents == []
+
+
+def test_scan_home_discovers_stdio_and_streamable_http_extensions(tmp_path: Path):
+    _write_config(
+        tmp_path,
+        {
+            "developer": {"type": "builtin", "name": "developer", "enabled": True},
+            "computercontroller": {"type": "platform", "name": "computercontroller", "enabled": True},
+            "snippet": {"type": "inline_python", "name": "snippet", "code": "print(1)"},
+            "filesystem": {
+                "type": "stdio",
+                "name": "filesystem",
+                "cmd": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            },
+            "legacy-sse": {"type": "sse", "name": "legacy-sse", "uri": "https://example.com/sse"},
+            "remote-tools": {"type": "streamable_http", "name": "remote", "uri": "https://example.com/mcp"},
+        },
+    )
+
+    mcps = {mcp.name: mcp for mcp in GooseAdapter().scan_home(tmp_path).mcps}
+
+    # builtin, platform and inline_python extensions have no command to record.
+    assert set(mcps) == {"filesystem", "legacy-sse", "remote"}
+    assert mcps["filesystem"].command == "npx"
+    assert mcps["filesystem"].args == ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    assert mcps["remote"].url == "https://example.com/mcp"
+    assert mcps["legacy-sse"].url == "https://example.com/sse"
+
+
+def test_scan_home_survives_malformed_config(tmp_path: Path):
+    config_dir = tmp_path / ".config" / "goose"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.yaml").write_text("extensions: [unclosed\n")
+    assert GooseAdapter().scan_home(tmp_path).mcps == []
+
+
+def test_scan_home_discovers_skills_agents_and_plugin_hooks(tmp_path: Path):
+    skill = tmp_path / ".agents" / "skills" / "helper"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: helper\ndescription: Does helpful things\n---\n")
+
+    agents = tmp_path / ".agents" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "reviewer.md").write_text(
+        "---\nname: code-reviewer\ndescription: Reviews code\nmodel: gpt-5.5\n---\nBe direct."
+    )
+
+    hooks = tmp_path / ".agents" / "plugins" / "observal" / "hooks"
+    hooks.mkdir(parents=True)
+    hooks.joinpath("hooks.json").write_text(
+        json.dumps({"hooks": {"SessionEnd": [{"hooks": [{"type": "command", "command": "observal_cli"}]}]}})
+    )
+
+    result = GooseAdapter().scan_home(tmp_path)
+
+    assert [skill.name for skill in result.skills] == ["helper"]
+    assert result.skills[0].description == "Does helpful things"
+    assert [agent.name for agent in result.agents] == ["code-reviewer"]
+    assert result.agents[0].model_name == "gpt-5.5"
+    assert [(hook.name, hook.event) for hook in result.hooks] == [("observal", "SessionEnd")]
+
+
+def test_scan_project_discovers_project_agents_dir(tmp_path: Path):
+    skill = tmp_path / ".agents" / "skills" / "project-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\ndescription: Project scoped\n---\n")
+
+    result = GooseAdapter().scan_project(tmp_path)
+
+    assert [skill.name for skill in result.skills] == ["project-skill"]
+    assert result.mcps == []  # goose only reads extensions from the user config
+
+
+def test_extract_mcp_servers_ignores_unrelated_config_sections():
+    adapter = GooseAdapter()
+    config = {"active_provider": "anthropic", "providers": {"anthropic": {"enabled": True}}}
+    assert adapter.extract_mcp_servers(config) == {}
+    assert adapter.extract_mcp_servers({"extensions": {"a": {}}}) == {"a": {}}
+
+
+# ── Hooks ─────────────────────────────────────────────────────────────────────
+
+
+def test_detect_hooks_missing(tmp_path: Path):
+    assert GooseAdapter().detect_hooks(tmp_path) == "missing"
+
+
+def test_detect_hooks_installed_and_partial(tmp_path: Path):
+    from observal_cli.harness_specs.goose_hooks_spec import GOOSE_HOOK_EVENTS, build_hooks
+
+    hooks_dir = tmp_path / "plugins" / "observal" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    hooks_json = hooks_dir / "hooks.json"
+
+    hooks_json.write_text(json.dumps(build_hooks()))
+    assert GooseAdapter().detect_hooks(tmp_path) == "installed"
+
+    partial = build_hooks()
+    partial["hooks"].pop(GOOSE_HOOK_EVENTS[-1])
+    hooks_json.write_text(json.dumps(partial))
+    assert GooseAdapter().detect_hooks(tmp_path) == "partial"
+
+    hooks_json.write_text("{ not json")
+    assert GooseAdapter().detect_hooks(tmp_path) == "missing"
+
+
+def test_hook_spec_uses_documented_goose_events():
+    spec = GooseAdapter().get_hook_spec()
+    assert spec.format == "plugin"
+    assert set(spec.events) == {"SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"}
+
+
+def test_generated_hook_rules_omit_matcher_and_never_write_stdout():
+    from observal_cli.harness_specs.goose_hooks_spec import build_hooks
+
+    hooks = build_hooks()["hooks"]
+    for rules in hooks.values():
+        assert len(rules) == 1
+        assert "matcher" not in rules[0]  # a bare glob matcher would be skipped by goose
+        handler = rules[0]["hooks"][0]
+        assert handler["type"] == "command"
+        assert "--harness goose" in handler["command"]
+        assert "--json-response" not in handler["command"]
+
+
+def test_hook_command_is_posix_shell_safe(monkeypatch: pytest.MonkeyPatch):
+    """goose runs every hook through ``sh -c``, including on Windows."""
+    import shlex
+
+    from observal_cli.harness_specs import goose_hooks_spec
+
+    monkeypatch.setattr(goose_hooks_spec.sys, "executable", "/opt/py 3.14/bin/python")
+    command = goose_hooks_spec.hook_command()
+
+    assert shlex.split(command)[:3] == ["/opt/py 3.14/bin/python", "-m", "observal_cli.hooks.session_push"]
+    assert "&&" not in command  # cmd.exe syntax would never parse under sh -c
+
+
+# ── Layer attribution ─────────────────────────────────────────────────────────
+
+
+def test_managed_files_for_layer_source_attribution():
+    lockfile = {
+        "harnesses": {
+            "goose": {
+                "agents": [{"name": "agent-one", "components": [{"type": "skill", "name": "helper"}]}],
+            }
+        }
+    }
+    assert GooseAdapter().get_observal_managed_files(lockfile) == {
+        "user:agents/agent-one.md",
+        "project:.agents/agents/agent-one.md",
+        "user:skills/helper/SKILL.md",
+        "project:.agents/skills/helper/SKILL.md",
+    }
+
+
+def test_layer_scan_globs_registered():
+    from observal_cli.layer import HARNESS_LAYER_CONFIGS
+
+    config = HARNESS_LAYER_CONFIGS["goose"]
+    user_bases = {base for base, _patterns in config["user"]}
+    assert user_bases == {"~/.agents", "~/.config/goose"}
+    assert any("config.yaml" in patterns for _base, patterns in config["user"])
+
+
+# ── Server-side config generation ─────────────────────────────────────────────
+
+
+def _agent(description: str = "A goose test agent") -> MagicMock:
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "goose-agent"
+    agent.description = description
+    agent.prompt = "You are helpful."
+    agent.model_name = "gpt-5.5"
+    agent.components = []
+    agent.external_mcps = []
+    return agent
+
+
+def _generate(**options):
+    from services.harness import generate_agent_config
+
+    return generate_agent_config(_agent(), "goose", options=options)
+
+
+def test_server_config_writes_agent_markdown_with_frontmatter():
+    result = _generate(scope="user", _resolved_model="gpt-5.5")
+
+    profile = result["agent_profile"]
+    assert profile["path"] == "~/.agents/agents/goose-agent.md"
+    header, body = profile["content"].split("---\n", 2)[1:]
+    frontmatter = yaml.safe_load(header)
+    assert frontmatter["name"] == "goose-agent"
+    assert frontmatter["model"] == "gpt-5.5"
+    assert "You are helpful." in body
+
+
+def test_server_config_agent_markdown_escapes_yaml_hostile_descriptions():
+    from services.harness import generate_agent_config
+
+    agent = _agent(description='Reviews: "code" & stuff #1')
+    content = generate_agent_config(agent, "goose", options={"scope": "user"})["agent_profile"]["content"]
+    frontmatter = yaml.safe_load(content.split("---\n", 2)[1])
+    assert frontmatter["description"] == 'Reviews: "code" & stuff #1'
+
+
+def test_server_config_emits_goose_extension_entries():
+    from services.harness import McpConfigContext, ensure_loaded, get_adapter
+
+    ensure_loaded()
+    adapter = get_adapter("goose")
+
+    stdio = adapter.agent_mcp_entry(
+        McpConfigContext(
+            name="fs",
+            command="npx",
+            args=["-y", "server"],
+            server_env={"TOKEN": "x"},
+            headers={},
+            transport="stdio",
+            url=None,
+            auto_approve=[],
+        )
+    )
+    assert stdio == {
+        "type": "stdio",
+        "name": "fs",
+        "enabled": True,
+        "cmd": "npx",
+        "args": ["-y", "server"],
+        "envs": {"TOKEN": "x"},
+        "env_keys": [],
+        "timeout": 300,
+    }
+
+    remote = adapter.agent_mcp_entry(
+        McpConfigContext(
+            name="remote",
+            command="",
+            args=[],
+            server_env={},
+            headers={"Authorization": "Bearer x"},
+            transport="streamable_http",
+            url="https://example.com/mcp",
+            auto_approve=[],
+        )
+    )
+    assert remote["type"] == "streamable_http"
+    assert remote["uri"] == "https://example.com/mcp"
+    assert remote["headers"] == {"Authorization": "Bearer x"}
+
+
+def test_server_config_normalises_external_mcp_entries():
+    from services.harness import generate_agent_config
+
+    agent = _agent()
+    agent.external_mcps = [{"name": "extra", "command": "node", "args": ["server.js"]}]
+    result = generate_agent_config(agent, "goose", options={"scope": "user"})
+
+    extensions = result["mcp_config"]["content"]["extensions"]
+    assert result["mcp_config"]["path"] == "~/.config/goose/config.yaml"
+    assert extensions["extra"]["type"] == "stdio"
+    assert extensions["extra"]["cmd"] == "node"
+    assert extensions["extra"]["envs"]["OBSERVAL_AGENT_ID"] == str(agent.id)
+
+
+def test_server_config_emits_plugin_manifest_and_telemetry_hooks():
+    result = _generate(scope="user")
+
+    hooks = result["hooks_config"]
+    assert hooks["path"] == "~/.agents/plugins/observal/hooks/hooks.json"
+    assert hooks["merge"] is True
+    assert set(hooks["content"]["hooks"]) == {"SessionStart", "UserPromptSubmit", "Stop", "SessionEnd"}
+
+    manifest = next(f for f in result["hook_files"] if f["path"].endswith("plugin.json"))
+    assert manifest["path"] == "~/.agents/plugins/observal/plugin.json"
+    assert json.loads(manifest["content"])["name"] == "observal"
+
+
+def test_server_config_omits_mcp_section_when_agent_has_no_servers():
+    assert "mcp_config" not in _generate(scope="user")

--- a/tests/test_goose_adapter.py
+++ b/tests/test_goose_adapter.py
@@ -179,7 +179,9 @@ def test_extract_mcp_servers_ignores_unrelated_config_sections():
 # ── Hooks ─────────────────────────────────────────────────────────────────────
 
 
-def test_detect_hooks_missing(tmp_path: Path):
+def test_detect_hooks_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Without this the user-scope fallback would read the developer's real plugin.
+    monkeypatch.setenv("GOOSE_PATH_ROOT", str(tmp_path))
     assert GooseAdapter().detect_hooks(tmp_path) == "missing"
 
 
@@ -200,6 +202,28 @@ def test_detect_hooks_installed_and_partial(tmp_path: Path):
 
     hooks_json.write_text("{ not json")
     assert GooseAdapter().detect_hooks(tmp_path) == "missing"
+
+
+def test_rewrite_hooks_repoints_pulled_commands_at_the_local_interpreter():
+    from observal_cli.harness_specs.goose_hooks_spec import hook_command
+
+    pulled = {
+        "hooks": {
+            "Stop": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": "python3 -m observal_cli.hooks.session_push --harness goose"}
+                    ]
+                },
+                {"hooks": [{"type": "command", "command": "/usr/local/bin/my-hook.sh"}]},
+            ]
+        }
+    }
+
+    rewritten = GooseAdapter().rewrite_hooks(pulled, agent_id="a1")["hooks"]["Stop"]
+
+    assert rewritten[0]["hooks"][0]["command"] == hook_command()
+    assert rewritten[1]["hooks"][0]["command"] == "/usr/local/bin/my-hook.sh"
 
 
 def test_hook_spec_uses_documented_goose_events():

--- a/tests/test_goose_session_delivery.py
+++ b/tests/test_goose_session_delivery.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Goose session delivery through the shared acknowledged-delivery pipeline."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import TYPE_CHECKING
+
+from observal_cli import telemetry_buffer
+from observal_cli.hooks import session_push
+from observal_cli.sessions import base
+from observal_cli.sessions import goose as goose_sessions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_DDL = (
+    """
+    CREATE TABLE sessions (
+        id TEXT PRIMARY KEY, name TEXT DEFAULT '', description TEXT DEFAULT '',
+        session_type TEXT DEFAULT 'user', working_dir TEXT NOT NULL,
+        created_at TIMESTAMP, updated_at TIMESTAMP,
+        accumulated_input_tokens INTEGER, accumulated_output_tokens INTEGER,
+        accumulated_total_tokens INTEGER, accumulated_cost REAL,
+        provider_name TEXT, model_config_json TEXT, goose_mode TEXT DEFAULT 'auto',
+        schedule_id TEXT, parent_session_id TEXT
+    )
+    """,
+    """
+    CREATE TABLE messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT, session_id TEXT NOT NULL,
+        role TEXT NOT NULL, content_json TEXT NOT NULL, created_timestamp INTEGER NOT NULL,
+        metadata_json TEXT
+    )
+    """,
+)
+
+
+def _seed_goose(home: Path, session_id: str = "20260807_1") -> None:
+    db = home / ".local" / "share" / "goose" / "sessions" / "sessions.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db) as connection:
+        for statement in _DDL:
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO sessions (id, name, working_dir, created_at, updated_at) VALUES (?,?,?,?,?)",
+            (session_id, "Fix parser", "/project", "2026-08-07 11:59:00", "2026-08-07 12:00:00"),
+        )
+        connection.execute(
+            "INSERT INTO messages (message_id, session_id, role, content_json, created_timestamp, metadata_json) "
+            "VALUES (?,?,?,?,?,?)",
+            ("msg-1", session_id, "user", json.dumps([{"type": "text", "text": "hi"}]), 1_785_000_000, "{}"),
+        )
+
+
+def _configure(home: Path, monkeypatch, tmp_path: Path):
+    config_dir = home / ".observal"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.json").write_text(
+        json.dumps({"server_url": "http://server", "access_token": "token", "user_id": "user"})
+    )
+    db = tmp_path / "outbox.db"
+    monkeypatch.setattr(telemetry_buffer, "DB_PATH", db)
+    monkeypatch.setattr(base, "_resolve_agent", lambda *_a, **_k: (None, None))
+    monkeypatch.setattr(base, "_get_cached_layer_hash", lambda *_a, **_k: None)
+    return db
+
+
+def test_hook_spools_goose_records_into_the_shared_outbox(tmp_path: Path, monkeypatch):
+    _seed_goose(tmp_path)
+    db = _configure(tmp_path, monkeypatch, tmp_path)
+    monkeypatch.setattr(base, "post_to_server_ack", lambda *_a, **_k: None)
+    monkeypatch.setattr(session_push, "_spawn_worker", lambda *_a, **_k: None)
+
+    session_push._run_hook(
+        {"event": "UserPromptSubmit", "session_id": "20260807_1", "working_dir": "/project"},
+        harness="goose",
+        home=tmp_path,
+    )
+
+    item = telemetry_buffer.pending(destination="http://server", user_id="user", db_path=db)[0]
+    assert item.harness == "goose"
+    assert item.payload["hook_event"] == "UserPromptSubmit"
+    types = [json.loads(line)["type"] for line in item.payload["lines"]]
+    assert types == ["session", "message"]
+
+
+def test_hook_never_posts_inline_and_hands_delivery_to_a_worker(tmp_path: Path, monkeypatch):
+    """goose awaits hooks inside its agent loop, so the hook must only spool."""
+    _seed_goose(tmp_path)
+    db = _configure(tmp_path, monkeypatch, tmp_path)
+    posts: list = []
+    workers: list[tuple] = []
+    monkeypatch.setattr(base, "post_to_server_ack", lambda *a, **k: posts.append(a) or None)
+    monkeypatch.setattr(session_push, "_spawn_worker", lambda *args, harness: workers.append((args, harness)))
+
+    session_push._run_hook(
+        {"event": "Stop", "session_id": "20260807_1", "working_dir": "/project"},
+        harness="goose",
+        home=tmp_path,
+    )
+
+    assert posts == []
+    assert ("--drain-outbox",) in [args for args, _harness in workers]
+    assert telemetry_buffer.pending(destination="http://server", user_id="user", db_path=db)
+
+
+def test_hook_recovers_the_working_dir_goose_omits(tmp_path: Path, monkeypatch):
+    """SessionStart, UserPromptSubmit and SessionEnd carry no working_dir."""
+    _seed_goose(tmp_path)
+    _configure(tmp_path, monkeypatch, tmp_path)
+    monkeypatch.setattr(session_push, "_spawn_worker", lambda *_a, **_k: None)
+
+    from observal_cli.harness.goose import GooseAdapter
+
+    source = GooseAdapter().resolve_session_source(
+        {"event": "SessionEnd", "session_id": "20260807_1"},
+        home=tmp_path,
+    )
+
+    assert source is not None
+    assert source.cwd == "/project"
+
+
+def test_session_end_finalises_and_advances_the_cursor(tmp_path: Path, monkeypatch):
+    _seed_goose(tmp_path)
+    db = _configure(tmp_path, monkeypatch, tmp_path)
+    posted: list[dict] = []
+
+    def _ack(payload, _config):
+        posted.append(payload)
+        return {"acknowledged_line": len(payload["lines"]) - 1, "acknowledged_offset": payload["total_offset"]}
+
+    mirrored = goose_sessions.export_session("20260807_1", home=tmp_path, finalize=True)
+    assert base.drain_session_source(
+        _source(mirrored.path),
+        {"server_url": "http://server", "access_token": "token", "user_id": "user"},
+        hook_event="SessionEnd",
+        final=True,
+        home=tmp_path,
+        db_path=db,
+        post=_ack,
+        checkpoint_fetch=lambda *_a, **_k: None,
+    )
+
+    assert posted[0]["final"] is True
+    assert posted[0]["session_hash"]
+    offset, line_count, finalized = base.read_cursor_state("20260807_1", home=tmp_path)
+    assert finalized is True
+    assert line_count == 3  # session + message + session_end
+    assert offset == mirrored.path.stat().st_size
+
+
+def test_second_drain_sends_only_new_goose_rows(tmp_path: Path, monkeypatch):
+    _seed_goose(tmp_path)
+    db = _configure(tmp_path, monkeypatch, tmp_path)
+    config = {"server_url": "http://server", "access_token": "token", "user_id": "user"}
+    posted: list[dict] = []
+
+    def _ack(payload, _config):
+        posted.append(payload)
+        return {"acknowledged_line": payload["start_offset"] + len(payload["lines"]) - 1, "acknowledged_offset": 0}
+
+    first = goose_sessions.export_session("20260807_1", home=tmp_path)
+    base.drain_session_source(_source(first.path), config, hook_event="Stop", home=tmp_path, db_path=db, post=_ack)
+
+    with sqlite3.connect(tmp_path / ".local" / "share" / "goose" / "sessions" / "sessions.db") as connection:
+        connection.execute(
+            "INSERT INTO messages (message_id, session_id, role, content_json, created_timestamp, metadata_json) "
+            "VALUES (?,?,?,?,?,?)",
+            ("msg-2", "20260807_1", "assistant", json.dumps([{"type": "text", "text": "yo"}]), 1_785_000_001, "{}"),
+        )
+    second = goose_sessions.export_session("20260807_1", home=tmp_path)
+    base.drain_session_source(_source(second.path), config, hook_event="Stop", home=tmp_path, db_path=db, post=_ack)
+
+    assert [len(payload["lines"]) for payload in posted] == [2, 1]
+    assert json.loads(posted[1]["lines"][0])["message_id"] == "msg-2"
+
+
+def test_reconcile_discovers_goose_sessions_without_touching_the_database(tmp_path: Path, monkeypatch):
+    from observal_cli.harness.goose import GooseAdapter
+
+    _seed_goose(tmp_path)
+    db_file = tmp_path / ".local" / "share" / "goose" / "sessions" / "sessions.db"
+    before = db_file.read_bytes()
+
+    sources = GooseAdapter().discover_session_sources(home=tmp_path, since_hours=24 * 365 * 100)
+
+    assert [source.session_id for source in sources] == ["20260807_1"]
+    assert sources[0].path.is_file()
+    assert db_file.read_bytes() == before
+
+
+def _source(path: Path):
+    from observal_cli.harness import SessionSource
+
+    return SessionSource("goose", "20260807_1", path, cwd="/project")

--- a/tests/test_goose_session_parser.py
+++ b/tests/test_goose_session_parser.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Goose ingest classifier and trace-viewer parser."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from services.session_ingest import _extract_usage_tokens, _extract_uuid
+from services.session_parsers import parse_raw_events
+from services.session_parsers.ingest_classify import classify, extract_preview, extract_timestamp, extract_tool_info
+
+
+def _row(record: dict) -> dict:
+    return {
+        "raw_line": json.dumps(record),
+        "harness": "goose",
+        "timestamp": "2026-08-07 12:00:00.000",
+        "ingested_at": "2026-08-07 12:00:01.000",
+    }
+
+
+def _message(role: str, content: list, **extra) -> dict:
+    return {
+        "type": "message",
+        "row_id": 1,
+        "session_id": "20260807_1",
+        "message_id": "msg-1",
+        "role": role,
+        "timestamp": "2026-08-07T12:00:00.000Z",
+        "content": content,
+        "metadata": {},
+        **extra,
+    }
+
+
+_TOOL_REQUEST = {
+    "type": "toolRequest",
+    "id": "tool-1",
+    "toolCall": {"status": "success", "value": {"name": "developer__shell", "arguments": {"command": "ls"}}},
+}
+
+
+# ── Ingest classification ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        ({"type": "session", "name": "Fix parser"}, "system"),
+        ({"type": "session_end", "usage": {}}, "system"),
+        (_message("user", [{"type": "text", "text": "hi"}]), "user_prompt"),
+        (_message("assistant", [{"type": "text", "text": "sure"}]), "assistant_text"),
+        (_message("assistant", [{"type": "thinking", "thinking": "hmm", "signature": ""}]), "thinking"),
+        (_message("assistant", [{"type": "redactedThinking", "data": "x"}]), "thinking"),
+        (_message("assistant", [_TOOL_REQUEST]), "tool_call"),
+        (
+            _message("user", [{"type": "toolResponse", "id": "tool-1", "toolResult": {"status": "success"}}]),
+            "tool_result",
+        ),
+    ],
+)
+def test_classify_goose_records(record: dict, expected: str):
+    assert classify("goose", record) == expected
+
+
+def test_classify_skips_empty_message_rows():
+    assert classify("goose", _message("assistant", [])) is None
+
+
+def test_preview_covers_every_record_kind():
+    assert "Fix parser" in extract_preview("goose", {"type": "session", "name": "Fix parser"}, "system")
+    assert extract_preview("goose", {"type": "session_end"}, "system") == "[session end]"
+    assert "developer__shell" in extract_preview("goose", _message("assistant", [_TOOL_REQUEST]), "tool_call")
+    result = _message(
+        "user",
+        [
+            {
+                "type": "toolResponse",
+                "id": "tool-1",
+                "toolResult": {"status": "success", "value": {"content": [{"type": "text", "text": "README.md"}]}},
+            }
+        ],
+    )
+    assert "README.md" in extract_preview("goose", result, "tool_result")
+
+
+def test_tool_info_reads_the_namespaced_tool_name():
+    assert extract_tool_info("goose", _message("assistant", [_TOOL_REQUEST])) == ("developer__shell", "tool-1")
+    assert extract_tool_info("goose", _message("user", [{"type": "text", "text": "hi"}])) == (None, None)
+
+
+def test_timestamp_is_read_from_the_mirrored_record():
+    assert extract_timestamp("goose", _message("user", [])) == "2026-08-07 12:00:00.000"
+    assert extract_timestamp("goose", {"type": "session"}) is None
+
+
+def test_usage_and_uuid_extraction():
+    record = _message(
+        "assistant",
+        [{"type": "text", "text": "done"}],
+        metadata={
+            "usage": {"inputTokens": 120, "outputTokens": 45, "cacheReadTokens": 10, "cacheWriteTokens": 5},
+            "inference": {"provider": "anthropic", "requestedModel": "claude-sonnet-4-6", "resolvedModel": "claude-4"},
+        },
+    )
+
+    assert _extract_usage_tokens(record, "goose") == {
+        "input_tokens": 120,
+        "output_tokens": 45,
+        "cache_read_tokens": 10,
+        "cache_write_tokens": 5,
+        "model": "claude-4",
+    }
+    assert _extract_uuid(record, "goose") == ("msg-1", None)
+    assert _extract_usage_tokens({"type": "session"}, "goose")["input_tokens"] == 0
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"usage": "not-a-dict"},
+        {"usage": {"inputTokens": "many"}},
+        {"usage": {"inputTokens": None}},
+        {"inference": []},
+        [],
+    ],
+)
+def test_usage_extraction_never_raises_on_malformed_metadata(metadata):
+    usage = _extract_usage_tokens(_message("assistant", [], metadata=metadata), "goose")
+    assert usage["input_tokens"] == 0
+    assert usage["model"] == ""
+
+
+# ── Trace viewer parsing ──────────────────────────────────────────────────────
+
+
+def test_parse_rows_emits_session_boundaries():
+    events = parse_raw_events(
+        [
+            _row(
+                {
+                    "type": "session",
+                    "session_id": "20260807_1",
+                    "name": "Fix parser",
+                    "working_dir": "/project",
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-4-6",
+                    "timestamp": "2026-08-07T11:59:00.000Z",
+                }
+            ),
+            _row({"type": "session_end", "usage": {"inputTokens": 120, "totalTokens": 165}}),
+        ]
+    )
+
+    assert [event["event_name"] for event in events] == ["hook_sessionstart", "hook_stop"]
+    assert events[0]["attributes"]["working_dir"] == "/project"
+    assert events[0]["attributes"]["model"] == "claude-sonnet-4-6"
+    assert events[1]["attributes"]["total_tokens"] == "165"
+
+
+def test_parse_rows_merges_tool_results_into_their_request():
+    events = parse_raw_events(
+        [
+            _row(_message("assistant", [_TOOL_REQUEST])),
+            _row(
+                _message(
+                    "user",
+                    [
+                        {
+                            "type": "toolResponse",
+                            "id": "tool-1",
+                            "toolResult": {
+                                "status": "success",
+                                "value": {"content": [{"type": "text", "text": "README.md"}], "isError": False},
+                            },
+                        }
+                    ],
+                )
+            ),
+        ]
+    )
+
+    assert len(events) == 1
+    assert events[0]["event_name"] == "hook_posttooluse"
+    assert events[0]["attributes"]["tool_name"] == "developer__shell"
+    assert json.loads(events[0]["attributes"]["tool_input"]) == {"command": "ls"}
+    assert events[0]["attributes"]["tool_response"] == "README.md"
+
+
+def test_parse_rows_flags_failed_tool_calls():
+    events = parse_raw_events(
+        [
+            _row(_message("assistant", [_TOOL_REQUEST])),
+            _row(
+                _message(
+                    "user",
+                    [
+                        {
+                            "type": "toolResponse",
+                            "id": "tool-1",
+                            "toolResult": {
+                                "status": "success",
+                                "value": {"content": [{"type": "text", "text": "boom"}], "isError": True},
+                            },
+                        }
+                    ],
+                )
+            ),
+        ]
+    )
+
+    assert events[0]["attributes"]["tool_status"] == "error"
+    assert events[0]["attributes"]["tool_response"] == "boom"
+
+
+def test_parse_rows_handles_legacy_tool_result_shape():
+    events = parse_raw_events(
+        [
+            _row(_message("assistant", [_TOOL_REQUEST])),
+            _row(
+                _message(
+                    "user",
+                    [
+                        {
+                            "type": "toolResponse",
+                            "id": "tool-1",
+                            "toolResult": {"status": "success", "value": [{"type": "text", "text": "legacy"}]},
+                        }
+                    ],
+                )
+            ),
+        ]
+    )
+
+    assert events[0]["attributes"]["tool_response"] == "legacy"
+
+
+def test_parse_rows_surfaces_tool_call_errors():
+    events = parse_raw_events(
+        [
+            _row(
+                _message(
+                    "assistant",
+                    [{"type": "toolRequest", "id": "tool-2", "toolCall": {"status": "error", "error": "bad args"}}],
+                )
+            )
+        ]
+    )
+
+    assert events[0]["attributes"]["tool_status"] == "error"
+    assert events[0]["attributes"]["tool_response"] == "bad args"
+
+
+def test_parse_rows_emits_prompts_thinking_and_responses_with_tokens():
+    events = parse_raw_events(
+        [
+            _row(_message("user", [{"type": "text", "text": "why?"}])),
+            _row(
+                _message(
+                    "assistant",
+                    [
+                        {"type": "thinking", "thinking": "because", "signature": ""},
+                        {"type": "text", "text": "here you go"},
+                    ],
+                    metadata={"usage": {"inputTokens": 10, "outputTokens": 3}},
+                )
+            ),
+        ]
+    )
+
+    assert [event["event_name"] for event in events] == [
+        "hook_userpromptsubmit",
+        "hook_assistant_thinking",
+        "hook_assistant_response",
+    ]
+    assert events[2]["attributes"]["input_tokens"] == "10"
+
+
+def test_parse_rows_reports_usage_for_a_tool_only_turn():
+    events = parse_raw_events([_row(_message("assistant", [_TOOL_REQUEST], metadata={"usage": {"outputTokens": 7}}))])
+
+    assert [event["event_name"] for event in events] == ["hook_posttooluse", "hook_token_usage"]
+    assert events[1]["attributes"]["output_tokens"] == "7"
+
+
+def test_parse_rows_emits_orphan_tool_results_standalone():
+    events = parse_raw_events(
+        [
+            _row(
+                _message(
+                    "user",
+                    [
+                        {
+                            "type": "toolResponse",
+                            "id": "unknown",
+                            "toolResult": {"status": "success", "value": {"content": [{"type": "text", "text": "x"}]}},
+                        }
+                    ],
+                )
+            )
+        ]
+    )
+
+    assert events[0]["event_name"] == "hook_posttooluse"
+    assert events[0]["attributes"]["tool_use_id"] == "unknown"
+
+
+def test_parse_rows_falls_back_for_unparseable_lines():
+    events = parse_raw_events(
+        [{"raw_line": "{not json", "harness": "goose", "event_type": "system", "content_preview": "oops"}]
+    )
+
+    assert events[0]["body"] == "oops"
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        [1, 2, 3],
+        "a string",
+        {"type": "message", "role": "assistant", "content": "not-a-list"},
+        {"type": "message", "role": "assistant", "content": [None, 7, "text", {}]},
+        {"type": "message", "role": None, "content": [{"type": "toolRequest", "toolCall": []}]},
+        {"type": "message", "content": [{"type": "toolResponse", "toolResult": {"value": 5}}]},
+        {"type": "session_end", "usage": "nope"},
+        {"type": "unknown-future-record"},
+        {},
+    ],
+)
+def test_malformed_records_never_crash_the_pipeline(record):
+    """Goose data is machine-generated, but a corrupt mirror must never break ingest."""
+    parsed = record if isinstance(record, dict) else {"type": "message", "content": record}
+    event_type = classify("goose", parsed)
+    extract_preview("goose", parsed, event_type or "")
+    extract_tool_info("goose", parsed)
+    extract_timestamp("goose", parsed)
+    _extract_usage_tokens(parsed, "goose")
+    assert isinstance(parse_raw_events([_row(record)]), list)

--- a/tests/test_goose_session_parser.py
+++ b/tests/test_goose_session_parser.py
@@ -57,6 +57,15 @@ _TOOL_REQUEST = {
         (_message("assistant", [{"type": "thinking", "thinking": "hmm", "signature": ""}]), "thinking"),
         (_message("assistant", [{"type": "redactedThinking", "data": "x"}]), "thinking"),
         (_message("assistant", [_TOOL_REQUEST]), "tool_call"),
+        # A mixed block list resolves on the first significant block, as Claude Code does.
+        (
+            _message("assistant", [{"type": "thinking", "thinking": "hmm", "signature": ""}, _TOOL_REQUEST]),
+            "thinking",
+        ),
+        (
+            _message("assistant", [_TOOL_REQUEST, {"type": "thinking", "thinking": "hmm", "signature": ""}]),
+            "tool_call",
+        ),
         (
             _message("user", [{"type": "toolResponse", "id": "tool-1", "toolResult": {"status": "success"}}]),
             "tool_result",
@@ -117,6 +126,13 @@ def test_usage_and_uuid_extraction():
     }
     assert _extract_uuid(record, "goose") == ("msg-1", None)
     assert _extract_usage_tokens({"type": "session"}, "goose")["input_tokens"] == 0
+
+
+def test_uuid_falls_back_to_the_session_id_without_a_message_id():
+    """Pre-v7 goose databases have no ``message_id`` column."""
+    record = _message("assistant", [{"type": "text", "text": "done"}], message_id=None)
+
+    assert _extract_uuid(record, "goose") == ("20260807_1", None)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_goose_sessions.py
+++ b/tests/test_goose_sessions.py
@@ -24,6 +24,7 @@ def _isolated_goose_env(monkeypatch: pytest.MonkeyPatch):
     """GOOSE_PATH_ROOT overrides every other location, so keep tests hermetic."""
     monkeypatch.delenv("GOOSE_PATH_ROOT", raising=False)
 
+
 _SESSIONS_DDL = """
 CREATE TABLE sessions (
     id TEXT PRIMARY KEY,

--- a/tests/test_goose_sessions.py
+++ b/tests/test_goose_sessions.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for reading Goose's SQLite session store and mirroring it as JSONL."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from observal_cli.harness.goose import GooseAdapter
+from observal_cli.sessions import goose as goose_sessions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_goose_env(monkeypatch: pytest.MonkeyPatch):
+    """GOOSE_PATH_ROOT overrides every other location, so keep tests hermetic."""
+    monkeypatch.delenv("GOOSE_PATH_ROOT", raising=False)
+
+_SESSIONS_DDL = """
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    session_type TEXT NOT NULL DEFAULT 'user',
+    working_dir TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    total_tokens INTEGER,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    accumulated_total_tokens INTEGER,
+    accumulated_input_tokens INTEGER,
+    accumulated_output_tokens INTEGER,
+    accumulated_cost REAL,
+    provider_name TEXT,
+    model_config_json TEXT,
+    goose_mode TEXT NOT NULL DEFAULT 'auto',
+    schedule_id TEXT,
+    parent_session_id TEXT
+)
+"""
+
+_MESSAGES_DDL = """
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id TEXT,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content_json TEXT NOT NULL,
+    created_timestamp INTEGER NOT NULL,
+    metadata_json TEXT
+)
+"""
+
+# Pre-v7 goose databases have neither message_id nor metadata_json.
+_LEGACY_MESSAGES_DDL = """
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content_json TEXT NOT NULL,
+    created_timestamp INTEGER NOT NULL
+)
+"""
+
+
+def _db_path(home: Path) -> Path:
+    path = home / ".local" / "share" / "goose" / "sessions" / "sessions.db"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _make_db(home: Path, *, legacy_messages: bool = False) -> Path:
+    path = _db_path(home)
+    with sqlite3.connect(path) as connection:
+        connection.execute(_SESSIONS_DDL)
+        connection.execute(_LEGACY_MESSAGES_DDL if legacy_messages else _MESSAGES_DDL)
+    return path
+
+
+def _add_session(
+    home: Path,
+    session_id: str = "20260807_1",
+    *,
+    working_dir: str = "/project",
+    parent: str | None = None,
+    updated_at: str = "2026-08-07 12:00:00",
+) -> None:
+    with sqlite3.connect(_db_path(home)) as connection:
+        connection.execute(
+            "INSERT INTO sessions (id, name, working_dir, created_at, updated_at, provider_name, "
+            "model_config_json, accumulated_input_tokens, accumulated_output_tokens, "
+            "accumulated_total_tokens, parent_session_id) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                session_id,
+                "Fix the parser",
+                working_dir,
+                "2026-08-07 11:59:00",
+                updated_at,
+                "anthropic",
+                json.dumps({"model_name": "claude-sonnet-4-6"}),
+                120,
+                45,
+                165,
+                parent,
+            ),
+        )
+
+
+def _add_message(
+    home: Path,
+    session_id: str = "20260807_1",
+    *,
+    role: str = "user",
+    content: list | None = None,
+    created: int = 1_785_000_000,
+    message_id: str | None = "msg-1",
+    metadata: dict | None = None,
+    legacy: bool = False,
+) -> None:
+    content_json = json.dumps(content if content is not None else [{"type": "text", "text": "hello"}])
+    with sqlite3.connect(_db_path(home)) as connection:
+        if legacy:
+            connection.execute(
+                "INSERT INTO messages (session_id, role, content_json, created_timestamp) VALUES (?,?,?,?)",
+                (session_id, role, content_json, created),
+            )
+        else:
+            connection.execute(
+                "INSERT INTO messages (message_id, session_id, role, content_json, created_timestamp, "
+                "metadata_json) VALUES (?,?,?,?,?,?)",
+                (message_id, session_id, role, content_json, created, json.dumps(metadata or {})),
+            )
+
+
+def _records(mirrored) -> list[dict]:
+    return [json.loads(line) for line in mirrored.path.read_text().splitlines() if line.strip()]
+
+
+# ── Export ────────────────────────────────────────────────────────────────────
+
+
+def test_export_writes_session_then_message_records(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path)
+
+    mirrored = goose_sessions.export_session("20260807_1", home=tmp_path)
+
+    assert mirrored.path == goose_sessions.mirror_path("20260807_1", home=tmp_path)
+    assert mirrored.working_dir == "/project"
+    records = _records(mirrored)
+    assert [record["type"] for record in records] == ["session", "message"]
+    assert records[0]["working_dir"] == "/project"
+    assert records[0]["provider"] == "anthropic"
+    assert records[0]["model"] == "claude-sonnet-4-6"
+    assert records[1]["role"] == "user"
+    assert records[1]["content"] == [{"type": "text", "text": "hello"}]
+    assert records[1]["timestamp"].endswith("Z")
+
+
+def test_export_is_incremental_and_never_rewrites_history(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path, message_id="msg-1")
+
+    mirrored = goose_sessions.export_session("20260807_1", home=tmp_path)
+    first_pass = mirrored.path.read_bytes()
+
+    assert goose_sessions.export_session("20260807_1", home=tmp_path).path.read_bytes() == first_pass
+
+    _add_message(tmp_path, role="assistant", message_id="msg-2")
+    goose_sessions.export_session("20260807_1", home=tmp_path)
+
+    assert mirrored.path.read_bytes().startswith(first_pass)
+    assert [record["message_id"] for record in _records(mirrored) if record["type"] == "message"] == ["msg-1", "msg-2"]
+
+
+def test_export_appends_session_end_exactly_once(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path)
+
+    mirrored = goose_sessions.export_session("20260807_1", home=tmp_path, finalize=True)
+    goose_sessions.export_session("20260807_1", home=tmp_path, finalize=True)
+
+    ends = [record for record in _records(mirrored) if record["type"] == "session_end"]
+    assert len(ends) == 1
+    assert ends[0]["usage"] == {"inputTokens": 120, "outputTokens": 45, "totalTokens": 165, "cost": None}
+
+
+def test_export_never_modifies_the_goose_database(tmp_path: Path):
+    db = _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path)
+    before = db.read_bytes()
+    sidecars_before = sorted(p.name for p in db.parent.iterdir())
+
+    goose_sessions.export_session("20260807_1", home=tmp_path, finalize=True)
+
+    assert db.read_bytes() == before
+    assert sorted(p.name for p in db.parent.iterdir()) == sidecars_before
+
+
+def test_export_reads_a_database_missing_optional_columns(tmp_path: Path):
+    _make_db(tmp_path, legacy_messages=True)
+    _add_session(tmp_path)
+    _add_message(tmp_path, legacy=True)
+
+    records = _records(goose_sessions.export_session("20260807_1", home=tmp_path))
+
+    assert records[1]["message_id"] is None
+    assert records[1]["metadata"] == {}
+
+
+def test_export_normalises_millisecond_timestamps(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path, created=1_785_000_000_000)
+
+    records = _records(goose_sessions.export_session("20260807_1", home=tmp_path))
+
+    assert records[1]["timestamp"].startswith("2026-")
+
+
+def test_export_tolerates_corrupt_message_content(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    with sqlite3.connect(_db_path(tmp_path)) as connection:
+        connection.execute(
+            "INSERT INTO messages (message_id, session_id, role, content_json, created_timestamp) VALUES (?,?,?,?,?)",
+            ("msg-x", "20260807_1", "assistant", "{not json", 1_785_000_000),
+        )
+
+    records = _records(goose_sessions.export_session("20260807_1", home=tmp_path))
+
+    assert records[1]["content"] == []
+
+
+@pytest.mark.parametrize("session_id", ["", "does-not-exist"])
+def test_export_returns_none_for_unknown_sessions(tmp_path: Path, session_id: str):
+    _make_db(tmp_path)
+    assert goose_sessions.export_session(session_id, home=tmp_path) is None
+
+
+def test_export_returns_none_without_a_database(tmp_path: Path):
+    assert goose_sessions.export_session("20260807_1", home=tmp_path) is None
+
+
+def test_export_returns_none_for_an_unreadable_database(tmp_path: Path):
+    _db_path(tmp_path).write_text("this is not a sqlite database")
+    assert goose_sessions.export_session("20260807_1", home=tmp_path) is None
+
+
+def test_mirror_path_is_filesystem_safe(tmp_path: Path):
+    path = goose_sessions.mirror_path("../../escape/me", home=tmp_path)
+    assert path.parent == goose_sessions.mirror_dir(tmp_path)
+    assert "/" not in path.name.removesuffix(".jsonl")
+
+
+# ── Discovery ─────────────────────────────────────────────────────────────────
+
+
+def test_list_recent_sessions_respects_the_cutoff(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path, "recent", updated_at="2026-08-07 12:00:00")
+    _add_session(tmp_path, "stale", updated_at="2020-01-01 00:00:00")
+
+    cutoff = time.mktime(time.strptime("2026-01-01", "%Y-%m-%d"))
+    assert [row[0] for row in goose_sessions.list_recent_sessions(cutoff, home=tmp_path)] == ["recent"]
+
+
+def test_list_recent_sessions_without_a_database(tmp_path: Path):
+    assert goose_sessions.list_recent_sessions(0, home=tmp_path) == []
+
+
+def test_read_child_session_ids(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path, "parent")
+    _add_session(tmp_path, "child", working_dir="/child", parent="parent")
+
+    assert goose_sessions.read_child_session_ids("parent", home=tmp_path) == [("child", "/child")]
+    assert goose_sessions.read_child_session_ids("child", home=tmp_path) == []
+
+
+def test_resolve_session_id_caches_the_last_seen_value(tmp_path: Path):
+    assert goose_sessions.resolve_session_id({"session_id": "abc-123"}, home=tmp_path) == "abc-123"
+    assert goose_sessions.resolve_session_id({"event": "SessionEnd"}, home=tmp_path) == "abc-123"
+
+
+def test_resolve_session_id_without_history(tmp_path: Path):
+    assert goose_sessions.resolve_session_id({"event": "Stop"}, home=tmp_path) == ""
+
+
+def test_goose_path_root_overrides_every_other_location(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Goose relocates config, data and .agents wholesale when GOOSE_PATH_ROOT is set."""
+    from observal_cli.shared.utils import (
+        resolve_goose_agents_home,
+        resolve_goose_config_dir,
+        resolve_goose_data_dir,
+    )
+
+    root = tmp_path / "root"
+    monkeypatch.setenv("GOOSE_PATH_ROOT", str(root))
+
+    assert resolve_goose_config_dir() == root / "config"
+    assert resolve_goose_data_dir() == root / "data"
+    assert resolve_goose_agents_home() == root / ".agents"
+    assert goose_sessions.find_sessions_db() == root / "data" / "sessions" / "sessions.db"
+
+
+def test_goose_path_root_is_ignored_when_relative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from observal_cli.shared.utils import resolve_goose_config_dir
+
+    monkeypatch.setenv("GOOSE_PATH_ROOT", "relative/path")
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    assert resolve_goose_config_dir(tmp_path) == tmp_path / ".config" / "goose"
+
+
+# ── Adapter session wiring ────────────────────────────────────────────────────
+
+
+def test_adapter_resolves_a_hook_payload_to_the_mirror(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path)
+
+    source = GooseAdapter().resolve_session_source(
+        {"event": "UserPromptSubmit", "session_id": "20260807_1", "working_dir": "/project"},
+        home=tmp_path,
+    )
+
+    assert source is not None
+    assert source.harness == "goose"
+    assert source.cwd == "/project"
+    assert source.path == goose_sessions.mirror_path("20260807_1", home=tmp_path)
+
+
+def test_adapter_discovers_recent_sessions_with_parent_links(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path, "parent")
+    _add_session(tmp_path, "child", parent="parent")
+    _add_message(tmp_path, "parent")
+    _add_message(tmp_path, "child")
+
+    sources = {source.session_id: source for source in GooseAdapter().discover_session_sources(home=tmp_path)}
+
+    assert set(sources) == {"parent", "child"}
+    assert sources["child"].parent_session_id == "parent"
+
+
+def test_adapter_returns_delegated_child_sources(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path, "parent")
+    _add_session(tmp_path, "child", working_dir="/child", parent="parent")
+    _add_message(tmp_path, "child")
+
+    parent = GooseAdapter().resolve_session_source({"session_id": "parent"}, home=tmp_path)
+    children = GooseAdapter().related_session_sources(parent, home=tmp_path)
+
+    assert [child.session_id for child in children] == ["child"]
+    assert children[0].parent_session_id == "parent"
+
+
+def test_only_session_end_finalises_a_goose_session():
+    adapter = GooseAdapter()
+    assert adapter.is_session_final({"event": "SessionEnd"}) is True
+    assert adapter.is_session_final({"event": "Stop"}) is False
+    assert adapter.is_session_final({"event": "PostToolUse"}) is False
+
+
+def test_adapter_falls_back_to_the_recorded_working_dir(tmp_path: Path):
+    """SessionStart, UserPromptSubmit and SessionEnd payloads omit working_dir."""
+    _make_db(tmp_path)
+    _add_session(tmp_path, working_dir="/repo")
+    _add_message(tmp_path)
+
+    source = GooseAdapter().resolve_session_source({"event": "SessionEnd", "session_id": "20260807_1"}, home=tmp_path)
+
+    assert source.cwd == "/repo"
+
+
+def test_discovery_skips_reading_sessions_the_mirror_already_covers(tmp_path: Path, monkeypatch):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path)
+    with sqlite3.connect(_db_path(tmp_path)) as connection:
+        connection.execute("UPDATE sessions SET updated_at = datetime('now', '-1 hour')")
+    adapter = GooseAdapter()
+    adapter.discover_session_sources(home=tmp_path)  # first pass builds the mirror
+
+    exports: list[str] = []
+    original = goose_sessions.export_session
+    monkeypatch.setattr(
+        goose_sessions,
+        "export_session",
+        lambda session_id, **kwargs: exports.append(session_id) or original(session_id, **kwargs),
+    )
+
+    sources = adapter.discover_session_sources(home=tmp_path)
+
+    assert [source.session_id for source in sources] == ["20260807_1"]
+    assert exports == []  # mirror is newer than the session row, so the database is not reopened
+
+
+def test_discovery_re_exports_when_goose_wrote_after_the_last_mirror(tmp_path: Path):
+    _make_db(tmp_path)
+    _add_session(tmp_path)
+    _add_message(tmp_path, message_id="msg-1")
+    adapter = GooseAdapter()
+    adapter.discover_session_sources(home=tmp_path)
+
+    _add_message(tmp_path, message_id="msg-2", role="assistant")
+    with sqlite3.connect(_db_path(tmp_path)) as connection:
+        connection.execute("UPDATE sessions SET updated_at = datetime('now', '+1 hour') WHERE id = ?", ("20260807_1",))
+
+    adapter.discover_session_sources(home=tmp_path)
+
+    ids = [r["message_id"] for r in _records(goose_sessions.export_session("20260807_1", home=tmp_path))[1:]]
+    assert ids == ["msg-1", "msg-2"]
+
+
+def test_goose_defers_network_delivery_out_of_the_hook():
+    assert GooseAdapter().defer_session_delivery() is True

--- a/tests/test_harness_config_e2e.py
+++ b/tests/test_harness_config_e2e.py
@@ -581,6 +581,45 @@ class TestWriteFile:
         status = _write_file(p, "new content")
         assert status == "updated"
 
+    def test_merges_yaml_and_preserves_unrelated_config(self, tmp_path):
+        import yaml
+
+        p = tmp_path / "config.yaml"
+        p.write_text(
+            yaml.safe_dump(
+                {
+                    "active_provider": "anthropic",
+                    "GOOSE_MODE": "smart_approve",
+                    "extensions": {"developer": {"type": "builtin", "enabled": True}},
+                }
+            )
+        )
+
+        status = _write_file(p, {"extensions": {"fs": {"type": "stdio", "cmd": "npx"}}}, merge_mcp=True)
+
+        assert status == "merged"
+        data = yaml.safe_load(p.read_text())
+        assert data["active_provider"] == "anthropic"
+        assert data["GOOSE_MODE"] == "smart_approve"
+        assert set(data["extensions"]) == {"developer", "fs"}
+
+    def test_creates_yaml_when_absent(self, tmp_path):
+        import yaml
+
+        p = tmp_path / ".config" / "goose" / "config.yaml"
+        status = _write_file(p, {"extensions": {"fs": {"type": "stdio"}}}, merge_mcp=True)
+        assert status == "created"
+        assert yaml.safe_load(p.read_text())["extensions"]["fs"]["type"] == "stdio"
+
+    def test_leaves_unparseable_yaml_untouched(self, tmp_path):
+        p = tmp_path / "config.yaml"
+        p.write_text("extensions: [unclosed\n")
+
+        status = _write_file(p, {"extensions": {"fs": {}}}, merge_mcp=True)
+
+        assert status.startswith("skipped")
+        assert p.read_text() == "extensions: [unclosed\n"
+
 
 # ═══════════════════════════════════════════════════════════════════
 # 8. PULL — Full CLI flow (E2E per harness)

--- a/tests/test_harness_refactor_baseline.py
+++ b/tests/test_harness_refactor_baseline.py
@@ -26,6 +26,7 @@ ALL_HARNESSES = [
     "copilot-cli",
     "opencode",
     "antigravity",
+    "goose",
     "pi",
 ]
 


### PR DESCRIPTION
## Purpose / Description

[Goose](https://goose-docs.ai/) is an open source local AI agent under the Agentic AI
Foundation, with CLI and Desktop clients that share the same on-disk state. Observal had
no integration for it, so Goose users could not install agents, scan their setup, or get
session traces.

This adds Goose as a **first-class** harness: agent installs, MCP extensions, skills,
custom agents, hook instrumentation, session capture, and reconciliation.

The interesting constraint is that Goose 1.10+ stores every session in a single SQLite
database, while Observal's delivery engine is byte-offset based over JSONL. Rather than
build a second transport, the CLI projects each session onto an append-only JSONL mirror
so the existing spool, acknowledgement, checkpoint-recovery and final-hash protocol apply
unchanged.

## Fixes

* Fixes #1600

## Approach

Ten focused commits, following `docs/adding-a-harness.md`:

| Layer | What it does |
| --- | --- |
| Path resolution | Mirrors Goose's own order: `GOOSE_PATH_ROOT` → XDG → platform default |
| Session mirror | Reads `sessions.db` via a `file:...?mode=ro` URI and appends new rows to `~/.observal/sessions/goose/<id>.jsonl` |
| Hook plugin | Open Plugins spec: `.agents/plugins/observal/` with `plugin.json` + `hooks/hooks.json` |
| CLI adapter | Scans extensions, skills, custom agents and plugins; resolves session sources; links delegated subagents |
| Doctor / scan / layer | Diagnose, install and remove the hook plugin; layer snapshot attribution |
| Install config | Custom agent markdown, `stdio`/`streamable_http` extensions, skills, plugin hooks |
| Server parsing | Ingest classifier, per-message token/cost extraction, trace-viewer parser |
| Registration | Shared registry entry, model catalog, and every dispatch map |

Design decisions worth calling out:

- **The mirror is append-only.** That is what keeps previously acknowledged byte offsets
  and server checkpoints valid across runs.
- **Reads never mutate Goose's database.** No writes, no migrations, no WAL checkpointing,
  and a busy timeout so a concurrently writing Goose is never blocked.
- **The hook does no network IO.** Goose *awaits* hooks inside its agent loop with a 30s
  timeout, so the hook only reads SQLite and spools locally; a detached worker uploads.
- **`config.yaml` is merged, not rewritten.** Goose keeps providers, models, global
  settings and extensions in one file; only the `extensions` section is touched, and an
  unparseable file is left alone rather than overwritten.

Several behaviours were corrected after checking the official source rather than the docs:

- `GOOSE_PATH_ROOT` relocates config, data **and** `.agents` wholesale.
- `working_dir` is **absent** on `SessionStart`, `UserPromptSubmit` and `SessionEnd`, so
  the working directory is read from `sessions.working_dir` instead.
- `SessionEnd` is emitted by the goose **CLI only**; Desktop sessions finalize via
  background recovery / `observal reconcile`.
- Goose runs hooks through `sh -c` on **every** platform, so the command is POSIX-quoted.
- `inline_python` extensions carry code, not a command, so they are not reported as MCPs.

## How Has This Been Tested?

**Configuration:** Fedora, Python 3.14, goose **1.45.0** (installed via the official
`download_cli.sh`), Observal CLI from this branch.

**1. Unit / integration —** `make test`: **5462 passed**, 135 of them Goose-specific across
`tests/test_goose_{adapter,sessions,session_parser,session_delivery}.py`. `make lint` clean,
REUSE compliant.

> The 2 failures in `tests/test_cmd_recommend.py` are pre-existing and unrelated — they
> assert on a Rich table column that truncates at narrow console width under `pytest-xdist`.
> Verified they fail identically on `origin/main`.

**2. Per-commit buildability —** each of the 10 commits was extracted with `git archive`,
byte-compiled, and imported; the CLI adapter set matched the shared registry at every
commit (9 harnesses until the registration commit, then 10).

**3. Real end-to-end —** driven with the actual Goose binary, no mocking of Goose itself:

```bash
# 1. Sandbox
export HOME=/tmp/goose-e2e/home
observal doctor patch --harness goose

# 2. Real goose sessions against a local OpenAI-compatible mock provider
#    (must emit SSE — goose streams by default)
goose run --name run-1 --text "list the files then try to read a missing file"

# 3. Verify
observal scan --harness goose
observal reconcile --harness goose --dry-run
```

Results, against a mock Observal ingest server implementing the acknowledgement protocol:

- 3 sessions × real tool calls (one succeeding, one failing) delivered **complete and
  byte-exact**, each with a final integrity hash and matching `total_line_count`.
- `sessions.db` byte-identical before/after (`md5sum -c`), no stray `-wal`/`-shm` files.
- Trace events render session start, prompts, thinking, merged tool results, failed tool
  calls (`tool_status: error`), per-message tokens/cost and session totals.
- Hook latency against an unresponsive server: **20.08s → 0.00s** after deferring delivery.
- A capture plugin recorded every hook payload, which is how the `working_dir` gap was found.
- `GOOSE_PATH_ROOT` verified end-to-end: plugin install, session capture and doctor all
  follow the relocated root.

**4. Malformed input —** a parametrised matrix feeds non-dict rows, wrong-typed content
blocks, corrupt `content_json`, unparseable YAML, a truncated SQLite file and a pre-v7
schema through the classifier, parser and usage extractors, asserting nothing raises.

## Learning (optional, can help others)

- [Goose source](https://github.com/aaif-goose/goose) — `crates/goose/src/hooks/mod.rs`,
  `plugins/discovery.rs`, `config/paths.rs` and `session/session_manager.rs` were the
  authoritative references; several details are not in the published docs.
- [Open Plugins hooks specification](https://open-plugins.com/agent-builders/components/hooks) — the spec Goose implements.
- [Goose config](https://goose-docs.ai/docs/guides/config-files/) ·
  [hooks](https://goose-docs.ai/docs/guides/context-engineering/hooks/) ·
  [custom agents](https://goose-docs.ai/docs/guides/context-engineering/custom-agents) ·
  [session storage](https://goose-docs.ai/docs/guides/logs/)
- The SQLite-to-JSONL mirror is the transferable idea here: a database-backed harness can
  reuse a file-offset delivery engine as long as the projection is append-only.
- No new dependencies: `pyyaml` and the stdlib `sqlite3` module were already available.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens — **N/A, no UI changes**
      (the harness list is served from `/api/v1/config/harnesses`, so the web UI picks
      Goose up automatically with no frontend edit)

## AI Assistance

- [x] Yes (Please Specify the tool): **GitHub Copilot (Claude Opus 5) in VS Code**
- [x] Was the generated code manually reviewed and tested? — every change was reviewed
      against the official Goose source and validated end-to-end with the real Goose CLI
      running actual sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full Goose harness integration, including configuration scanning, MCP extensions, agents, skills, and hooks.
  * Added Goose session discovery, telemetry delivery, parent-child session support, usage tracking, and normalized event parsing.
  * Added Goose model catalog and cross-platform configuration path support.
* **CLI Improvements**
  * Added Goose support to scan, pull, doctor, hook installation, patching, and cleanup workflows.
  * Preserved unrelated YAML settings when updating configuration files.
* **Documentation**
  * Added comprehensive Goose setup, configuration, and integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->