### PR TITLE
ci: target canonical Codecov project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,10 @@ jobs:
         with:
           files: observal-server/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          slug: Observal/Observal
+          disable_search: true
+          # Fork pull requests cannot access repository secrets, so Codecov authenticates those tokenlessly.
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
 # ── Job 4: Next.js lint + typecheck ───────────────────────────────────────────
   web-lint:


### PR DESCRIPTION
## Purpose / Description

Ensure coverage uploads target the canonical `Observal/Observal` Codecov project instead of relying on token inference. The existing integration left the README badge on a stale June 2026 report and silently accepted failed uploads.

## Fixes

No linked issue. Corrects the stale Codecov integration discovered while verifying PR #1677.

## Approach

- Set the Codecov slug explicitly to `Observal/Observal`.
- Disable report auto-discovery so only `observal-server/coverage.xml` is uploaded.
- Fail trusted CI runs when Codecov upload fails.
- Keep tokenless uploads nonblocking for pull requests from forks because GitHub does not expose repository secrets to those workflows.

## How Has This Been Tested?

No local tests were run, per maintainer request. `git diff --check` passed. A rerun on `main` confirmed that the updated secret still targets `blazeup-ai/observal`, not `Observal/Observal`. Canonical upload verification remains blocked until the repository secret is corrected. This change makes that mismatch fail loudly on trusted CI runs.

## Learning (optional, can help others)

Codecov repository tokens identify a specific repository, while fork pull requests cannot access GitHub repository secrets. Explicitly setting the slug prevents a token from silently sending data to a legacy personal project.

Reference: https://docs.codecov.com/docs/codecov-tokens

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (not applicable, no UI changes)

## AI Assistance

- [x] Yes (Pi coding agent with OpenAI model)
- [ ] Was the generated code manually reviewed and tested? Maintainer review and CI verification are pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code coverage reporting reliability across pull requests and other automated checks.
  * Forked pull requests can now submit coverage results without authentication-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->