### PR TITLE
chore(release): v1.12.0

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,42 +1,49 @@
 <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-# Observal v1.11.0
-
-This release includes 13 change groups through `ad7a6cf`.
+This release includes 25 change groups through `fde9c88`.
 
 ## Features
 
-- add teamspace membership and handle reservation ([#1619](https://github.com/Observal/Observal/pull/1619))
-- add team publishing and team-private visibility ([#1640](https://github.com/Observal/Observal/pull/1640))
-- add success criteria fields to agent versions ([#1623](https://github.com/Observal/Observal/pull/1623))
-- add curated release pipeline ([#1642](https://github.com/Observal/Observal/pull/1642))
+- add Goose as a first-class harness ([#1667](https://github.com/Observal/Observal/pull/1667))
+- continuous fuzzing via OSS-Fuzz (Scorecard Fuzzing 0/10 → 10/10) ([#1668](https://github.com/Observal/Observal/pull/1668))
+- add the cross-product actionable inbox ([#1669](https://github.com/Observal/Observal/pull/1669))
+- meet OpenSSF security criteria ([#1674](https://github.com/Observal/Observal/pull/1674))
+- add shareable registry and team links ([#1673](https://github.com/Observal/Observal/pull/1673))
 
 ## Fixes
 
-- resolve release tags to SHAs to survive background tag pruning ([#1651](https://github.com/Observal/Observal/pull/1651))
+- attestation verify identity and resume-safe publish jobs ([#1655](https://github.com/Observal/Observal/pull/1655))
+- make pypi, npm, and helm jobs resume-safe ([#1656](https://github.com/Observal/Observal/pull/1656))
+- remove duplicate title and contributors section from release notes ([#1658](https://github.com/Observal/Observal/pull/1658))
+- only stamp alembic HEAD on a genuinely fresh database ([#1662](https://github.com/Observal/Observal/pull/1662))
+- pre-create ~/.observal before Docker makes it root-owned ([#1664](https://github.com/Observal/Observal/pull/1664))
+- red parallel test run, dropped log records, and stale AGENTS.md ([#1666](https://github.com/Observal/Observal/pull/1666))
+- preserve intentional downgrades ([#1672](https://github.com/Observal/Observal/pull/1672))
+- correct agent trace attribution ([#1671](https://github.com/Observal/Observal/pull/1671))
+- support headless setup ([#1676](https://github.com/Observal/Observal/pull/1676))
+- preserve debug symbols ([#1679](https://github.com/Observal/Observal/pull/1679))
+- require explicit session identity ([#1675](https://github.com/Observal/Observal/pull/1675))
+
+## Documentation
+
+- remove repetition between How It Works and feature sections ([#1657](https://github.com/Observal/Observal/pull/1657))
 
 ## Maintenance
 
-- remove legacy tenant scaffold ([#1641](https://github.com/Observal/Observal/pull/1641))
-- Feat/registry recommendations ([#1638](https://github.com/Observal/Observal/pull/1638))
-- add OpenSSF Scorecard ([#1643](https://github.com/Observal/Observal/pull/1643))
-- support linear releases and merge queue ([#1644](https://github.com/Observal/Observal/pull/1644))
-- fix root lockfile vulns and scope workflow token permissions ([#1645](https://github.com/Observal/Observal/pull/1645))
-- pin dependencies, attach signed release provenance, and docs fixes ([#1648](https://github.com/Observal/Observal/pull/1648))
-- drop redundant workflow_dispatch prerelease override flag ([#1650](https://github.com/Observal/Observal/pull/1650))
-- run pytest in parallel across cores with pytest-xdist ([#1652](https://github.com/Observal/Observal/pull/1652))
+- add E2E tests for CLI doctor commands ([#1018](https://github.com/Observal/Observal/pull/1018))
+- traces pipeline end-to-end tests (#946) ([#1174](https://github.com/Observal/Observal/pull/1174))
+- agents e2e tests (#936, #937, #938, #939, #941) ([#1169](https://github.com/Observal/Observal/pull/1169))
+- add Playwright tests for SSO and device auth (#929) ([#1177](https://github.com/Observal/Observal/pull/1177))
+- add unit tests for observal_cli/cmd_scan.py ([#1369](https://github.com/Observal/Observal/pull/1369))
+- cover cmd auth helpers ([#1647](https://github.com/Observal/Observal/pull/1647))
+- raise Python coverage with focused suites ([#1677](https://github.com/Observal/Observal/pull/1677))
+- target canonical Codecov project ([#1678](https://github.com/Observal/Observal/pull/1678))
 
-## Contributors
+## Verify this release
 
-- @Haz3-jolt
-- @Kaushik-Kumar-CEG
-- @Lokesh7025
-- Hari Srinivasan
-- Kaushik Kumar
-- Lokesh Selvam
-- Shaan Narendran
+Verify checksums, artifact provenance, and the signed release tag using the [release verification guide](https://github.com/Observal/Observal/blob/main/docs/security/release-verification.md).
 
 ## Full comparison
 
-[v1.10.7...v1.11.0](https://github.com/Observal/Observal/compare/v1.10.7...v1.11.0)
+[v1.11.0...v1.12.0](https://github.com/Observal/Observal/compare/v1.11.0...v1.12.0)

--- a/.release.toml
+++ b/.release.toml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-version = "1.11.0"
+version = "1.12.0"
 channel = "stable"
-previous_tag = "v1.10.7"
-cutoff = "ad7a6cf6809cb722a580f791f8650b5f3750a25e"
-created_at = "2026-08-02T19:28:41.731778+00:00"
-commit_count = 54
-included_prs = [1619, 1640, 1641, 1623, 1638, 1642, 1643, 1644, 1645, 1648, 1650, 1651, 1652]
+previous_tag = "v1.11.0"
+cutoff = "fde9c88947f5be55b589a6b6daaa1c63e7287b85"
+created_at = "2026-08-09T12:44:59.459224+00:00"
+commit_count = 127
+included_prs = [1655, 1656, 1657, 1658, 1662, 1664, 1666, 1667, 1668, 1672, 1671, 1669, 1674, 1676, 1673, 1018, 1174, 1169, 1177, 1369, 1647, 1677, 1678, 1679, 1675]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.12.0] - 2026-08-09
+
+### Features
+
+- add Goose as a first-class harness ([#1667](https://github.com/Observal/Observal/pull/1667))
+- continuous fuzzing via OSS-Fuzz (Scorecard Fuzzing 0/10 → 10/10) ([#1668](https://github.com/Observal/Observal/pull/1668))
+- add the cross-product actionable inbox ([#1669](https://github.com/Observal/Observal/pull/1669))
+- meet OpenSSF security criteria ([#1674](https://github.com/Observal/Observal/pull/1674))
+- add shareable registry and team links ([#1673](https://github.com/Observal/Observal/pull/1673))
+
+### Fixes
+
+- attestation verify identity and resume-safe publish jobs ([#1655](https://github.com/Observal/Observal/pull/1655))
+- make pypi, npm, and helm jobs resume-safe ([#1656](https://github.com/Observal/Observal/pull/1656))
+- remove duplicate title and contributors section from release notes ([#1658](https://github.com/Observal/Observal/pull/1658))
+- only stamp alembic HEAD on a genuinely fresh database ([#1662](https://github.com/Observal/Observal/pull/1662))
+- pre-create ~/.observal before Docker makes it root-owned ([#1664](https://github.com/Observal/Observal/pull/1664))
+- red parallel test run, dropped log records, and stale AGENTS.md ([#1666](https://github.com/Observal/Observal/pull/1666))
+- preserve intentional downgrades ([#1672](https://github.com/Observal/Observal/pull/1672))
+- correct agent trace attribution ([#1671](https://github.com/Observal/Observal/pull/1671))
+- support headless setup ([#1676](https://github.com/Observal/Observal/pull/1676))
+- preserve debug symbols ([#1679](https://github.com/Observal/Observal/pull/1679))
+- require explicit session identity ([#1675](https://github.com/Observal/Observal/pull/1675))
+
+### Documentation
+
+- remove repetition between How It Works and feature sections ([#1657](https://github.com/Observal/Observal/pull/1657))
+
+### Maintenance
+
+- add E2E tests for CLI doctor commands ([#1018](https://github.com/Observal/Observal/pull/1018))
+- traces pipeline end-to-end tests (#946) ([#1174](https://github.com/Observal/Observal/pull/1174))
+- agents e2e tests (#936, #937, #938, #939, #941) ([#1169](https://github.com/Observal/Observal/pull/1169))
+- add Playwright tests for SSO and device auth (#929) ([#1177](https://github.com/Observal/Observal/pull/1177))
+- add unit tests for observal_cli/cmd_scan.py ([#1369](https://github.com/Observal/Observal/pull/1369))
+- cover cmd auth helpers ([#1647](https://github.com/Observal/Observal/pull/1647))
+- raise Python coverage with focused suites ([#1677](https://github.com/Observal/Observal/pull/1677))
+- target canonical Codecov project ([#1678](https://github.com/Observal/Observal/pull/1678))
+
 ## [Unreleased]
 
 ### Security

--- a/observal-server/pyproject.toml
+++ b/observal-server/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "observal-server"
-version = "1.11.0"
+version = "1.12.0"
 description = "Observal API server"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/observal-server/uv.lock
+++ b/observal-server/uv.lock
@@ -1998,7 +1998,7 @@ wheels = [
 
 [[package]]
 name = "observal-server"
-version = "1.11.0"
+version = "1.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "observal-pi",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "description": "Observal session telemetry for Pi \u2014 zero-dependency extension that pushes session traces to your Observal server",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@
 
 [project]
 name = "observal-cli"
-version = "1.11.0"
+version = "1.12.0"
 description = "Observal MCP Server Registry & Agent Registry CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "observal-cli"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Purpose / Description
Prepare Observal v1.12.0 from the contiguous release range `v1.11.0..fde9c88`.

## Fixes
No linked issue. This is a release preparation change.

## Approach
The release contains 25 PR or commit groups. This PR updates version metadata, lockfiles, the curated release notes, and prepends one new changelog section without rewriting existing changelog history.

Merge this PR with squash, rebase, or the merge queue. The release workflow publishes this PR's selected-cutoff head rather than the resulting `main` commit.

## How Has This Been Tested?

The release tool validated ancestry, tag state, version consistency, allowed changed files, changelog preservation, and release-note generation. The release workflow will build and verify every artifact before publishing.

## Learning (optional, can help others)
Not applicable. The implementation uses existing Git, GitHub CLI, uv, and repository build tooling.

## Release preview

## [1.12.0] - 2026-08-09

### Features

- add Goose as a first-class harness ([#1667](https://github.com/Observal/Observal/pull/1667))
- continuous fuzzing via OSS-Fuzz (Scorecard Fuzzing 0/10 → 10/10) ([#1668](https://github.com/Observal/Observal/pull/1668))
- add the cross-product actionable inbox ([#1669](https://github.com/Observal/Observal/pull/1669))
- meet OpenSSF security criteria ([#1674](https://github.com/Observal/Observal/pull/1674))
- add shareable registry and team links ([#1673](https://github.com/Observal/Observal/pull/1673))

### Fixes

- attestation verify identity and resume-safe publish jobs ([#1655](https://github.com/Observal/Observal/pull/1655))
- make pypi, npm, and helm jobs resume-safe ([#1656](https://github.com/Observal/Observal/pull/1656))
- remove duplicate title and contributors section from release notes ([#1658](https://github.com/Observal/Observal/pull/1658))
- only stamp alembic HEAD on a genuinely fresh database ([#1662](https://github.com/Observal/Observal/pull/1662))
- pre-create ~/.observal before Docker makes it root-owned ([#1664](https://github.com/Observal/Observal/pull/1664))
- red parallel test run, dropped log records, and stale AGENTS.md ([#1666](https://github.com/Observal/Observal/pull/1666))
- preserve intentional downgrades ([#1672](https://github.com/Observal/Observal/pull/1672))
- correct agent trace attribution ([#1671](https://github.com/Observal/Observal/pull/1671))
- support headless setup ([#1676](https://github.com/Observal/Observal/pull/1676))
- preserve debug symbols ([#1679](https://github.com/Observal/Observal/pull/1679))
- require explicit session identity ([#1675](https://github.com/Observal/Observal/pull/1675))

### Documentation

- remove repetition between How It Works and feature sections ([#1657](https://github.com/Observal/Observal/pull/1657))

### Maintenance

- add E2E tests for CLI doctor commands ([#1018](https://github.com/Observal/Observal/pull/1018))
- traces pipeline end-to-end tests (#946) ([#1174](https://github.com/Observal/Observal/pull/1174))
- agents e2e tests (#936, #937, #938, #939, #941) ([#1169](https://github.com/Observal/Observal/pull/1169))
- add Playwright tests for SSO and device auth (#929) ([#1177](https://github.com/Observal/Observal/pull/1177))
- add unit tests for observal_cli/cmd_scan.py ([#1369](https://github.com/Observal/Observal/pull/1369))
- cover cmd auth helpers ([#1647](https://github.com/Observal/Observal/pull/1647))
- raise Python coverage with focused suites ([#1677](https://github.com/Observal/Observal/pull/1677))
- target canonical Codecov project ([#1678](https://github.com/Observal/Observal/pull/1678))

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. Not applicable, this PR contains generated release metadata.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens. Not applicable, this PR has no UI changes.

## AI Assistance

- [ ] Yes (Please Specify the tool): Not applicable to generated release metadata.
- [ ] Was the generated code manually reviewed and tested? Not applicable.
