### PR TITLE
fix(release): validate current notes format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
           if f"## [{version}]" not in pathlib.Path("CHANGELOG.md").read_text():
               raise SystemExit("release version is missing from CHANGELOG.md")
           notes = pathlib.Path(".github/release-notes.md").read_text()
-          if f"# Observal v{version}" not in notes or "## Contributors" not in notes:
+          if f"{previous_tag}...v{version}" not in notes:
               raise SystemExit("release notes are incomplete")
 
           previous = previous_tag.removeprefix("v").split(".")


### PR DESCRIPTION
## Purpose / Description

Release 1.12.0 failed during preflight because the workflow still required the release title and Contributors sections, although PR #1658 intentionally removed both from generated release notes.

## Fixes

No linked issue. Fixes failed release run [31314373412](https://github.com/Observal/Observal/actions/runs/31314373412).

## Approach

Validate release notes using their canonical comparison marker, `{previous_tag}...v{version}`. This keeps stale or incomplete notes detection while matching the current generated format.

## How Has This Been Tested?

- `uv run pytest tests/test_release.py -q`: 21 passed.
- Git whitespace validation: passed.
- The updated condition was evaluated against release target `01b154de`, confirming `v1.11.0...v1.12.0` is present.
- `actionlint` was not installed locally. GitHub CI will perform repository workflow checks.

## Learning (optional, can help others)

PR #1658 changed the generated note format, but the duplicated preflight expectations were not updated with it. The failure occurred before any release artifacts were built or published.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. Not applicable because this is one direct validation condition.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens. Not applicable because this has no UI changes.

## AI Assistance

- [x] Yes (Please Specify the tool): pi coding agent 0.84.1.
- [x] Was the generated code manually reviewed and tested? The maintainer reviewed and directed the one-line preflight approach, and the checks above passed.
