### PR TITLE
fix(build): preserve debug symbols

### DIFF
--- a/observal_cli/pyinstaller.spec
+++ b/observal_cli/pyinstaller.spec
@@ -7,7 +7,6 @@
 Produces a single-file executable containing the main CLI and sandbox runner support.
 """
 
-import sys
 from pathlib import Path
 
 block_cipher = None
@@ -72,7 +71,7 @@ exe = EXE(
     name="observal",
     debug=False,
     bootloader_ignore_signals=False,
-    strip=sys.platform != "win32",
+    strip=False,
     upx=True,
     upx_exclude=[],
     runtime_tmpdir=None,


### PR DESCRIPTION
## Purpose / Description

Unix PyInstaller release builds stripped debugging symbols unconditionally. This prevented the project from satisfying the OpenSSF `build_preserve_debug` criterion when debugging information should be retained.

## Fixes

* No linked issue.

## Approach

Set `strip=False` in `observal_cli/pyinstaller.spec` for every supported platform and remove the now unused `sys` import. This only changes release build configuration. No application Python behavior changes, and the setting is self-explanatory without an added comment.

## How Has This Been Tested?

* Parsed `observal_cli/pyinstaller.spec` with Python's AST parser.
* Asserted that the `strip` argument is the literal value `False`.
* Confirmed the release workflow builds from this specification.
* The full test suite was not run at maintainer direction because no runtime code changed.
* No UI files changed, so screenshots are not applicable.

## Learning (optional, can help others)

No external research was needed. PyInstaller's `strip` setting controls symbol stripping, while its `debug` setting controls bootloader diagnostics.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): pi coding agent 0.84.1
- [x] Was the generated code manually reviewed and tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused build configuration code.
  * Updated executable packaging settings for more consistent builds across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->