### PR TITLE
fix(release): update gitsign verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,16 +424,41 @@ jobs:
 
       - uses: chainguard-dev/actions/setup-gitsign@9d631658f55713e5f63ca0cc21ee168f81301fd9 # v1.6.30
 
+      # setup-gitsign configures Git but still installs gitsign 0.16.1.
+      - name: Install gitsign 0.17.1
+        env:
+          GITSIGN_VERSION: "0.17.1"
+          GITSIGN_SHA256: "69213a8a0813a151e5a47d0060862952ff833a845d57309dff76f7ba6600abae"
+        run: |
+          GITSIGN_BIN=$(mktemp)
+          trap 'rm -f "$GITSIGN_BIN"' EXIT
+          curl -fLsS \
+            "https://github.com/sigstore/gitsign/releases/download/v${GITSIGN_VERSION}/gitsign_${GITSIGN_VERSION}_linux_amd64" \
+            -o "$GITSIGN_BIN"
+          printf '%s  %s\n' "$GITSIGN_SHA256" "$GITSIGN_BIN" | sha256sum -c
+          install -m 0755 "$GITSIGN_BIN" "$HOME/.gitsign/gitsign"
+          gitsign version
+
       - name: Create or verify tag
         env:
           VERSION: ${{ needs.preflight.outputs.version }}
           TARGET: ${{ needs.preflight.outputs.target }}
+          GITSIGN_ENABLE_SIGSTORE_GO: "true"
+          GITSIGN_REKOR_MODE: "online"
+          GITSIGN_REKOR_VERSION: "1"
         run: |
           TAG="v$VERSION"
           verify_tag() {
-            gitsign verify-tag "$TAG" \
-              --certificate-identity "https://github.com/$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main" \
-              --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+            for attempt in {1..5}; do
+              if gitsign verify-tag "$TAG" \
+                --certificate-identity "https://github.com/$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main" \
+                --certificate-oidc-issuer "https://token.actions.githubusercontent.com"; then
+                return 0
+              fi
+              [ "$attempt" -eq 5 ] && return 1
+              echo "Tag verification attempt $attempt failed, retrying in 15 seconds"
+              sleep 15
+            done
           }
           if git rev-parse "$TAG^{commit}" >/dev/null 2>&1; then
             [ "$(git rev-parse "$TAG^{commit}")" = "$TARGET" ] || {

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -301,11 +301,25 @@ def test_release_notes_include_version_and_comparison_link():
 def test_release_workflow_signs_and_verifies_tags_before_push():
     workflow = (ROOT / ".github/workflows/release.yml").read_text()
     tag_job = workflow[workflow.index("  tag:\n") : workflow.index("  pypi:\n")]
+    install_gitsign = tag_job[
+        tag_job.index("      - name: Install gitsign 0.17.1") : tag_job.index("      - name: Create or verify tag")
+    ]
+    verify_tag = tag_job[tag_job.index("          verify_tag() {") : tag_job.index("          if git rev-parse")]
 
     assert "id-token: write" in tag_job
     assert "chainguard-dev/actions/setup-gitsign@9d631658f55713e5f63ca0cc21ee168f81301fd9" in tag_job
+    assert 'GITSIGN_VERSION: "0.17.1"' in install_gitsign
+    assert "69213a8a0813a151e5a47d0060862952ff833a845d57309dff76f7ba6600abae" in install_gitsign
+    assert "sha256sum -c" in install_gitsign
+    assert "gitsign version" in install_gitsign
+    assert 'GITSIGN_ENABLE_SIGSTORE_GO: "true"' in tag_job
+    assert 'GITSIGN_REKOR_MODE: "online"' in tag_job
+    assert 'GITSIGN_REKOR_VERSION: "1"' in tag_job
     assert "git tag -s" in tag_job
-    assert "gitsign verify-tag" in tag_job
+    assert "gitsign verify-tag" in verify_tag
+    assert "for attempt in {1..5}" in verify_tag
+    assert '"$attempt" -eq 5' in verify_tag
+    assert "sleep 15" in verify_tag
     assert tag_job.index("gitsign verify-tag") < tag_job.index("git push origin")
     assert "certificate-oidc-issuer" in tag_job
     assert "predates signed-tag enforcement" in tag_job


### PR DESCRIPTION
## Purpose / Description

Release 1.12.0 reached tag creation, but gitsign 0.16.1 failed Rekor verification three times before the signed tag could be pushed. The first attempt exhausted Rekor network retries. The next two could not find a matching transparency-log entry through the legacy online lookup path.

## Fixes

No linked issue. Fixes the tag failure in release run [31315446952](https://github.com/Observal/Observal/actions/runs/31315446952).

## Approach

Keep the pinned setup action for Git configuration, then replace only its gitsign binary with the official Linux amd64 release for version 0.17.1. The download uses an exact version URL and pinned SHA-256 digest.

Use the newer Sigstore Go verification path explicitly while retaining online Rekor version 1. Rekor v2 is not enabled. Verification retries the same locally signed tag up to five times with a 15 second pause. Verification still fails closed after the final attempt, and the workflow never pushes an unverified tag.

## How Has This Been Tested?

- Downloaded the exact release binary and verified its pinned SHA-256 digest.
- The binary reported `gitsign version v0.17.1` with Sigstore Go enabled, online Rekor mode, and Rekor version 1.
- `uv run pytest tests/test_release.py -q`: 21 passed.
- Ruff check and formatting validation passed for `tests/test_release.py`.
- Git whitespace and added-line style validation passed.

## Learning (optional, can help others)

gitsign 0.17.0 added the Sigstore Go online Rekor flow, while the pinned setup action still installs 0.16.1. Repeating the old job generated a fresh signature each time and repeatedly entered the failing legacy lookup path. The upgrade changes the client path without changing GitHub permissions or enabling Rekor v2.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. The version override has one focused comment explaining why it follows the setup action.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens. Not applicable because this has no UI changes.

## AI Assistance

- [x] Yes (Please Specify the tool): pi coding agent 0.84.1.
- [x] Was the generated code manually reviewed and tested? The maintainer selected the checksum-pinned 0.17.1 approach, and the checks above passed.
