### PR TITLE
fix(kiro): correct agent trace attribution

### DIFF
--- a/observal_cli/harness/base.py
+++ b/observal_cli/harness/base.py
@@ -114,6 +114,14 @@ class BaseAdapter:
         """Return recent session sources; harness adapters opt in as they are migrated."""
         return []
 
+    def resolve_session_agent_identity(
+        self,
+        session_jsonl: Path | None,
+        cwd: str,
+    ) -> tuple[str | None, str | None] | None:
+        """Resolve a harness-specific session identity, or defer to shared resolution."""
+        return None
+
     def related_session_sources(self, source: SessionSource, home: Path | None = None) -> list[SessionSource]:
         """Return child sources when a harness stores them separately."""
         return []

--- a/observal_cli/harness/kiro.py
+++ b/observal_cli/harness/kiro.py
@@ -41,7 +41,7 @@ class KiroAdapter(BaseAdapter):
         return "kiro"
 
     def resolve_session_source(self, event: dict[str, Any], home: Path | None = None) -> SessionSource | None:
-        from observal_cli.sessions.kiro import find_kiro_jsonl, resolve_session_id
+        from observal_cli.sessions.kiro import find_kiro_jsonl, read_kiro_session_cwd, resolve_session_id
 
         session_id = resolve_session_id(event, home=home)
         if not session_id:
@@ -57,7 +57,7 @@ class KiroAdapter(BaseAdapter):
             harness=self.harness_name,
             session_id=session_id,
             path=path,
-            cwd=str(event.get("cwd") or ""),
+            cwd=read_kiro_session_cwd(path),
         )
 
     def discover_session_sources(
@@ -65,7 +65,7 @@ class KiroAdapter(BaseAdapter):
         home: Path | None = None,
         since_hours: int = 168,
     ) -> list[SessionSource]:
-        from observal_cli.sessions.kiro import find_sessions_dir
+        from observal_cli.sessions.kiro import find_sessions_dir, read_kiro_session_cwd
 
         cutoff = time.time() - since_hours * 3600
         root = find_sessions_dir(home)
@@ -75,10 +75,37 @@ class KiroAdapter(BaseAdapter):
         for path in sorted(root.glob("*.jsonl")):
             try:
                 if path.stat().st_mtime >= cutoff:
-                    sources.append(SessionSource(self.harness_name, path.stem, path))
+                    sources.append(
+                        SessionSource(
+                            self.harness_name,
+                            path.stem,
+                            path,
+                            cwd=read_kiro_session_cwd(path),
+                        )
+                    )
             except OSError:
                 continue
         return sources
+
+    def resolve_session_agent_identity(
+        self,
+        session_jsonl: Path | None,
+        cwd: str,
+    ) -> tuple[str | None, str | None] | None:
+        """Resolve Kiro identity from session metadata, never the global hook environment."""
+        from observal_cli.lockfile import get_agent_by_name
+        from observal_cli.sessions.kiro import read_kiro_agent_name
+
+        agent_name = read_kiro_agent_name(session_jsonl)
+        if not agent_name or agent_name == "kiro_default":
+            return None, None
+        try:
+            entry = get_agent_by_name(agent_name, harness=self.harness_name, directory=cwd or None)
+        except Exception:
+            return None, None
+        if entry is None:
+            return None, None
+        return entry.get("id"), entry.get("version")
 
     def session_extra_fields(
         self,

--- a/observal_cli/lockfile.py
+++ b/observal_cli/lockfile.py
@@ -406,6 +406,34 @@ def get_agent_by_id(agent_id: str, harness: str | None = None) -> dict | None:
     return None
 
 
+def get_agent_by_name(
+    name: str,
+    harness: str,
+    directory: str | None = None,
+) -> dict | None:
+    """Find one harness agent by its generated local name, name, or UUID.
+
+    A matching project directory disambiguates project-scoped installs. Without
+    that signal, a unique user-scoped or unique overall match is accepted;
+    ambiguous matches fail closed.
+    """
+    _, registry = read_registry_lockfile()
+    agents = registry.get("harnesses", {}).get(harness, {}).get("agents", [])
+    matches = [agent for agent in agents if name in {agent.get("local_name"), agent.get("name"), agent.get("id")}]
+    if directory:
+        directory_matches = [agent for agent in matches if agent.get("directory") == directory]
+        if len(directory_matches) == 1:
+            return directory_matches[0]
+        if len(directory_matches) > 1:
+            return None
+    user_matches = [agent for agent in matches if agent.get("scope") != "project"]
+    if len(user_matches) == 1:
+        return user_matches[0]
+    if user_matches:
+        return None
+    return matches[0] if len(matches) == 1 else None
+
+
 def get_all_entries(harness: str | None = None) -> list[dict]:
     """Get all lock file entries, optionally filtered by harness.
 

--- a/observal_cli/sessions/base.py
+++ b/observal_cli/sessions/base.py
@@ -787,12 +787,18 @@ def _resolve_agent(
     session_jsonl: Path | None,
     harness: str = "claude-code",
 ) -> tuple[str | None, str | None]:
-    """Resolve agent identity from explicit metadata and the lockfile.
-
-    Kiro attribution is UUID-only via OBSERVAL_AGENT_ID. The lockfile is the
-    source of truth for the installed version; cwd must not guess Kiro agents.
-    """
+    """Resolve agent identity through the harness adapter, environment, and lockfile."""
     import os
+
+    from observal_cli.harness import ensure_loaded, get_adapter
+
+    ensure_loaded()
+    adapter = get_adapter(harness)
+    resolve_identity = getattr(adapter, "resolve_session_agent_identity", None)
+    if callable(resolve_identity):
+        adapter_identity = resolve_identity(session_jsonl, cwd)
+        if adapter_identity is not None:
+            return adapter_identity
 
     env_agent_id = os.environ.get("OBSERVAL_AGENT_ID", "")
     if env_agent_id:
@@ -811,10 +817,7 @@ def _resolve_agent(
         optic.warning("OBSERVAL_AGENT_ID={} not found in lockfile (harness={})", env_agent_id, harness)
         return None, None
 
-    from observal_cli.harness import ensure_loaded, get_adapter
-
-    ensure_loaded()
-    if get_adapter(harness).requires_explicit_agent_id():
+    if adapter.requires_explicit_agent_id():
         optic.debug("{} session has no OBSERVAL_AGENT_ID; leaving unattributed", harness)
         return None, None
 

--- a/observal_cli/sessions/kiro.py
+++ b/observal_cli/sessions/kiro.py
@@ -34,6 +34,63 @@ def find_kiro_jsonl(session_id: str, home: Path | None = None) -> Path | None:
     return path if path.exists() else None
 
 
+def _read_kiro_session(session_jsonl: Path | None) -> dict | None:
+    """Read a Kiro companion session object, returning None on any invalid shape."""
+    if session_jsonl is None:
+        return None
+    try:
+        session = json.loads(session_jsonl.with_suffix(".json").read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return session if isinstance(session, dict) else None
+
+
+def read_kiro_agent_name(session_jsonl: Path | None) -> str | None:
+    """Return the active Kiro agent recorded in a session companion file.
+
+    Kiro stores session metadata next to the transcript as ``<session_id>.json``.
+    Current versions expose the active agent directly as
+    ``session_state.agent_name``. Older-compatible metadata also records the
+    agent on each user turn, so the latest turn is a safe fallback when the
+    direct field is absent. Missing or malformed metadata is left unattributed.
+    """
+    session = _read_kiro_session(session_jsonl)
+    if session is None:
+        return None
+
+    state = session.get("session_state")
+    if not isinstance(state, dict):
+        return None
+    agent_name = state.get("agent_name")
+    if isinstance(agent_name, str) and agent_name.strip():
+        return agent_name.strip()
+
+    conversation = state.get("conversation_metadata")
+    if not isinstance(conversation, dict):
+        return None
+    turns = conversation.get("user_turn_metadatas")
+    if not isinstance(turns, list):
+        return None
+    for turn in reversed(turns):
+        if not isinstance(turn, dict):
+            continue
+        loop_id = turn.get("loop_id")
+        agent_id = loop_id.get("agent_id") if isinstance(loop_id, dict) else None
+        name = agent_id.get("name") if isinstance(agent_id, dict) else None
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None
+
+
+def read_kiro_session_cwd(session_jsonl: Path | None) -> str:
+    """Return the working directory persisted in a Kiro companion session."""
+    session = _read_kiro_session(session_jsonl)
+    if session is None:
+        return ""
+    cwd = session.get("cwd")
+    return cwd.strip() if isinstance(cwd, str) else ""
+
+
 def resolve_session_id(event: dict, home: Path | None = None) -> str:
     """Return the session_id for a Kiro hook event.
 

--- a/tests/test_kiro_session_delivery.py
+++ b/tests/test_kiro_session_delivery.py
@@ -11,12 +11,18 @@ from typing import TYPE_CHECKING
 from observal_cli.harness import ensure_loaded, get_adapter
 from observal_cli.harness_specs.kiro_hooks_spec import build_kiro_hooks
 from observal_cli.hooks import session_push
+from observal_cli.sessions.kiro import read_kiro_agent_name
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def make_session(home: Path, session_id: str = "kiro-session") -> Path:
+def make_session(
+    home: Path,
+    session_id: str = "kiro-session",
+    agent_name: str = "kiro_default",
+    cwd: str = "/work",
+) -> Path:
     root = home / ".kiro" / "sessions" / "cli"
     root.mkdir(parents=True, exist_ok=True)
     transcript = root / f"{session_id}.jsonl"
@@ -24,14 +30,22 @@ def make_session(home: Path, session_id: str = "kiro-session") -> Path:
     (root / f"{session_id}.json").write_text(
         json.dumps(
             {
+                "cwd": cwd,
                 "session_state": {
+                    "agent_name": agent_name,
                     "conversation_metadata": {
                         "user_turn_metadatas": [
-                            {"metering_usage": [{"unit": "credit", "value": 1.25}]},
-                            {"metering_usage": [{"unit": "credit", "value": 0.75}]},
+                            {
+                                "loop_id": {"agent_id": {"name": agent_name}},
+                                "metering_usage": [{"unit": "credit", "value": 1.25}],
+                            },
+                            {
+                                "loop_id": {"agent_id": {"name": agent_name}},
+                                "metering_usage": [{"unit": "credit", "value": 0.75}],
+                            },
                         ]
-                    }
-                }
+                    },
+                },
             }
         )
     )
@@ -52,12 +66,13 @@ def test_kiro_adapter_resolves_and_persists_session_for_stop(tmp_path: Path):
     adapter = get_adapter("kiro")
 
     source = adapter.resolve_session_source(
-        {"session_id": "kiro-session", "cwd": "/work"},
+        {"session_id": "kiro-session", "cwd": "/hook-work"},
         home=tmp_path,
     )
     stop_source = adapter.resolve_session_source({"event": "stop"}, home=tmp_path)
 
     assert source is not None and source.path == transcript
+    assert source.cwd == "/work"
     assert stop_source is not None and stop_source.session_id == "kiro-session"
     assert json.loads((tmp_path / ".observal" / ".kiro-session").read_text())["session_id"] == "kiro-session"
 
@@ -73,7 +88,78 @@ def test_kiro_adapter_discovers_recent_sessions_and_credits(tmp_path: Path):
     sources = adapter.discover_session_sources(home=tmp_path, since_hours=24)
 
     assert [source.path for source in sources] == [recent]
+    assert sources[0].cwd == "/work"
     assert adapter.session_extra_fields(sources[0], {}, True, home=tmp_path) == {"total_credits": 2.0}
+
+
+def test_kiro_reads_active_agent_with_latest_turn_fallback(tmp_path: Path):
+    transcript = make_session(tmp_path, agent_name="top-level-agent")
+    assert read_kiro_agent_name(transcript) == "top-level-agent"
+
+    companion = transcript.with_suffix(".json")
+    companion.write_text(
+        json.dumps(
+            {
+                "session_state": {
+                    "conversation_metadata": {
+                        "user_turn_metadatas": [
+                            {"loop_id": {"agent_id": {"name": "old-agent"}}},
+                            {"loop_id": {"agent_id": {"name": "latest-agent"}}},
+                        ]
+                    }
+                }
+            }
+        )
+    )
+    assert read_kiro_agent_name(transcript) == "latest-agent"
+
+
+def test_kiro_agent_metadata_fails_safely(tmp_path: Path):
+    transcript = make_session(tmp_path)
+    transcript.with_suffix(".json").write_text("not json")
+    assert read_kiro_agent_name(transcript) is None
+    transcript.with_suffix(".json").write_text("[]")
+    assert read_kiro_agent_name(transcript) is None
+    transcript.with_suffix(".json").write_text("null")
+    assert read_kiro_agent_name(transcript) is None
+    assert read_kiro_agent_name(tmp_path / "missing.jsonl") is None
+    assert read_kiro_agent_name(None) is None
+
+
+def test_kiro_recovery_attributes_each_session_from_its_metadata(tmp_path: Path, monkeypatch):
+    pulled = make_session(tmp_path, "agent-session", agent_name="pulled-agent")
+    default = make_session(tmp_path, "default-session", agent_name="kiro_default")
+    old_time = time.time() - 180
+    os.utime(pulled, (old_time, old_time))
+    os.utime(default, (old_time, old_time))
+    write_config(tmp_path)
+    recovered: dict[str, tuple[str | None, str | None]] = {}
+
+    def lookup(name, harness, directory=None):
+        assert name == "pulled-agent"
+        assert directory == "/work"
+        assert harness == "kiro"
+        return {"id": "pulled-uuid", "version": "1.2.0"}
+
+    def capture(source, _config, **_kwargs):
+        from observal_cli.sessions.base import _resolve_agent
+
+        assert source.session_id not in recovered
+        recovered[source.session_id] = _resolve_agent(source.cwd, [], source.path, harness="kiro")
+        return True
+
+    monkeypatch.setenv("OBSERVAL_AGENT_ID", "triggering-hook-uuid")
+    monkeypatch.setattr("observal_cli.lockfile.get_agent_by_name", lookup)
+    monkeypatch.setattr(session_push, "drain_outbox", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(session_push, "read_cursor_state", lambda *_args, **_kwargs: (0, 0, False))
+    monkeypatch.setattr(session_push, "drain_session_source", capture)
+
+    session_push._recover_sessions("kiro", home=tmp_path)
+
+    assert recovered == {
+        "agent-session": ("pulled-uuid", "1.2.0"),
+        "default-session": (None, None),
+    }
 
 
 def test_kiro_stop_routes_credits_through_shared_engine(tmp_path: Path, monkeypatch):

--- a/tests/test_resolve_agent_version.py
+++ b/tests/test_resolve_agent_version.py
@@ -4,8 +4,10 @@
 """Tests for _resolve_agent version attribution from lockfile."""
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
+from observal_cli.lockfile import get_agent_by_name
 from observal_cli.sessions.base import _lookup_lockfile_agent, _resolve_agent
 
 
@@ -30,46 +32,111 @@ def _make_lockfile_entry(
     }
 
 
+def _write_kiro_session(tmp_path: Path, agent_name: str) -> Path:
+    session_dir = tmp_path / ".kiro" / "sessions" / "cli"
+    session_dir.mkdir(parents=True)
+    transcript = session_dir / "session.jsonl"
+    transcript.write_text('{"kind":"Prompt"}\n')
+    transcript.with_suffix(".json").write_text(
+        json.dumps(
+            {
+                "session_state": {
+                    "agent_name": agent_name,
+                    "conversation_metadata": {
+                        "user_turn_metadatas": [
+                            {"loop_id": {"agent_id": {"name": agent_name}}},
+                        ]
+                    },
+                }
+            }
+        )
+    )
+    return transcript
+
+
 class TestResolveAgentVersionFromLockfile:
     """Verify that _resolve_agent enriches agent name with version from lockfile."""
 
-    def test_env_agent_id_gets_version_from_lockfile(self):
-        """Kiro per-agent hooks pass only the Observal agent UUID."""
+    def test_kiro_session_agent_gets_version_from_lockfile(self, tmp_path):
+        """Kiro attribution comes from session metadata, not the hook environment."""
+        transcript = _write_kiro_session(tmp_path, "my-agent")
         entry = _make_lockfile_entry(name="my-agent", agent_id="uuid-123", version="1.2.0")
 
         with (
-            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "uuid-123"}, clear=True),
-            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id", return_value=entry),
+            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "wrong-hook-uuid"}, clear=True),
+            patch("observal_cli.lockfile.get_agent_by_name", return_value=entry) as lookup,
+            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id") as id_lookup,
         ):
-            agent_id, agent_version = _resolve_agent("", [], None, harness="kiro")
+            agent_id, agent_version = _resolve_agent("", [], transcript, harness="kiro")
 
         assert agent_id == "uuid-123"
         assert agent_version == "1.2.0"
+        lookup.assert_called_once_with("my-agent", harness="kiro", directory=None)
+        id_lookup.assert_not_called()
 
-    def test_env_agent_id_missing_lockfile_returns_unattributed(self, tmp_path):
-        """Unknown Kiro UUIDs must not fall back to cwd guesses."""
+    def test_kiro_session_agent_missing_lockfile_returns_unattributed(self, tmp_path):
+        """Unknown Kiro agent names must not fall back to a hook UUID or cwd guess."""
+        transcript = _write_kiro_session(tmp_path, "local-agent")
         with (
-            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "missing-uuid"}, clear=True),
-            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id", return_value=None),
-            patch("observal_cli.sessions.base._lookup_lockfile_agent") as cwd_lookup,
+            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "pulled-agent-uuid"}, clear=True),
+            patch("observal_cli.lockfile.get_agent_by_name", return_value=None),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id") as id_lookup,
         ):
-            agent_id, agent_version = _resolve_agent(str(tmp_path), [], None, harness="kiro")
+            agent_id, agent_version = _resolve_agent(str(tmp_path), [], transcript, harness="kiro")
 
         assert agent_id is None
         assert agent_version is None
-        cwd_lookup.assert_not_called()
+        id_lookup.assert_not_called()
 
-    def test_kiro_without_env_agent_id_returns_unattributed(self, tmp_path):
-        """Kiro has no JSONL agent field, so missing UUID means no attribution."""
+    def test_kiro_default_ignores_pulled_agent_hook_id(self, tmp_path):
+        """Globally fired pulled-agent hooks must not claim kiro_default sessions."""
+        transcript = _write_kiro_session(tmp_path, "kiro_default")
+        with (
+            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "pulled-agent-uuid"}, clear=True),
+            patch("observal_cli.lockfile.get_agent_by_name") as name_lookup,
+            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id") as id_lookup,
+        ):
+            agent_id, agent_version = _resolve_agent(str(tmp_path), [], transcript, harness="kiro")
+
+        assert agent_id is None
+        assert agent_version is None
+        name_lookup.assert_not_called()
+        id_lookup.assert_not_called()
+
+    def test_kiro_missing_metadata_does_not_trust_hook_id(self, tmp_path):
+        """Missing session metadata fails safely instead of guessing from the hook."""
+        transcript = tmp_path / "missing.jsonl"
+        transcript.write_text('{"kind":"Prompt"}\n')
+        with (
+            patch.dict("os.environ", {"OBSERVAL_AGENT_ID": "uuid-123"}, clear=True),
+            patch("observal_cli.lockfile.get_agent_by_name") as name_lookup,
+            patch("observal_cli.sessions.base._lookup_lockfile_agent_by_id") as id_lookup,
+        ):
+            agent_id, agent_version = _resolve_agent(str(tmp_path), [], transcript, harness="kiro")
+
+        assert agent_id is None
+        assert agent_version is None
+        name_lookup.assert_not_called()
+        id_lookup.assert_not_called()
+
+    def test_adapter_without_identity_extension_uses_shared_resolution(self):
+        """Existing structural adapters can omit the optional identity resolver."""
+
+        class LegacyAdapter:
+            @staticmethod
+            def requires_explicit_agent_id() -> bool:
+                return False
+
         with (
             patch.dict("os.environ", {}, clear=True),
-            patch("observal_cli.sessions.base._lookup_lockfile_agent") as cwd_lookup,
+            patch("observal_cli.harness.ensure_loaded"),
+            patch("observal_cli.harness.get_adapter", return_value=LegacyAdapter()),
+            patch("observal_cli.sessions.base._lookup_lockfile_agent", return_value=None),
         ):
-            agent_id, agent_version = _resolve_agent(str(tmp_path), [], None, harness="kiro")
+            agent_id, agent_version = _resolve_agent("", [], None, harness="legacy")
 
         assert agent_id is None
         assert agent_version is None
-        cwd_lookup.assert_not_called()
 
     def test_env_var_gets_version_from_lockfile(self, tmp_path):
         """When OBSERVAL_AGENT_NAME is set, version should come from lockfile."""
@@ -230,3 +297,28 @@ class TestResolveAgentVersionFromLockfile:
 
         assert entry is not None
         assert entry["version"] == "1.2.0"
+
+    def test_kiro_lockfile_lookup_matches_generated_local_name(self):
+        """Session metadata records the generated Kiro profile name, not its display name."""
+        entry = _make_lockfile_entry(name="Display Name", agent_id="uuid-local", version="2.0.0", scope="user")
+        entry["local_name"] = "alice-shared"
+        data = {"harnesses": {"kiro": {"agents": [entry]}}}
+
+        with patch("observal_cli.lockfile.read_registry_lockfile", return_value=({}, data)):
+            matched = get_agent_by_name("alice-shared", harness="kiro")
+
+        assert matched is entry
+
+    def test_kiro_lockfile_lookup_fails_closed_for_ambiguous_projects(self):
+        """Recovery without cwd must not choose an arbitrary project-scoped agent."""
+        first = _make_lockfile_entry(name="Agent", agent_id="uuid-one", directory="/project/one")
+        second = _make_lockfile_entry(name="Agent", agent_id="uuid-two", directory="/project/two")
+        first["local_name"] = second["local_name"] = "shared-agent"
+        data = {"harnesses": {"kiro": {"agents": [first, second]}}}
+
+        with patch("observal_cli.lockfile.read_registry_lockfile", return_value=({}, data)):
+            ambiguous = get_agent_by_name("shared-agent", harness="kiro")
+            scoped = get_agent_by_name("shared-agent", harness="kiro", directory="/project/two")
+
+        assert ambiguous is None
+        assert scoped is second


### PR DESCRIPTION
## Purpose / Description

Kiro CLI can fire hooks from multiple agent profiles for the same session. Observal trusted the hook's `OBSERVAL_AGENT_ID`, so `kiro_default` and other agent chats could be attributed to the wrong pulled agent.

## Fixes

- No linked issue

## Approach

- Resolve Kiro session identity inside `KiroAdapter`
- Read the active agent from the Kiro session companion JSON
- Resolve generated profile names through the Kiro lockfile's `local_name` field
- Preserve `cwd` during recovery for project-scoped lookups
- Leave default, unknown, malformed, and ambiguous sessions unattributed
- Keep shared session delivery harness-agnostic and preserve the existing hook format

## How Has This Been Tested?

- `uv run pytest tests/test_kiro_session_delivery.py tests/test_resolve_agent_version.py -q`
- `uv run pytest tests/test_session_delivery.py tests/test_session_reconcile.py tests/test_session_outbox.py tests/test_cli_harness_adapters.py tests/test_scan_kiro_home.py tests/test_harness_refactor_baseline.py tests/test_harness_registry.py -q`
- 288 affected tests passed after the adapter refactor
- Ruff lint and format checks passed for all changed Python files

## Learning (optional, can help others)

Kiro session companion files contain the active profile name and working directory. These values are a safer attribution source than the environment of a globally dispatched hook.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: not applicable

## AI Assistance

- [x] Yes (Kiro)
- [x] The generated code was manually reviewed and tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kiro sessions now automatically identify their associated agent and version from session metadata.
  * Session discovery now records each session’s working directory.
  * Agent matching supports local names, display names, and unique identifiers, with project-specific matching prioritized.

* **Bug Fixes**
  * Improved handling of missing, invalid, ambiguous, or incomplete session metadata without assigning incorrect identities.
  * Default Kiro agents are no longer attributed to sessions through unrelated identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->