### PR TITLE
fix(cli): preserve intentional downgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixes
+
+- keep intentional CLI downgrades pinned when targeting legacy releases ([#1672](https://github.com/Observal/Observal/pull/1672))
+
 ## [1.11.0] - 2026-08-02
 
 ### Features

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -1770,10 +1770,29 @@ def downgrade(
     except UpgradeLockError as e:
         rprint(f"[red]{e}[/red]")
         raise typer.Exit(1)
+
+    # Releases before v1.10.4 silently auto-updated on startup. Pin their
+    # legacy setting before installation so the next command cannot undo an
+    # intentional downgrade. Restore the prior value if installation fails.
+    pin_legacy_auto_update = target < Version("1.10.4")
+    previous_auto_update = None
     try:
+        if pin_legacy_auto_update:
+            previous_auto_update = config.load().get("auto_update", True)
+            config.save({"auto_update": False})
         _do_install(install, version, direction="downgrade")
+    except BaseException:
+        if pin_legacy_auto_update:
+            try:
+                config.save({"auto_update": previous_auto_update})
+            except Exception as restore_error:
+                rprint(f"[yellow]Warning: could not restore auto-update setting: {restore_error}[/yellow]")
+        raise
     finally:
         release_lock(lock)
+
+    if pin_legacy_auto_update:
+        rprint("[dim]Automatic updates disabled to keep this legacy version pinned.[/dim]")
 
 
 @self_app.command()

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -1785,7 +1785,7 @@ def downgrade(
         if pin_legacy_auto_update:
             try:
                 config.save({"auto_update": previous_auto_update})
-            except Exception as restore_error:
+            except (Exception, SystemExit) as restore_error:
                 rprint(f"[yellow]Warning: could not restore auto-update setting: {restore_error}[/yellow]")
         raise
     finally:

--- a/observal_cli/upgrade_executor.py
+++ b/observal_cli/upgrade_executor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -51,7 +52,7 @@ def execute(install_info: InstallInfo, target_version: str, direction: str, spin
         raise typer.Exit(1)
 
     # Post-install verification
-    _verify_install(direction)
+    _verify_install(install_info, target_version, direction)
 
 
 def _install_via_uv(target_version: str, direction: str, spinner) -> None:
@@ -235,11 +236,45 @@ def _replace_binary(install_info: InstallInfo, content: bytes, target_version: s
         raise typer.Exit(1)
 
 
-def _verify_install(direction: str) -> None:
-    """Run observal --version to confirm the install worked."""
+def _verify_install(install_info: InstallInfo, target_version: str, direction: str) -> None:
+    """Verify that the updated executable reports the requested version."""
+    from packaging.version import InvalidVersion, Version
+
+    executable = str(install_info.path)
     try:
-        result = subprocess.run(["observal", "--version"], capture_output=True, text=True, timeout=10)
-        new_version = result.stdout.strip().split()[-1] if result.returncode == 0 else "unknown"
-        rprint(f"[green]{direction.capitalize()}d to v{new_version}[/green]")
-    except (subprocess.TimeoutExpired, OSError, IndexError):
-        rprint(f"[green]{direction.capitalize()} complete. Restart your shell to use the new version.[/green]")
+        result = subprocess.run([executable, "--version"], capture_output=True, text=True, timeout=10)
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        rprint(f"[red]{direction.capitalize()} verification failed:[/red] {exc}")
+        rprint(f"[dim]Executable: {executable}[/dim]")
+        raise typer.Exit(1) from exc
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+        rprint(f"[red]{direction.capitalize()} verification failed:[/red] {detail}")
+        rprint(f"[dim]Executable: {executable}[/dim]")
+        raise typer.Exit(1)
+
+    output = result.stdout.strip() or result.stderr.strip()
+    match = re.search(r"(?<![\w.])v?(\d+(?:\.\d+){2}(?:[-+][0-9A-Za-z.-]+)?)", output)
+    if not match:
+        rprint(f"[red]{direction.capitalize()} verification failed:[/red] could not parse version from {output!r}")
+        rprint(f"[dim]Executable: {executable}[/dim]")
+        raise typer.Exit(1)
+
+    try:
+        actual = Version(match.group(1))
+        expected = Version(target_version)
+    except InvalidVersion as exc:
+        rprint(f"[red]{direction.capitalize()} verification failed:[/red] invalid version output {output!r}")
+        rprint(f"[dim]Executable: {executable}[/dim]")
+        raise typer.Exit(1) from exc
+
+    if actual != expected:
+        rprint(
+            f"[red]{direction.capitalize()} verification failed:[/red] "
+            f"expected v{expected}, but {executable} reports v{actual}."
+        )
+        rprint("[dim]Check for multiple Observal installations on PATH.[/dim]")
+        raise typer.Exit(1)
+
+    rprint(f"[green]{direction.capitalize()}d to v{actual}[/green]")

--- a/tests/test_self_commands.py
+++ b/tests/test_self_commands.py
@@ -188,6 +188,31 @@ class TestSelfDowngrade:
         assert result.exit_code != 0
         assert mock_auto_update_config["auto_update"] is True
 
+    def test_downgrade_warns_when_auto_update_restore_fails(
+        self, mock_version, mock_install_uv, mock_lock, mock_auto_update_config, monkeypatch
+    ):
+        save_calls = []
+
+        def save_config(updates):
+            save_calls.append(updates)
+            if len(save_calls) == 2:
+                raise SystemExit("permission denied")
+            mock_auto_update_config.update(updates)
+
+        def fail_install(*args, **kwargs):
+            raise RuntimeError("install failed")
+
+        monkeypatch.setattr("observal_cli.cmd_ops.config.save", save_config)
+        monkeypatch.setattr("observal_cli.cmd_ops._do_install", fail_install)
+
+        result = runner.invoke(_get_app(), ["self", "downgrade", "--version", "1.1.0", "--force"])
+
+        assert isinstance(result.exception, RuntimeError)
+        assert str(result.exception) == "install failed"
+        assert save_calls == [{"auto_update": False}, {"auto_update": True}]
+        assert "could not restore auto-update setting" in result.output
+        assert "permission denied" in result.output
+
     def test_modern_downgrade_does_not_change_auto_update(
         self, mock_install_uv, mock_lock, mock_auto_update_config, monkeypatch
     ):

--- a/tests/test_self_commands.py
+++ b/tests/test_self_commands.py
@@ -63,6 +63,15 @@ def mock_lock(monkeypatch, tmp_path):
     monkeypatch.setattr("observal_cli.upgrade_lock.CONFIG_DIR", tmp_path)
 
 
+@pytest.fixture
+def mock_auto_update_config(monkeypatch):
+    """Keep downgrade pinning isolated from the user's real config."""
+    state = {}
+    monkeypatch.setattr("observal_cli.cmd_ops.config.load", lambda: state.copy())
+    monkeypatch.setattr("observal_cli.cmd_ops.config.save", lambda updates: state.update(updates))
+    return state
+
+
 def _get_app():
     """Import the app fresh (avoids circular import issues in tests)."""
     from observal_cli.main import app
@@ -129,7 +138,7 @@ class TestSelfDowngrade:
         result = runner.invoke(app, ["self", "downgrade", "--version", "1.3.0"])
         assert "not older" in result.output.lower() or "upgrade" in result.output.lower()
 
-    def test_downgrade_pipx_install(self, mock_version, mock_lock, monkeypatch):
+    def test_downgrade_pipx_install(self, mock_version, mock_lock, mock_auto_update_config, monkeypatch):
         from observal_cli.install_detector import InstallInfo, InstallMethod
 
         info = InstallInfo(InstallMethod.PIPX, Path("/home/user/.local/bin/observal"), True, "pipx")
@@ -144,8 +153,10 @@ class TestSelfDowngrade:
         result = runner.invoke(app, ["self", "downgrade", "--version", "1.1.0", "--force"])
         assert result.exit_code == 0
         assert install_called == {"i": info, "target": "1.1.0", "direction": "downgrade"}
+        assert mock_auto_update_config["auto_update"] is False
+        assert "legacy version pinned" in result.output
 
-    def test_downgrade_curl_install(self, mock_version, mock_lock, monkeypatch):
+    def test_downgrade_curl_install(self, mock_version, mock_lock, mock_auto_update_config, monkeypatch):
         from observal_cli.install_detector import InstallInfo, InstallMethod
 
         info = InstallInfo(InstallMethod.BINARY, Path("/usr/local/bin/observal"), True, "curl")
@@ -160,6 +171,80 @@ class TestSelfDowngrade:
         result = runner.invoke(app, ["self", "downgrade", "--version", "1.1.0", "--force"])
         assert result.exit_code == 0
         assert install_called == {"i": info, "target": "1.1.0", "direction": "downgrade"}
+        assert mock_auto_update_config["auto_update"] is False
+
+    def test_downgrade_restores_auto_update_when_install_fails(
+        self, mock_version, mock_install_uv, mock_lock, mock_auto_update_config, monkeypatch
+    ):
+        mock_auto_update_config["auto_update"] = True
+
+        def fail_install(*args, **kwargs):
+            raise RuntimeError("install failed")
+
+        monkeypatch.setattr("observal_cli.cmd_ops._do_install", fail_install)
+
+        result = runner.invoke(_get_app(), ["self", "downgrade", "--version", "1.1.0", "--force"])
+
+        assert result.exit_code != 0
+        assert mock_auto_update_config["auto_update"] is True
+
+    def test_modern_downgrade_does_not_change_auto_update(
+        self, mock_install_uv, mock_lock, mock_auto_update_config, monkeypatch
+    ):
+        monkeypatch.setattr("observal_cli.version_check.get_current_version", lambda: "1.11.0")
+        mock_auto_update_config["auto_update"] = True
+        monkeypatch.setattr("observal_cli.cmd_ops._do_install", lambda *args, **kwargs: None)
+
+        result = runner.invoke(_get_app(), ["self", "downgrade", "--version", "1.10.4", "--force"])
+
+        assert result.exit_code == 0
+        assert mock_auto_update_config["auto_update"] is True
+        assert "legacy version pinned" not in result.output
+
+
+class TestInstallVerification:
+    def test_verify_install_checks_target_executable(self, monkeypatch, capsys):
+        from subprocess import CompletedProcess
+
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+        from observal_cli.upgrade_executor import _verify_install
+
+        info = InstallInfo(InstallMethod.UV_TOOL, Path("/tools/observal"), True, "uv")
+        run_calls = []
+
+        def mock_run(command, **kwargs):
+            run_calls.append(command)
+            return CompletedProcess(command, 0, stdout="observal 1.9.6\n", stderr="")
+
+        monkeypatch.setattr("observal_cli.upgrade_executor.subprocess.run", mock_run)
+
+        _verify_install(info, "1.9.6", "downgrade")
+
+        assert run_calls == [["/tools/observal", "--version"]]
+        assert "Downgraded to v1.9.6" in capsys.readouterr().out
+
+    def test_verify_install_rejects_wrong_version(self, monkeypatch, capsys):
+        from subprocess import CompletedProcess
+
+        import typer
+
+        from observal_cli.install_detector import InstallInfo, InstallMethod
+        from observal_cli.upgrade_executor import _verify_install
+
+        info = InstallInfo(InstallMethod.UV_TOOL, Path("/tools/observal"), True, "uv")
+        monkeypatch.setattr(
+            "observal_cli.upgrade_executor.subprocess.run",
+            lambda command, **kwargs: CompletedProcess(command, 0, stdout="observal 1.11.0\n", stderr=""),
+        )
+
+        with pytest.raises(typer.Exit):
+            _verify_install(info, "1.9.6", "downgrade")
+
+        output = capsys.readouterr().out
+        assert "expected v1.9.6" in output
+        assert "reports" in output
+        assert "v1.11.0" in output
+        assert "/tools/observal" in output
 
 
 class TestSelfRollback:


### PR DESCRIPTION
## Purpose / Description

`observal self downgrade` could report success, then a legacy CLI older than v1.10.4 would silently update itself on the next command. This returned users to the original CLI and server version mismatch.

## Fixes

* No linked issue. Found during local CLI and server version testing.

## Approach

* Disable the legacy `auto_update` setting before installing targets older than v1.10.4.
* Restore the previous setting if installation or verification fails.
* Verify that the detected executable reports the requested target version.
* Leave downgrade behavior for v1.10.4 and newer unchanged.
* Add an Unreleased changelog entry.

## How Has This Been Tested?

* `uv run --with pytest --with typer --with rich pytest tests/test_self_commands.py tests/test_version_check.py -q`
  * 56 tests passed.
* Ruff lint and format checks passed for changed Python files.
* `git diff --check` passed.
* CI passes on Python 3.11, 3.12, and 3.13, plus lint, CodeQL, dependency review, secret scanning, Docker build, and CLA checks.

## Checklist

- [x] Descriptive Conventional Commit messages with short subjects.
- [x] Comments added for the legacy behavior that is not obvious from current code.
- [x] Full diff reviewed for scope, failure rollback, and user configuration safety.
- [x] UI changes are not applicable.

## AI Assistance

- [x] Yes: Kiro with GPT 5.6 Sol.
- [x] Generated code manually reviewed and tested by the PR author.