### PR TITLE
fix(kiro): require explicit session identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- require explicit Kiro session identity and keep aged recovery non-final
 - keep intentional CLI downgrades pinned when targeting legacy releases ([#1672](https://github.com/Observal/Observal/pull/1672))
 
 ## [1.11.0] - 2026-08-02

--- a/observal_cli/harness/base.py
+++ b/observal_cli/harness/base.py
@@ -150,6 +150,10 @@ class BaseAdapter:
         """Return whether the harness requires detached network delivery."""
         return False
 
+    def aged_recovery_final(self) -> bool:
+        """Finalize aged session sources by default."""
+        return True
+
     def is_session_final(self, event: dict[str, Any]) -> bool:
         """Recognize common final lifecycle event names."""
         event_name = str(

--- a/observal_cli/harness/kiro.py
+++ b/observal_cli/harness/kiro.py
@@ -43,7 +43,7 @@ class KiroAdapter(BaseAdapter):
     def resolve_session_source(self, event: dict[str, Any], home: Path | None = None) -> SessionSource | None:
         from observal_cli.sessions.kiro import find_kiro_jsonl, read_kiro_session_cwd, resolve_session_id
 
-        session_id = resolve_session_id(event, home=home)
+        session_id = resolve_session_id(event)
         if not session_id:
             return None
         home = home or Path.home()

--- a/observal_cli/harness/kiro.py
+++ b/observal_cli/harness/kiro.py
@@ -47,9 +47,6 @@ class KiroAdapter(BaseAdapter):
         if not session_id:
             return None
         home = home or Path.home()
-        state_dir = home / ".observal"
-        state_dir.mkdir(parents=True, exist_ok=True)
-        (state_dir / ".kiro-session").write_text(json.dumps({"session_id": session_id}))
         path = find_kiro_jsonl(session_id, home=home)
         if path is None:
             return None
@@ -106,6 +103,10 @@ class KiroAdapter(BaseAdapter):
         if entry is None:
             return None, None
         return entry.get("id"), entry.get("version")
+
+    def aged_recovery_final(self) -> bool:
+        """Keep quiet Kiro sessions recoverable while they may be permission-paused."""
+        return False
 
     def session_extra_fields(
         self,

--- a/observal_cli/harness/protocol.py
+++ b/observal_cli/harness/protocol.py
@@ -290,6 +290,10 @@ class HarnessAdapter(Protocol):
         """Return whether network drain must run outside the hook process."""
         ...
 
+    def aged_recovery_final(self) -> bool:
+        """Return whether aged session recovery should finalize the source."""
+        ...
+
     def is_session_final(self, event: dict[str, Any]) -> bool:
         """Return whether a hook payload marks its session final."""
         ...

--- a/observal_cli/hooks/session_push.py
+++ b/observal_cli/hooks/session_push.py
@@ -177,6 +177,7 @@ def _recover_sessions(harness: str, exclude_session: str = "", home: Path | None
     if config is None:
         return
     drain_outbox(config, home=home)
+    recovery_final = adapter.aged_recovery_final()
     now = time.time()
     for source in adapter.discover_session_sources(home=home):
         if source.session_id == exclude_session or source.path is None:
@@ -188,15 +189,15 @@ def _recover_sessions(harness: str, exclude_session: str = "", home: Path | None
         except OSError:
             continue
         offset, _line_count, finalized = read_cursor_state(source.checkpoint_key, home=home)
-        if finalized and offset >= stat.st_size:
+        if offset >= stat.st_size and (finalized or not recovery_final):
             continue
         event = {"session_id": source.session_id, "hook_event_name": "Stop"}
         drain_session_source(
             source,
             config,
             hook_event="CrashRecovery",
-            final=True,
-            extra_fields=adapter.session_extra_fields(source, event, True, home=home),
+            final=recovery_final,
+            extra_fields=adapter.session_extra_fields(source, event, recovery_final, home=home),
             recover_from_server=True,
             home=home,
         )

--- a/observal_cli/sessions/kiro.py
+++ b/observal_cli/sessions/kiro.py
@@ -91,13 +91,12 @@ def read_kiro_session_cwd(session_jsonl: Path | None) -> str:
     return cwd.strip() if isinstance(cwd, str) else ""
 
 
-def resolve_session_id(event: dict, home: Path | None = None) -> str:
+def resolve_session_id(event: dict) -> str:
     """Return a non-empty session ID supplied explicitly by a Kiro hook event.
 
     Identity-less events are intentionally left unresolved because a shared
     fallback cannot safely correlate concurrent Kiro sessions.
     """
-    del home  # Kept for call-site compatibility.
     session_id = event.get("session_id")
     return session_id.strip() if isinstance(session_id, str) else ""
 

--- a/observal_cli/sessions/kiro.py
+++ b/observal_cli/sessions/kiro.py
@@ -92,25 +92,14 @@ def read_kiro_session_cwd(session_jsonl: Path | None) -> str:
 
 
 def resolve_session_id(event: dict, home: Path | None = None) -> str:
-    """Return the session_id for a Kiro hook event.
+    """Return a non-empty session ID supplied explicitly by a Kiro hook event.
 
-    Kiro sends ``session_id`` on userPromptSubmit / agentSpawn, but NOT on stop.
-    For stop events, falls back to the value persisted by a previous hook in
-    ~/.observal/.kiro-session.
+    Identity-less events are intentionally left unresolved because a shared
+    fallback cannot safely correlate concurrent Kiro sessions.
     """
-    session_id = event.get("session_id", "")
-    if session_id:
-        return session_id
-    if home is None:
-        home = Path.home()
-    session_file = home / ".observal" / ".kiro-session"
-    try:
-        if session_file.exists():
-            cached = json.loads(session_file.read_text())
-            session_id = cached.get("session_id", "")
-    except Exception:
-        pass
-    return session_id
+    del home  # Kept for call-site compatibility.
+    session_id = event.get("session_id")
+    return session_id.strip() if isinstance(session_id, str) else ""
 
 
 def read_kiro_credits(session_id: str, home: Path | None = None) -> float | None:

--- a/tests/test_kiro_session_delivery.py
+++ b/tests/test_kiro_session_delivery.py
@@ -60,7 +60,7 @@ def write_config(home: Path) -> None:
     )
 
 
-def test_kiro_adapter_resolves_and_persists_session_for_stop(tmp_path: Path):
+def test_kiro_adapter_resolves_explicit_session_without_singleton(tmp_path: Path):
     transcript = make_session(tmp_path)
     ensure_loaded()
     adapter = get_adapter("kiro")
@@ -69,12 +69,36 @@ def test_kiro_adapter_resolves_and_persists_session_for_stop(tmp_path: Path):
         {"session_id": "kiro-session", "cwd": "/hook-work"},
         home=tmp_path,
     )
-    stop_source = adapter.resolve_session_source({"event": "stop"}, home=tmp_path)
 
     assert source is not None and source.path == transcript
     assert source.cwd == "/work"
-    assert stop_source is not None and stop_source.session_id == "kiro-session"
-    assert json.loads((tmp_path / ".observal" / ".kiro-session").read_text())["session_id"] == "kiro-session"
+    assert not (tmp_path / ".observal" / ".kiro-session").exists()
+
+
+def test_kiro_adapter_ignores_missing_id_and_stale_singleton(tmp_path: Path):
+    make_session(tmp_path, "stale-session")
+    state_file = tmp_path / ".observal" / ".kiro-session"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(json.dumps({"session_id": "stale-session"}))
+    ensure_loaded()
+    adapter = get_adapter("kiro")
+
+    assert adapter.resolve_session_source({"event": "stop"}, home=tmp_path) is None
+    assert json.loads(state_file.read_text()) == {"session_id": "stale-session"}
+
+
+def test_uncorrelated_stop_does_not_select_concurrent_kiro_session(tmp_path: Path):
+    make_session(tmp_path, "session-a")
+    make_session(tmp_path, "session-b")
+    ensure_loaded()
+    adapter = get_adapter("kiro")
+
+    source_a = adapter.resolve_session_source({"session_id": "session-a"}, home=tmp_path)
+    source_b = adapter.resolve_session_source({"session_id": "session-b"}, home=tmp_path)
+
+    assert source_a is not None and source_a.session_id == "session-a"
+    assert source_b is not None and source_b.session_id == "session-b"
+    assert adapter.resolve_session_source({"event": "stop"}, home=tmp_path) is None
 
 
 def test_kiro_adapter_discovers_recent_sessions_and_credits(tmp_path: Path):
@@ -133,7 +157,7 @@ def test_kiro_recovery_attributes_each_session_from_its_metadata(tmp_path: Path,
     os.utime(pulled, (old_time, old_time))
     os.utime(default, (old_time, old_time))
     write_config(tmp_path)
-    recovered: dict[str, tuple[str | None, str | None]] = {}
+    recovered: dict[str, tuple[str | None, str | None, bool]] = {}
 
     def lookup(name, harness, directory=None):
         assert name == "pulled-agent"
@@ -145,7 +169,8 @@ def test_kiro_recovery_attributes_each_session_from_its_metadata(tmp_path: Path,
         from observal_cli.sessions.base import _resolve_agent
 
         assert source.session_id not in recovered
-        recovered[source.session_id] = _resolve_agent(source.cwd, [], source.path, harness="kiro")
+        identity = _resolve_agent(source.cwd, [], source.path, harness="kiro")
+        recovered[source.session_id] = (*identity, _kwargs["final"])
         return True
 
     monkeypatch.setenv("OBSERVAL_AGENT_ID", "triggering-hook-uuid")
@@ -157,9 +182,60 @@ def test_kiro_recovery_attributes_each_session_from_its_metadata(tmp_path: Path,
     session_push._recover_sessions("kiro", home=tmp_path)
 
     assert recovered == {
-        "agent-session": ("pulled-uuid", "1.2.0"),
-        "default-session": (None, None),
+        "agent-session": ("pulled-uuid", "1.2.0", False),
+        "default-session": (None, None, False),
     }
+
+
+def test_kiro_recovery_skips_acknowledged_eof(tmp_path: Path, monkeypatch):
+    transcript = make_session(tmp_path)
+    old_time = time.time() - 180
+    os.utime(transcript, (old_time, old_time))
+    write_config(tmp_path)
+    recovered: list[str] = []
+
+    monkeypatch.setattr(session_push, "drain_outbox", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        session_push,
+        "read_cursor_state",
+        lambda *_args, **_kwargs: (transcript.stat().st_size, 1, False),
+    )
+    monkeypatch.setattr(
+        session_push,
+        "drain_session_source",
+        lambda source, *_args, **_kwargs: recovered.append(source.session_id) or True,
+    )
+
+    session_push._recover_sessions("kiro", home=tmp_path)
+
+    assert recovered == []
+
+
+def test_kiro_recovery_delivers_growth_non_finally(tmp_path: Path, monkeypatch):
+    transcript = make_session(tmp_path)
+    acknowledged_offset = transcript.stat().st_size
+    with transcript.open("a") as file:
+        file.write('{"kind":"Response","data":{"content":"later"}}\n')
+    old_time = time.time() - 180
+    os.utime(transcript, (old_time, old_time))
+    write_config(tmp_path)
+    recovered: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(session_push, "drain_outbox", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        session_push,
+        "read_cursor_state",
+        lambda *_args, **_kwargs: (acknowledged_offset, 1, False),
+    )
+    monkeypatch.setattr(
+        session_push,
+        "drain_session_source",
+        lambda source, *_args, **kwargs: recovered.append((source.session_id, kwargs["final"])) or True,
+    )
+
+    session_push._recover_sessions("kiro", home=tmp_path)
+
+    assert recovered == [("kiro-session", False)]
 
 
 def test_kiro_stop_routes_credits_through_shared_engine(tmp_path: Path, monkeypatch):

--- a/tests/test_session_reconcile.py
+++ b/tests/test_session_reconcile.py
@@ -88,10 +88,14 @@ def test_background_recovery_uses_adapter_sources_and_shared_drain(tmp_path: Pat
             assert home == tmp_path
             return sources
 
+        def aged_recovery_final(self):
+            return True
+
         def session_extra_fields(self, source, event, final, home=None):
             return {"source": source.session_id}
 
     calls: list[str] = []
+    finals: list[bool] = []
     monkeypatch.setattr(session_push, "ensure_loaded", lambda: None)
     monkeypatch.setattr(session_push, "get_adapter", lambda _harness: Adapter())
     monkeypatch.setattr(session_push, "load_config", lambda home=None: {"user_id": "user"})
@@ -104,9 +108,10 @@ def test_background_recovery_uses_adapter_sources_and_shared_drain(tmp_path: Pat
     monkeypatch.setattr(
         session_push,
         "drain_session_source",
-        lambda source, *_args, **_kwargs: calls.append(source.session_id) or True,
+        lambda source, *_args, **kwargs: (calls.append(source.session_id), finals.append(kwargs["final"])) and True,
     )
 
     session_push._recover_sessions("claude-code", home=tmp_path)
 
     assert calls == ["outbox", "unfinished"]
+    assert finals == [True]


### PR DESCRIPTION
## Purpose / Description
Kiro hooks used a shared `.kiro-session` file when an event did not include a session ID. That fallback can select the wrong transcript when multiple sessions overlap. Aged recovery also treated quiet Kiro sessions as final, even when a session was paused waiting for tool approval.

## Fixes
* No linked issue.

## Approach
Kiro now uses only the `session_id` from the current hook event. If an event has no ID, it is skipped instead of being matched through shared state.

Aged Kiro recovery sends new records with `final=False` and does nothing when the saved cursor is already at EOF. If the transcript grows later, recovery resumes from that cursor. Other harnesses keep their existing final recovery behavior, and an explicit Kiro Stop still starts the final worker.

## How Has This Been Tested?

```bash
uv run pytest tests/test_kiro_session_delivery.py tests/test_session_delivery.py tests/test_session_reconcile.py tests/test_session_outbox.py tests/test_cli_harness_adapters.py tests/test_harness_refactor_baseline.py tests/test_harness_registry.py -q
```

Result: 251 passed.

I also ran Ruff lint and format checks on the changed Python files and ran `git diff --check`. The follow-up review cleanup passed 76 focused tests.

## Learning (optional, can help others)
I tested four concurrent sessions with Kiro IDE 1.0.242. Every observed Stop included a session ID. I also left a turn paused for approval for more than 225 seconds and then resumed it, which showed that 120 seconds of inactivity is not proof that a Kiro session has ended.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (not applicable; no UI changes)

## AI Assistance
_Was generative AI tooling used to co-author this PR?_

- [x] Yes (Kiro with Claude Opus 5)
- [x] Was the generated code manually reviewed and tested?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kiro sessions now require an explicit session ID for reliable session matching.
  * Session recovery supports harness-specific finalization behavior.

* **Bug Fixes**
  * Prevented stale or unrelated Kiro sessions from being selected.
  * Avoided creating or relying on persisted singleton session state.
  * Improved recovery handling for acknowledged sessions and sessions with new transcript activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->