### PR TITLE
fix(teams): correct teamspace lifecycle access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixes
 
+- restore teamspace discovery, membership controls, private join requests, and empty personal deletion
+- require global review before a teamspace becomes public
+- let approved public teamspace owners and reviewers decide all team content
+- move the inbox filter rail to the right
 - require explicit Kiro session identity and keep aged recovery non-final
 - keep intentional CLI downgrades pinned when targeting legacy releases ([#1672](https://github.com/Observal/Observal/pull/1672))
 

--- a/docs/use-cases/teamspaces.md
+++ b/docs/use-cases/teamspaces.md
@@ -3,28 +3,34 @@
 
 # Teamspaces
 
-A teamspace is a shared namespace that a group of users publishes under. Each teamspace has a unique handle (for example `platform-tools`) that is reserved across the whole registry, so a user cannot take a username that collides with a team handle and vice versa.
+A teamspace is a shared registry namespace with a unique handle such as `platform-tools`. Team handles and usernames cannot collide.
 
 ## Roles
 
-Every member of a teamspace has one of three roles:
+Every member has one role:
 
 | Role | Can |
 | --- | --- |
-| `owner` | Manage members, edit the teamspace, delete the teamspace |
-| `reviewer` | (Reserved for team publishing approval, see below) |
-| `member` | View the team roster |
+| `owner` | Manage members, invites, visibility, and registry content |
+| `reviewer` | Approve or reject the teamspace's pending agents and components |
+| `member` | View the roster and publish into the teamspace |
 
-Global admins can manage any teamspace regardless of membership. A teamspace always keeps at least one owner; the last owner cannot leave or be removed without first transferring ownership.
+Global admins can manage any teamspace. A teamspace always keeps at least one owner.
 
 ## Creating a teamspace
 
-Any user with the `reviewer` role or above can create a teamspace from the web UI under **Registry, Teamspaces**. The creator becomes the first owner. The handle is derived from the name you choose but can be edited, and it must pass the namespace rules: 3 to 32 lowercase letters, digits, and hyphens, starting and ending with a letter or digit.
+Any signed-in user can create a teamspace under **Registry, Teamspaces**. Private teamspaces are ready immediately. A public teamspace reserves its handle but stays private and locked until a global reviewer or above approves it in the Review queue. A global reviewer may approve their own request.
 
-## Managing members
+Changing an existing private teamspace to public follows the same review flow. A rejected request keeps the teamspace private and can be submitted again. Personal teamspaces always remain private.
 
-Team owners and global admins can add members by searching for a user by name, email, or username, and assigning a role. Members can leave a team on their own unless they are the last owner.
+## Publishing and review
 
-## What is not here yet
+Private teamspaces can publish only team-private agents and components. Teamspace submissions never auto-approve.
 
-Team-scoped publishing (publishing an agent or component directly into a team namespace, and team-private visibility for components and agents) is a follow-up slice. Today teamspaces establish identity, membership, and handle reservation only.
+After a teamspace is approved for public visibility, its owners and team reviewers may approve or reject all content in that namespace, including public content and their own submissions. Global reviewers continue to review public content across the registry. Public submissions notify both groups, while team-private submissions notify only that teamspace's owners and reviewers. Global admins may still review all content.
+
+A public teamspace cannot become private while it owns public agents, components, or component sources. Restrict or remove those items first.
+
+## Membership
+
+Owners and global admins can add users and assign roles. Public teamspaces accept join requests. Private teamspaces use expiring invite links, and their owners decide the resulting requests. Members can leave unless they are the last owner.

--- a/observal-server/alembic/versions/025_team_visibility_review.py
+++ b/observal-server/alembic/versions/025_team_visibility_review.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add teamspace public visibility review state.
+
+Revision ID: 025_team_visibility_review
+Revises: 024_shareable_teamspaces
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "025_team_visibility_review"
+down_revision = "024_shareable_teamspaces"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(name: str) -> bool:
+    return name in {column["name"] for column in sa.inspect(op.get_bind()).get_columns("teams")}
+
+
+def _has_check(name: str) -> bool:
+    return any(check["name"] == name for check in sa.inspect(op.get_bind()).get_check_constraints("teams"))
+
+
+def _has_foreign_key(name: str) -> bool:
+    return any(key["name"] == name for key in sa.inspect(op.get_bind()).get_foreign_keys("teams"))
+
+
+def upgrade() -> None:
+    columns = (
+        sa.Column("visibility_request_status", sa.String(length=16), nullable=True),
+        sa.Column("visibility_requested_by", sa.UUID(), nullable=True),
+        sa.Column("visibility_requested_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("visibility_reviewed_by", sa.UUID(), nullable=True),
+        sa.Column("visibility_reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("visibility_rejection_reason", sa.String(length=500), nullable=True),
+    )
+    for column in columns:
+        if not _has_column(column.name):
+            op.add_column("teams", column)
+
+    if not _has_check("ck_teams_visibility_request_status"):
+        op.create_check_constraint(
+            "ck_teams_visibility_request_status",
+            "teams",
+            "visibility_request_status IS NULL OR visibility_request_status IN ('pending', 'approved', 'rejected')",
+        )
+    if not _has_check("ck_teams_pending_visibility_private"):
+        op.create_check_constraint(
+            "ck_teams_pending_visibility_private",
+            "teams",
+            "visibility_request_status != 'pending' OR is_private",
+        )
+    if not _has_check("ck_teams_pending_visibility_requested_at"):
+        op.create_check_constraint(
+            "ck_teams_pending_visibility_requested_at",
+            "teams",
+            "visibility_request_status != 'pending' OR visibility_requested_at IS NOT NULL",
+        )
+    if not _has_foreign_key("fk_teams_visibility_requested_by_users"):
+        op.create_foreign_key(
+            "fk_teams_visibility_requested_by_users",
+            "teams",
+            "users",
+            ["visibility_requested_by"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+    if not _has_foreign_key("fk_teams_visibility_reviewed_by_users"):
+        op.create_foreign_key(
+            "fk_teams_visibility_reviewed_by_users",
+            "teams",
+            "users",
+            ["visibility_reviewed_by"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    if _has_foreign_key("fk_teams_visibility_reviewed_by_users"):
+        op.drop_constraint("fk_teams_visibility_reviewed_by_users", "teams", type_="foreignkey")
+    if _has_foreign_key("fk_teams_visibility_requested_by_users"):
+        op.drop_constraint("fk_teams_visibility_requested_by_users", "teams", type_="foreignkey")
+    if _has_check("ck_teams_pending_visibility_requested_at"):
+        op.drop_constraint("ck_teams_pending_visibility_requested_at", "teams", type_="check")
+    if _has_check("ck_teams_pending_visibility_private"):
+        op.drop_constraint("ck_teams_pending_visibility_private", "teams", type_="check")
+    if _has_check("ck_teams_visibility_request_status"):
+        op.drop_constraint("ck_teams_visibility_request_status", "teams", type_="check")
+    for name in (
+        "visibility_rejection_reason",
+        "visibility_reviewed_at",
+        "visibility_reviewed_by",
+        "visibility_requested_at",
+        "visibility_requested_by",
+        "visibility_request_status",
+    ):
+        if _has_column(name):
+            op.drop_column("teams", name)

--- a/observal-server/api/routes/agent/draft.py
+++ b/observal-server/api/routes/agent/draft.py
@@ -14,7 +14,7 @@ from api.deps import commit_or_name_conflict, get_db, get_effective_agent_permis
 from models.agent import Agent, AgentStatus, AgentVersion
 from models.agent_component import AgentComponent
 from models.skill import SkillListing
-from models.team import TeamRole
+from models.team import Team, TeamRole
 from models.user import User, UserRole
 from schemas.agent import AgentCreateRequest, AgentResponse, AgentUpdateRequest
 from services.config_generator import validate_mcp_command
@@ -23,7 +23,7 @@ from services.harness_capability_inference import compute_supported_harnesses, i
 from services.inbox import sources as inbox
 from services.registry_telemetry import emit_registry_event
 from services.teamspace import (
-    is_global_reviewer,
+    is_admin,
     publish_auto_approves_for_entity,
     resolve_publish_target,
     review_publication_to_public,
@@ -38,16 +38,24 @@ from .helpers import _agent_to_response, _load_agent, _resolve_component_names
 # ---------------------------------------------------------------------------
 
 
-async def _authorize_visibility_change(agent: Agent, current_user: User, db: AsyncSession) -> None:
-    """Gate a visibility flip behind the roles the registry visibility route requires.
-
-    Personal agents are already covered by the owner or editor check on the
-    route. Team agents additionally require a team owner or team reviewer,
-    matching PATCH /api/v1/registry/agent/{id}/visibility.
-    """
-    if is_global_reviewer(current_user):
-        return
+async def _authorize_visibility_change(
+    agent: Agent,
+    current_user: User,
+    db: AsyncSession,
+    *,
+    target_is_private: bool,
+) -> None:
+    """Authorize and serialize a team agent visibility change."""
     if agent.team_id is None:
+        return
+    team = (await db.execute(select(Team).where(Team.id == agent.team_id).with_for_update())).scalar_one_or_none()
+    if team is None:
+        raise HTTPException(status_code=404, detail="Teamspace not found")
+    if team.visibility_request_status == "pending":
+        raise HTTPException(status_code=409, detail="Teamspace is locked pending public visibility review")
+    if not target_is_private and team.is_private:
+        raise HTTPException(status_code=409, detail="Private teamspaces can only contain team-private items")
+    if is_admin(current_user):
         return
     membership = await team_membership(db, agent.team_id, current_user.id)
     if not membership or membership.role not in (TeamRole.owner, TeamRole.reviewer):
@@ -266,7 +274,7 @@ async def update_draft(
     visibility_changed = target_is_private != bool(agent.is_private)
     target_team_id = agent.team_id if target_is_private else None
     if visibility_changed:
-        await _authorize_visibility_change(agent, current_user, db)
+        await _authorize_visibility_change(agent, current_user, db, target_is_private=target_is_private)
         # A caller who resends components gets them validated below; otherwise
         # the currently attached set has to survive the new target.
         if req.components is None:

--- a/observal-server/api/routes/component_source.py
+++ b/observal-server/api/routes/component_source.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/api/v1/component-sources", tags=["component-sources"
 
 
 async def _source_visible(source: ComponentSource, current_user: User, db: AsyncSession) -> bool:
-    if source.is_public or current_user.role in (UserRole.super_admin, UserRole.admin, UserRole.reviewer):
+    if source.is_public or is_admin(current_user):
         return True
     if source.team_id is None:
         return False
@@ -92,7 +92,7 @@ async def list_sources(
     stmt = select(ComponentSource)
     if component_type:
         stmt = stmt.where(ComponentSource.component_type == component_type)
-    if current_user.role not in (UserRole.super_admin, UserRole.admin, UserRole.reviewer):
+    if not is_admin(current_user):
         member = (
             select(TeamMembership.id)
             .where(TeamMembership.team_id == ComponentSource.team_id, TeamMembership.user_id == current_user.id)

--- a/observal-server/api/routes/review.py
+++ b/observal-server/api/routes/review.py
@@ -105,8 +105,8 @@ def _authorize_item(entity, scope: ReviewScope) -> None:
 
     A team-private item the caller cannot review answers 404, matching the read
     paths: the queue already hides it, so a 403 naming it as team-private would
-    confirm both that the id exists and that it is private. A PUBLIC item is
-    already discoverable, so refusing it can say why without disclosing anything.
+    confirm both that the id exists and that it is private. A public item is
+    already discoverable, so refusing it can name the review-scope boundary.
     """
     if can_review(entity, scope):
         return
@@ -114,7 +114,7 @@ def _authorize_item(entity, scope: ReviewScope) -> None:
         raise HTTPException(status_code=404, detail="Submission not found")
     raise HTTPException(
         status_code=403,
-        detail="Public items are reviewed by global reviewers, not by teamspace roles",
+        detail="Public item is outside your review scope",
     )
 
 

--- a/observal-server/api/routes/teams.py
+++ b/observal-server/api/routes/teams.py
@@ -32,6 +32,8 @@ from schemas.team import (
     TeamMemberUpsertRequest,
     TeamResponse,
     TeamUpdateRequest,
+    TeamVisibilityDecisionRequest,
+    TeamVisibilityRequestResponse,
     TeamVisibilityUpdateRequest,
 )
 from services.inbox import sources as inbox_sources
@@ -57,6 +59,27 @@ def _role_value(role) -> str | None:
     return role.value if hasattr(role, "value") else str(role)
 
 
+def _require_team_unlocked(team: Team) -> None:
+    if team.visibility_request_status == "pending":
+        raise HTTPException(status_code=409, detail="Teamspace is locked pending public visibility review")
+
+
+async def _emit_visibility_event(team: Team, actor: User, detail: str) -> None:
+    await emit_security_event(
+        SecurityEvent(
+            event_type=EventType.TEAM_VISIBILITY_CHANGED,
+            severity=Severity.INFO,
+            outcome="success",
+            actor_id=str(actor.id),
+            actor_email=actor.email,
+            actor_role=actor.role.value,
+            target_id=str(team.id),
+            target_type="team",
+            detail=detail,
+        )
+    )
+
+
 async def _load_team(db: AsyncSession, team_id: uuid.UUID, *, for_update: bool = False) -> Team:
     if for_update:
         team = (await db.execute(select(Team).where(Team.id == team_id).with_for_update())).scalar_one_or_none()
@@ -80,8 +103,14 @@ async def _load_visible_team(db: AsyncSession, team_id: uuid.UUID, user: User) -
     return team
 
 
-async def _require_owner_or_admin(db: AsyncSession, team_id: uuid.UUID, user: User) -> Team:
-    team = await _load_team(db, team_id)
+async def _require_owner_or_admin(
+    db: AsyncSession,
+    team_id: uuid.UUID,
+    user: User,
+    *,
+    for_update: bool = False,
+) -> Team:
+    team = await _load_team(db, team_id, for_update=for_update)
     if is_admin(user):
         return team
     membership = await team_membership(db, team_id, user.id)
@@ -131,6 +160,8 @@ async def my_teams(
             description=team.description,
             visibility=team.visibility,
             is_personal=team.is_personal,
+            visibility_request_status=team.visibility_request_status,
+            visibility_rejection_reason=team.visibility_rejection_reason,
             role=_role_value(role),
             created_at=team.created_at,
         )
@@ -169,6 +200,8 @@ async def all_teams(
             description=team.description,
             visibility=team.visibility,
             is_personal=team.is_personal,
+            visibility_request_status=team.visibility_request_status,
+            visibility_rejection_reason=team.visibility_rejection_reason,
             role=_role_value(role),
             member_count=int(count) if count is not None else 0,
             created_at=team.created_at,
@@ -200,10 +233,7 @@ async def team_by_handle(
     if not team_visible_to(team, membership, current_user):
         # A hidden teamspace answers exactly like a missing one.
         raise HTTPException(status_code=404, detail="Teamspace not found")
-    if is_admin(current_user):
-        role = _role_value(TeamRole.owner)
-    else:
-        role = _role_value(membership.role) if membership else None
+    role = _role_value(membership.role) if membership else None
     member_count = await db.scalar(select(func.count(TeamMembership.id)).where(TeamMembership.team_id == team.id))
     return TeamResponse(
         id=team.id,
@@ -212,6 +242,8 @@ async def team_by_handle(
         description=team.description,
         visibility=team.visibility,
         is_personal=team.is_personal,
+        visibility_request_status=team.visibility_request_status,
+        visibility_rejection_reason=team.visibility_rejection_reason,
         role=role,
         member_count=int(member_count or 0),
         created_at=team.created_at,
@@ -246,9 +278,11 @@ async def preview_team_invite(
     if team is None or team.is_personal:
         return TeamInvitePreviewResponse(valid=False, invite_state=state)
     inviter = await db.get(User, invite.invited_by) if invite.invited_by else None
+    membership = await team_membership(db, team.id, current_user.id)
     return TeamInvitePreviewResponse(
         valid=state == "active",
         invite_state=state,
+        is_member=membership is not None,
         team_id=team.id,
         team_name=team.name,
         team_handle=team.handle,
@@ -268,19 +302,63 @@ async def preview_team_invite(
     )
 
 
-@router.get("/{team_id}", response_model=TeamResponse)
-async def team_detail(
+@router.get("/visibility-requests", response_model=list[TeamVisibilityRequestResponse])
+async def list_team_visibility_requests(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+):
+    rows = (
+        await db.execute(
+            select(Team, User.username)
+            .outerjoin(User, User.id == Team.visibility_requested_by)
+            .where(Team.visibility_request_status == "pending")
+            .order_by(Team.visibility_requested_at)
+        )
+    ).all()
+    return [
+        TeamVisibilityRequestResponse(
+            team_id=team.id,
+            name=team.name,
+            handle=team.handle,
+            description=team.description,
+            requested_by=team.visibility_requested_by,
+            requested_by_username=username,
+            requested_at=team.visibility_requested_at,
+        )
+        for team, username in rows
+    ]
+
+
+@router.post("/{team_id}/visibility-request/approve", response_model=TeamResponse)
+async def approve_team_visibility_request(
     team_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_role(UserRole.user)),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
 ):
-    team = await _load_visible_team(db, team_id, current_user)
-    role = None
-    if not is_admin(current_user):
-        membership = await team_membership(db, team.id, current_user.id)
-        role = _role_value(membership.role) if membership else None
-    else:
-        role = _role_value(TeamRole.owner)
+    team = await _load_team(db, team_id, for_update=True)
+    if team.visibility_request_status != "pending":
+        raise HTTPException(status_code=409, detail="Teamspace has no pending public visibility request")
+    team.is_private = False
+    team.visibility_request_status = "approved"
+    team.visibility_reviewed_by = current_user.id
+    team.visibility_reviewed_at = datetime.now(UTC)
+    team.visibility_rejection_reason = None
+    await db.execute(
+        update(TeamInvite)
+        .where(TeamInvite.team_id == team.id, TeamInvite.revoked_at.is_(None))
+        .values(revoked_at=datetime.now(UTC))
+    )
+    await inbox_sources.on_team_visibility_decided(
+        db,
+        team,
+        requester_id=team.visibility_requested_by,
+        approved=True,
+        actor_id=current_user.id,
+    )
+    await db.commit()
+    await db.refresh(team)
+    await _emit_visibility_event(team, current_user, f"Approved public visibility for teamspace '{team.handle}'")
+    membership = await team_membership(db, team.id, current_user.id)
     return TeamResponse(
         id=team.id,
         name=team.name,
@@ -288,6 +366,70 @@ async def team_detail(
         description=team.description,
         visibility=team.visibility,
         is_personal=team.is_personal,
+        visibility_request_status=team.visibility_request_status,
+        role=_role_value(membership.role) if membership else None,
+        created_at=team.created_at,
+    )
+
+
+@router.post("/{team_id}/visibility-request/reject", response_model=TeamResponse)
+async def reject_team_visibility_request(
+    team_id: uuid.UUID,
+    req: TeamVisibilityDecisionRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.reviewer)),
+):
+    team = await _load_team(db, team_id, for_update=True)
+    if team.visibility_request_status != "pending":
+        raise HTTPException(status_code=409, detail="Teamspace has no pending public visibility request")
+    team.visibility_request_status = "rejected"
+    team.visibility_reviewed_by = current_user.id
+    team.visibility_reviewed_at = datetime.now(UTC)
+    team.visibility_rejection_reason = ((req.reason if req else None) or "").strip() or None
+    await inbox_sources.on_team_visibility_decided(
+        db,
+        team,
+        requester_id=team.visibility_requested_by,
+        approved=False,
+        actor_id=current_user.id,
+        reason=team.visibility_rejection_reason,
+    )
+    await db.commit()
+    await db.refresh(team)
+    await _emit_visibility_event(team, current_user, f"Rejected public visibility for teamspace '{team.handle}'")
+    membership = await team_membership(db, team.id, current_user.id)
+    return TeamResponse(
+        id=team.id,
+        name=team.name,
+        handle=team.handle,
+        description=team.description,
+        visibility=team.visibility,
+        is_personal=team.is_personal,
+        visibility_request_status=team.visibility_request_status,
+        visibility_rejection_reason=team.visibility_rejection_reason,
+        role=_role_value(membership.role) if membership else None,
+        created_at=team.created_at,
+    )
+
+
+@router.get("/{team_id}", response_model=TeamResponse)
+async def team_detail(
+    team_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_role(UserRole.user)),
+):
+    team = await _load_visible_team(db, team_id, current_user)
+    membership = await team_membership(db, team.id, current_user.id)
+    role = _role_value(membership.role) if membership else None
+    return TeamResponse(
+        id=team.id,
+        name=team.name,
+        handle=team.handle,
+        description=team.description,
+        visibility=team.visibility,
+        is_personal=team.is_personal,
+        visibility_request_status=team.visibility_request_status,
+        visibility_rejection_reason=team.visibility_rejection_reason,
         role=role,
         created_at=team.created_at,
     )
@@ -306,22 +448,31 @@ async def create_team(
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
+    requests_public = req.visibility == "public"
     team = Team(
         name=req.name.strip(),
         handle=handle,
         description=req.description,
-        is_private=req.visibility == "private",
+        is_private=True,
+        is_personal=False,
+        visibility_request_status="pending" if requests_public else None,
+        visibility_requested_by=current_user.id if requests_public else None,
+        visibility_requested_at=datetime.now(UTC) if requests_public else None,
         created_by=current_user.id,
     )
     db.add(team)
     try:
         await db.flush()
         db.add(TeamMembership(team_id=team.id, user_id=current_user.id, role=TeamRole.owner))
+        if requests_public:
+            await inbox_sources.on_team_visibility_requested(db, team, requester_id=current_user.id)
         await db.commit()
     except IntegrityError:
         await db.rollback()
         raise HTTPException(status_code=409, detail="Team handle already exists")
     await db.refresh(team)
+    if requests_public:
+        await _emit_visibility_event(team, current_user, f"Requested public visibility for teamspace '{team.handle}'")
     return TeamResponse(
         id=team.id,
         name=team.name,
@@ -329,6 +480,7 @@ async def create_team(
         description=team.description,
         visibility=team.visibility,
         is_personal=team.is_personal,
+        visibility_request_status=team.visibility_request_status,
         role=_role_value(TeamRole.owner),
         member_count=1,
         created_at=team.created_at,
@@ -338,16 +490,14 @@ async def create_team(
 async def _ensure_personal_team_invariants(db: AsyncSession, team: Team, user: User) -> None:
     if team.created_by != user.id:
         raise HTTPException(status_code=403, detail="Only the personal teamspace creator may claim it")
+    _require_team_unlocked(team)
+    memberships = list(
+        (await db.execute(select(TeamMembership).where(TeamMembership.team_id == team.id).with_for_update())).scalars()
+    )
+    if any(membership.user_id != user.id for membership in memberships):
+        raise HTTPException(status_code=409, detail="A personal teamspace cannot have other members")
     team.is_private = True
-    memberships = (
-        await db.execute(select(TeamMembership).where(TeamMembership.team_id == team.id).with_for_update())
-    ).scalars()
-    creator_membership = None
-    for membership in memberships:
-        if membership.user_id == user.id:
-            creator_membership = membership
-        else:
-            await db.delete(membership)
+    creator_membership = next((membership for membership in memberships if membership.user_id == user.id), None)
     if creator_membership is None:
         db.add(TeamMembership(team_id=team.id, user_id=user.id, role=TeamRole.owner))
     else:
@@ -378,7 +528,9 @@ async def claim_personal_teamspace(
 ):
     """Create or return the caller's one personal private teamspace."""
     personal = (
-        await db.execute(select(Team).where(Team.created_by == current_user.id, Team.is_personal.is_(True)))
+        await db.execute(
+            select(Team).where(Team.created_by == current_user.id, Team.is_personal.is_(True)).with_for_update()
+        )
     ).scalar_one_or_none()
     if personal is not None:
         await _ensure_personal_team_invariants(db, personal, current_user)
@@ -389,7 +541,9 @@ async def claim_personal_teamspace(
     candidates = [base] + [slugify_handle(f"{base[:29].rstrip('-')}-{i}") for i in range(1, 6)]
 
     for candidate in candidates:
-        existing = (await db.execute(select(Team).where(Team.handle == candidate))).scalar_one_or_none()
+        existing = (
+            await db.execute(select(Team).where(Team.handle == candidate).with_for_update())
+        ).scalar_one_or_none()
         if existing is not None:
             membership = await team_membership(db, existing.id, current_user.id)
             legacy_personal = (
@@ -398,6 +552,19 @@ async def claim_personal_teamspace(
                 and existing.description == _PERSONAL_TEAM_DESCRIPTION
             )
             if membership is not None and membership.role == TeamRole.owner and legacy_personal:
+                member_ids = set(
+                    (
+                        await db.execute(
+                            select(TeamMembership.user_id)
+                            .where(TeamMembership.team_id == existing.id)
+                            .with_for_update()
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                if member_ids != {current_user.id}:
+                    continue
                 existing.is_personal = True
                 try:
                     await db.commit()
@@ -458,13 +625,15 @@ async def update_team(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    team = await _require_owner_or_admin(db, team_id, current_user)
+    team = await _require_owner_or_admin(db, team_id, current_user, for_update=True)
+    _require_team_unlocked(team)
     if req.name is not None:
         team.name = req.name.strip()
     if req.description is not None:
         team.description = req.description
     await db.commit()
     await db.refresh(team)
+    membership = await team_membership(db, team.id, current_user.id)
     return TeamResponse(
         id=team.id,
         name=team.name,
@@ -472,7 +641,9 @@ async def update_team(
         description=team.description,
         visibility=team.visibility,
         is_personal=team.is_personal,
-        role=_role_value(TeamRole.owner),
+        visibility_request_status=team.visibility_request_status,
+        visibility_rejection_reason=team.visibility_rejection_reason,
+        role=_role_value(membership.role) if membership else None,
         created_at=team.created_at,
     )
 
@@ -497,6 +668,43 @@ async def update_team_visibility(
     if team.is_personal and req.visibility != "private":
         raise HTTPException(status_code=409, detail="Personal teamspaces are always private")
 
+    if req.visibility == "public" and not team.is_private:
+        return TeamResponse(
+            id=team.id,
+            name=team.name,
+            handle=team.handle,
+            description=team.description,
+            visibility=team.visibility,
+            is_personal=team.is_personal,
+            visibility_request_status=team.visibility_request_status,
+            visibility_rejection_reason=team.visibility_rejection_reason,
+            role=_role_value(membership.role) if membership else None,
+            created_at=team.created_at,
+        )
+
+    if req.visibility == "public":
+        team.visibility_request_status = "pending"
+        team.visibility_requested_by = current_user.id
+        team.visibility_requested_at = datetime.now(UTC)
+        team.visibility_reviewed_by = None
+        team.visibility_reviewed_at = None
+        team.visibility_rejection_reason = None
+        await inbox_sources.on_team_visibility_requested(db, team, requester_id=current_user.id)
+        await db.commit()
+        await db.refresh(team)
+        await _emit_visibility_event(team, current_user, f"Requested public visibility for teamspace '{team.handle}'")
+        return TeamResponse(
+            id=team.id,
+            name=team.name,
+            handle=team.handle,
+            description=team.description,
+            visibility=team.visibility,
+            is_personal=team.is_personal,
+            visibility_request_status=team.visibility_request_status,
+            role=_role_value(membership.role) if membership else None,
+            created_at=team.created_at,
+        )
+
     if req.visibility == "private" and not team.is_private:
         public_items = await _team_owned_listing_counts(db, team.id, public_only=True)
         if public_items:
@@ -506,33 +714,47 @@ async def update_team_visibility(
                 detail=f"Make these public registry items team-private first: {detail}",
             )
 
-    changed = team.is_private != (req.visibility == "private")
-    team.is_private = req.visibility == "private"
-    if changed and not team.is_private:
-        await db.execute(
-            update(TeamInvite)
-            .where(TeamInvite.team_id == team.id, TeamInvite.revoked_at.is_(None))
-            .values(revoked_at=datetime.now(UTC))
+    changed = not team.is_private
+    team.is_private = True
+    if team.visibility_request_status == "pending":
+        await inbox_sources.on_team_visibility_cancelled(db, team, actor_id=current_user.id)
+        team.visibility_request_status = None
+        team.visibility_requested_by = None
+        team.visibility_requested_at = None
+    if changed:
+        pending_requests = (
+            (
+                await db.execute(
+                    select(TeamMembershipRequest)
+                    .where(
+                        TeamMembershipRequest.team_id == team.id,
+                        TeamMembershipRequest.status == TeamJoinRequestStatus.pending,
+                    )
+                    .with_for_update()
+                )
+            )
+            .scalars()
+            .all()
         )
+        for pending in pending_requests:
+            pending.status = TeamJoinRequestStatus.rejected
+            pending.decided_by = current_user.id
+            pending.decided_at = datetime.now(UTC)
+            pending.decision_reason = "Teamspace became private"
+            await inbox_sources.on_team_join_decided(
+                db,
+                team,
+                request_id=pending.id,
+                requester_id=pending.user_id,
+                approved=False,
+                actor_id=current_user.id,
+                reason=pending.decision_reason,
+            )
     await db.commit()
     await db.refresh(team)
     if changed:
-        await emit_security_event(
-            SecurityEvent(
-                event_type=EventType.TEAM_VISIBILITY_CHANGED,
-                severity=Severity.INFO,
-                outcome="success",
-                actor_id=str(current_user.id),
-                actor_email=current_user.email,
-                actor_role=current_user.role.value,
-                target_id=str(team.id),
-                target_type="team",
-                detail=f"Teamspace '{team.handle}' is now {team.visibility}",
-            )
-        )
-    role = (
-        _role_value(TeamRole.owner) if is_admin(current_user) else _role_value(membership.role) if membership else None
-    )
+        await _emit_visibility_event(team, current_user, f"Teamspace '{team.handle}' is now {team.visibility}")
+    role = _role_value(membership.role) if membership else None
     return TeamResponse(
         id=team.id,
         name=team.name,
@@ -540,6 +762,8 @@ async def update_team_visibility(
         description=team.description,
         visibility=team.visibility,
         is_personal=team.is_personal,
+        visibility_request_status=team.visibility_request_status,
+        visibility_rejection_reason=team.visibility_rejection_reason,
         role=role,
         created_at=team.created_at,
     )
@@ -576,14 +800,16 @@ async def _team_owned_listing_counts(
     }
     counts: dict[str, int] = {}
     for model, (singular, plural) in labels.items():
-        if public_only and not hasattr(model, "is_private"):
-            continue
         # Soft-deleted agents count too. They are restorable and still carry the
         # teamspace's namespace, so freeing the handle while one exists lets a new
         # team claim it and inherit that agent on restore.
         stmt = select(func.count(model.id)).where(model.team_id == team_id)
         if public_only:
-            stmt = stmt.where(model.is_private.is_(False))
+            stmt = (
+                stmt.where(model.is_public.is_(True))
+                if model is ComponentSource
+                else stmt.where(model.is_private.is_(False))
+            )
         total = await db.scalar(stmt)
         if total:
             counts[singular if total == 1 else plural] = total
@@ -596,9 +822,7 @@ async def delete_team(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    team = await _require_owner_or_admin(db, team_id, current_user)
-    if getattr(team, "is_personal", False) is True:
-        raise HTTPException(status_code=409, detail="Personal teamspaces cannot be deleted")
+    team = await _require_owner_or_admin(db, team_id, current_user, for_update=True)
 
     # Refuse while the teamspace still owns listings. ON DELETE SET NULL would
     # otherwise leave every one of them with is_private=True and team_id=NULL:
@@ -676,11 +900,34 @@ async def upsert_team_member(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    team = await _require_owner_or_admin(db, team_id, current_user)
+    team = await _require_owner_or_admin(db, team_id, current_user, for_update=True)
+    _require_team_unlocked(team)
     if team.is_personal:
         raise HTTPException(status_code=409, detail="Personal teamspaces cannot add members or change roles")
     target = await _resolve_member(db, req)
     membership = await team_membership(db, team.id, target.id)
+    pending = (
+        await db.execute(
+            select(TeamMembershipRequest)
+            .where(
+                TeamMembershipRequest.team_id == team.id,
+                TeamMembershipRequest.user_id == target.id,
+                TeamMembershipRequest.status == TeamJoinRequestStatus.pending,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    invite = None
+    if pending is not None and pending.invite_id is not None:
+        invite = (
+            await db.execute(select(TeamInvite).where(TeamInvite.id == pending.invite_id).with_for_update())
+        ).scalar_one_or_none()
+        if invite is None:
+            raise HTTPException(status_code=409, detail="Invitation no longer exists")
+        if membership is None and invite.max_uses is not None and invite.use_count >= invite.max_uses:
+            raise HTTPException(status_code=409, detail="Invitation has no remaining uses")
+
+    granted_membership = membership is None
     if membership:
         # Demoting the last owner is not allowed.
         if (
@@ -692,7 +939,31 @@ async def upsert_team_member(
         membership.role = req.role
     else:
         db.add(TeamMembership(team_id=team.id, user_id=target.id, role=req.role))
+
+    if pending is not None:
+        if invite is not None and granted_membership:
+            invite.use_count += 1
+        pending.status = TeamJoinRequestStatus.approved
+        pending.decided_by = current_user.id
+        pending.decided_at = datetime.now(UTC)
+        pending.decision_reason = "Added directly by a team owner"
+        await inbox_sources.on_team_join_decided(
+            db,
+            team,
+            request_id=pending.id,
+            requester_id=target.id,
+            approved=True,
+            actor_id=current_user.id,
+            reason=pending.decision_reason,
+        )
     await db.commit()
+    if invite is not None and granted_membership:
+        await _emit_team_invite_event(
+            EventType.TEAM_INVITE_REDEEMED,
+            invite,
+            current_user,
+            "Invite used by direct member approval",
+        )
     return TeamMemberResponse(
         id=target.id,
         email=target.email,
@@ -709,7 +980,8 @@ async def remove_team_member(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    team = await _require_owner_or_admin(db, team_id, current_user)
+    team = await _require_owner_or_admin(db, team_id, current_user, for_update=True)
+    _require_team_unlocked(team)
     if team.is_personal:
         raise HTTPException(status_code=409, detail="The personal teamspace creator cannot be removed")
     membership = await team_membership(db, team.id, user_id)
@@ -727,7 +999,8 @@ async def leave_team(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    team = await _load_team(db, team_id)
+    team = await _load_team(db, team_id, for_update=True)
+    _require_team_unlocked(team)
     if team.is_personal:
         raise HTTPException(status_code=409, detail="The personal teamspace creator cannot leave")
     membership = await team_membership(db, team.id, current_user.id)
@@ -783,7 +1056,8 @@ async def create_team_invite(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    team = await _require_owner_or_admin(db, team_id, current_user)
+    team = await _require_owner_or_admin(db, team_id, current_user, for_update=True)
+    _require_team_unlocked(team)
     if not team.is_private:
         raise HTTPException(status_code=409, detail="Public teamspaces use Share links")
     if team.is_personal:
@@ -837,8 +1111,12 @@ async def revoke_team_invite(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    await _require_owner_or_admin(db, team_id, current_user)
-    invite = await db.get(TeamInvite, invite_id)
+    await _require_owner_or_admin(db, team_id, current_user, for_update=True)
+    invite = (
+        await db.execute(
+            select(TeamInvite).where(TeamInvite.id == invite_id, TeamInvite.team_id == team_id).with_for_update()
+        )
+    ).scalar_one_or_none()
     if invite is None or invite.team_id != team_id:
         raise HTTPException(status_code=404, detail="Invite not found")
     if invite.revoked_at is None:
@@ -880,7 +1158,7 @@ async def delete_unused_team_invite(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_role(UserRole.user)),
 ):
-    await _require_owner_or_admin(db, team_id, current_user)
+    await _require_owner_or_admin(db, team_id, current_user, for_update=True)
     invite = (
         await db.execute(
             select(TeamInvite).where(TeamInvite.id == invite_id, TeamInvite.team_id == team_id).with_for_update()
@@ -890,6 +1168,11 @@ async def delete_unused_team_invite(
         raise HTTPException(status_code=404, detail="Invite not found")
     if invite.use_count:
         raise HTTPException(status_code=409, detail="Used invites are retained for audit")
+    referencing_request = (
+        await db.execute(select(TeamMembershipRequest.id).where(TeamMembershipRequest.invite_id == invite.id).limit(1))
+    ).scalar_one_or_none()
+    if referencing_request is not None:
+        raise HTTPException(status_code=409, detail="Invites with request history are retained for audit")
     await db.delete(invite)
     await db.commit()
     await _emit_team_invite_event(EventType.TEAM_INVITE_DELETED, invite, current_user, "Unused invite deleted")
@@ -971,7 +1254,8 @@ async def create_join_request(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Ask for member access to a teamspace. Owners decide; the link never does."""
-    team = await _load_team(db, team_id)
+    team = await _load_team(db, team_id, for_update=True)
+    _require_team_unlocked(team)
     if team.is_personal:
         raise HTTPException(status_code=404, detail="Team not found")
     membership = await team_membership(db, team.id, current_user.id)
@@ -1006,15 +1290,9 @@ async def create_join_request(
     except IntegrityError:
         raise HTTPException(status_code=409, detail="You already have a pending request for this teamspace") from None
 
-    if invite is not None:
-        invite.use_count += 1
     await inbox_sources.on_team_join_requested(db, team, requester_id=current_user.id, message=message)
     await db.commit()
     await _emit_join_event(EventType.TEAM_JOIN_REQUESTED, team, current_user, f"Requested to join '{team.handle}'")
-    if invite is not None:
-        await _emit_team_invite_event(
-            EventType.TEAM_INVITE_REDEEMED, invite, current_user, "Invite used to request access"
-        )
     return _join_request_response(row, current_user)
 
 
@@ -1078,16 +1356,30 @@ async def approve_join_request(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Approve a pending request: the one path a request can become membership."""
-    team = await _require_owner_or_admin(db, team_id, current_user)
+    team = await _require_owner_or_admin(db, team_id, current_user, for_update=True)
+    _require_team_unlocked(team)
+    if team.is_personal:
+        raise HTTPException(status_code=409, detail="Personal teamspaces cannot approve join requests")
     row = await _load_join_request(db, team.id, request_id, for_update=True)
     if row.status != TeamJoinRequestStatus.pending:
         raise HTTPException(status_code=409, detail=f"Request already {row.status.value}")
+
+    invite = None
+    if row.invite_id is not None:
+        invite = (
+            await db.execute(select(TeamInvite).where(TeamInvite.id == row.invite_id).with_for_update())
+        ).scalar_one_or_none()
+        if invite is None:
+            raise HTTPException(status_code=409, detail="Invitation no longer exists")
+        if invite.max_uses is not None and invite.use_count >= invite.max_uses:
+            raise HTTPException(status_code=409, detail="Invitation has no remaining uses")
 
     # Approval grants MEMBER only; role upgrades stay owner-initiated through
     # POST /{team_id}/members. A direct member add can race this decision, so
     # recover only when the membership now exists and surface any other
     # integrity failure.
     membership = await team_membership(db, team.id, row.user_id)
+    granted_membership = membership is None
     if not membership:
         try:
             async with db.begin_nested():
@@ -1096,7 +1388,10 @@ async def approve_join_request(
         except IntegrityError:
             if not await team_membership(db, team.id, row.user_id):
                 raise
+            granted_membership = False
 
+    if invite is not None and granted_membership:
+        invite.use_count += 1
     row.status = TeamJoinRequestStatus.approved
     row.decided_by = current_user.id
     row.decided_at = datetime.now(UTC)
@@ -1112,6 +1407,10 @@ async def approve_join_request(
     await _emit_join_event(
         EventType.TEAM_JOIN_DECIDED, team, current_user, f"Approved join request for '{team.handle}'"
     )
+    if invite is not None and granted_membership:
+        await _emit_team_invite_event(
+            EventType.TEAM_INVITE_REDEEMED, invite, current_user, "Invite used to approve membership"
+        )
     requester = await db.get(User, row.user_id)
     return _join_request_response(row, requester, current_user.username)
 
@@ -1125,7 +1424,8 @@ async def reject_join_request(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Reject a pending request. The requester may ask again later."""
-    team = await _require_owner_or_admin(db, team_id, current_user)
+    team = await _require_owner_or_admin(db, team_id, current_user, for_update=True)
+    _require_team_unlocked(team)
     row = await _load_join_request(db, team.id, request_id, for_update=True)
     if row.status != TeamJoinRequestStatus.pending:
         raise HTTPException(status_code=409, detail=f"Request already {row.status.value}")
@@ -1160,9 +1460,23 @@ async def cancel_join_request(
     current_user: User = Depends(require_role(UserRole.user)),
 ):
     """Withdraw your own pending request. Owners reject; requesters cancel."""
-    team = await _load_team(db, team_id)
-    row = await _load_join_request(db, team.id, request_id, for_update=True)
-    if row.user_id != current_user.id:
+    team = await _load_team(db, team_id, for_update=True)
+    row = (
+        await db.execute(
+            select(TeamMembershipRequest)
+            .where(
+                TeamMembershipRequest.id == request_id,
+                TeamMembershipRequest.team_id == team.id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    membership = await team_membership(db, team.id, current_user.id)
+    if row is None or row.user_id != current_user.id:
+        if not team_visible_to(team, membership, current_user):
+            raise HTTPException(status_code=404, detail="Team not found")
+        if row is None:
+            raise HTTPException(status_code=404, detail="Join request not found")
         raise HTTPException(status_code=403, detail="Only the requester can withdraw a request")
     if row.status != TeamJoinRequestStatus.pending:
         raise HTTPException(status_code=409, detail=f"Request already {row.status.value}")

--- a/observal-server/models/inbox.py
+++ b/observal-server/models/inbox.py
@@ -34,8 +34,7 @@ class InboxKind(str, enum.Enum):
 
     Kinds whose source does not exist in the codebase yet are declared here
     anyway so the enum and its migration stay stable when those initiatives
-    land. ``team_join_requested``, ``team_join_decided`` and
-    ``team_created_pending`` wait on the teamspace request flow;
+    land. ``ownership_transfer`` waits on its offer flow, and
     ``change_requested`` waits on review conversations.
     """
 

--- a/observal-server/models/team.py
+++ b/observal-server/models/team.py
@@ -25,6 +25,18 @@ class Team(Base):
     __table_args__ = (
         UniqueConstraint("handle", name="uq_teams_handle"),
         CheckConstraint("NOT is_personal OR is_private", name="ck_teams_personal_private"),
+        CheckConstraint(
+            "visibility_request_status IS NULL OR visibility_request_status IN ('pending', 'approved', 'rejected')",
+            name="ck_teams_visibility_request_status",
+        ),
+        CheckConstraint(
+            "visibility_request_status != 'pending' OR is_private",
+            name="ck_teams_pending_visibility_private",
+        ),
+        CheckConstraint(
+            "visibility_request_status != 'pending' OR visibility_requested_at IS NOT NULL",
+            name="ck_teams_pending_visibility_requested_at",
+        ),
         Index("ix_teams_created_by", "created_by"),
         Index(
             "uq_teams_personal_created_by",
@@ -39,10 +51,25 @@ class Team(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     handle: Mapped[str] = mapped_column(String(32), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    # A private teamspace is visible only to members and deployment admins.
+    # A private teamspace is visible to members and deployment admins.
+    # Global reviewers may also inspect it while public review is pending.
     # Same column shape as listings so `visibility` reads identically everywhere.
     is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=text("false"))
     is_personal: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default=text("false"))
+    visibility_request_status: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    visibility_requested_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", name="fk_teams_visibility_requested_by_users", ondelete="SET NULL"),
+        nullable=True,
+    )
+    visibility_requested_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    visibility_reviewed_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", name="fk_teams_visibility_reviewed_by_users", ondelete="SET NULL"),
+        nullable=True,
+    )
+    visibility_reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    visibility_rejection_reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(

--- a/observal-server/schemas/team.py
+++ b/observal-server/schemas/team.py
@@ -26,6 +26,10 @@ class TeamVisibilityUpdateRequest(BaseModel):
     visibility: Literal["public", "private"]
 
 
+class TeamVisibilityDecisionRequest(BaseModel):
+    reason: str | None = Field(default=None, max_length=500)
+
+
 class TeamResponse(BaseModel):
     id: uuid.UUID
     name: str
@@ -33,10 +37,22 @@ class TeamResponse(BaseModel):
     description: str | None = None
     visibility: str = "public"
     is_personal: bool = False
+    visibility_request_status: Literal["pending", "approved", "rejected"] | None = None
+    visibility_rejection_reason: str | None = None
     role: str | None = None
     member_count: int | None = None
     created_at: datetime | None = None
     model_config = ConfigDict(from_attributes=True)
+
+
+class TeamVisibilityRequestResponse(BaseModel):
+    team_id: uuid.UUID
+    name: str
+    handle: str
+    description: str | None = None
+    requested_by: uuid.UUID | None
+    requested_by_username: str | None = None
+    requested_at: datetime
 
 
 class TeamMemberResponse(BaseModel):
@@ -111,6 +127,7 @@ class TeamInviteCallerRequestResponse(BaseModel):
 class TeamInvitePreviewResponse(BaseModel):
     valid: bool
     invite_state: str | None = None
+    is_member: bool = False
     team_id: uuid.UUID | None = None
     team_name: str | None = None
     team_handle: str | None = None

--- a/observal-server/services/inbox/recipients.py
+++ b/observal-server/services/inbox/recipients.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 
-from models.team import TeamMembership, TeamRole
+from models.team import Team, TeamMembership, TeamRole
 from models.user import User, UserRole
 from services.teamspace import REVIEWING_TEAM_ROLES
 
@@ -34,36 +34,44 @@ async def _user_ids(db: AsyncSession, stmt) -> list[uuid.UUID]:
 
 
 async def reviewers_for(db: AsyncSession, entity) -> list[uuid.UUID]:
-    """Everyone who may review this entity.
+    """Return the reviewers who should be notified for one pending item.
 
-    This is the set inverse of ``teamspace.can_review``: that function answers
-    "may this caller review this item", and delivery needs "who are those
-    callers". The two must agree exactly, which is why the arms below are
-    written to mirror it line for line rather than approximating it —
-    ``test_reviewers_for_matches_can_review_exactly`` in ``tests/test_inbox.py``
-    asserts the agreement over a user matrix and fails the build if either side
-    drifts.
-
-    can_review: admins review everything; a private item belongs to its
-    teamspace's owners and reviewers; a private item with no teamspace is a
-    personal listing and stays admin-only; a public item is the global catalog.
+    Team-private work notifies only that team's owners and reviewers. Public
+    work notifies global reviewers plus owners and reviewers from its own public
+    teamspace. Review roles from unrelated teamspaces are never included.
+    A private item without a teamspace has no local reviewers, so deployment
+    admins remain its fallback recipients.
     """
-    admins = await _user_ids(db, select(User.id).where(User.role.in_(_ADMIN_ROLES)))
-
+    team_id = getattr(entity, "team_id", None)
     if getattr(entity, "is_private", False):
-        team_id = getattr(entity, "team_id", None)
         if team_id is None:
-            # Personal private listing: nobody holds a team role over it.
-            return admins
-        team_reviewers = await _user_ids(
+            return await _user_ids(db, select(User.id).where(User.role.in_(_ADMIN_ROLES)))
+        return await _user_ids(
             db,
             select(TeamMembership.user_id).where(
                 TeamMembership.team_id == team_id,
                 TeamMembership.role.in_(REVIEWING_TEAM_ROLES),
             ),
         )
-        return _dedupe(admins + team_reviewers)
 
+    global_users = await global_reviewers(db)
+    if team_id is None:
+        return global_users
+    team_reviewers = await _user_ids(
+        db,
+        select(TeamMembership.user_id)
+        .join(Team, Team.id == TeamMembership.team_id)
+        .where(
+            TeamMembership.team_id == team_id,
+            TeamMembership.role.in_(REVIEWING_TEAM_ROLES),
+            Team.is_private.is_(False),
+        ),
+    )
+    return _dedupe(global_users + team_reviewers)
+
+
+async def global_reviewers(db: AsyncSession) -> list[uuid.UUID]:
+    """Global reviewer, admin, and super-admin recipients."""
     return await _user_ids(db, select(User.id).where(User.role.in_(_GLOBAL_REVIEWER_ROLES)))
 
 

--- a/observal-server/services/inbox/registry.py
+++ b/observal-server/services/inbox/registry.py
@@ -241,11 +241,12 @@ SPECS: dict[InboxKind, KindSpec] = {
     ),
     InboxKind.team_created_pending: KindSpec(
         kind=InboxKind.team_created_pending,
-        # RESERVED - waits on teamspace creation requiring approval.
-        reserved=True,
         action_required=True,
         title=lambda s, c: f"Teamspace awaiting approval: {_label(s)}",
         dedupe=lambda s, c: f"team_created_pending:{s.id}",
+        url=lambda s: "/review?tab=teamspaces",
+        # The team is deliberately private while global review is pending.
+        recheck_visibility=False,
     ),
     InboxKind.ownership_transfer: KindSpec(
         kind=InboxKind.ownership_transfer,

--- a/observal-server/services/inbox/sources.py
+++ b/observal-server/services/inbox/sources.py
@@ -205,6 +205,79 @@ def _team_subject(team) -> Subject:
     )
 
 
+async def on_team_visibility_requested(
+    db: AsyncSession,
+    team,
+    *,
+    requester_id: uuid.UUID,
+) -> int:
+    """Tell global reviewers that a teamspace is waiting for public approval."""
+    subject = _team_subject(team)
+    users = await recipients.global_reviewers(db)
+    items = await deliver(
+        db,
+        kind=InboxKind.team_created_pending,
+        recipients=users,
+        subject=subject,
+        actor_id=requester_id,
+        skip_actor=False,
+    )
+    optic.debug("inbox: team visibility requested for {} -> {} item(s)", team.id, len(items))
+    return len(items)
+
+
+async def on_team_visibility_cancelled(
+    db: AsyncSession,
+    team,
+    *,
+    actor_id: uuid.UUID | None,
+) -> int:
+    """Close reviewer work when an owner withdraws a visibility request."""
+    subject = _team_subject(team)
+    request_key = spec_for(InboxKind.team_created_pending).dedupe(subject, {})[:255]
+    return await resolve_matching(
+        db,
+        kind=InboxKind.team_created_pending,
+        dedupe_key=request_key,
+        detail="Public visibility request withdrawn",
+        actor_id=actor_id,
+    )
+
+
+async def on_team_visibility_decided(
+    db: AsyncSession,
+    team,
+    *,
+    requester_id: uuid.UUID | None,
+    approved: bool,
+    actor_id: uuid.UUID | None,
+    reason: str | None = None,
+) -> int:
+    """Notify the requester and current owners, then close reviewer work."""
+    subject = _team_subject(team)
+    owners = await recipients.team_owners(db, team.id)
+    users = owners + ([requester_id] if requester_id is not None else [])
+    items = await deliver(
+        db,
+        kind=InboxKind.review_approved if approved else InboxKind.review_rejected,
+        recipients=users,
+        subject=subject,
+        actor_id=actor_id,
+        body=reason,
+        context={"reason": reason} if reason else None,
+        skip_actor=False,
+    )
+    request_key = spec_for(InboxKind.team_created_pending).dedupe(subject, {})[:255]
+    await resolve_matching(
+        db,
+        kind=InboxKind.team_created_pending,
+        dedupe_key=request_key,
+        detail=f"Public visibility {'approved' if approved else 'rejected'}",
+        actor_id=actor_id,
+    )
+    return len(items)
+
+
 async def on_team_join_requested(
     db: AsyncSession,
     team,

--- a/observal-server/services/teamspace.py
+++ b/observal-server/services/teamspace.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from models.team import Team, TeamMembership, TeamRole
 from models.user import User, UserRole
@@ -68,16 +68,17 @@ REVIEWING_TEAM_ROLES = (TeamRole.owner, TeamRole.reviewer)
 class ReviewScope:
     """What one caller is allowed to review.
 
-    ``is_admin`` reviews everything, team-private items included, because an admin
-    already administers the whole deployment. ``is_global_reviewer`` without
-    ``is_admin`` is the plain global reviewer role: public items only. ``team_ids``
-    are the teamspaces where the caller is an owner or a reviewer, and they carry
-    the right to review that teamspace's own private items and nothing else.
+    ``is_admin`` reviews everything. ``is_global_reviewer`` without ``is_admin``
+    is the plain global reviewer role. ``team_ids`` contains unlocked teamspaces
+    where the caller owns or reviews private content. ``public_team_ids`` is the
+    subset already approved for public visibility, whose public content those
+    same team roles may also review.
     """
 
     is_admin: bool
     is_global_reviewer: bool
     team_ids: frozenset[uuid.UUID]
+    public_team_ids: frozenset[uuid.UUID] = frozenset()
 
     @property
     def is_empty(self) -> bool:
@@ -96,16 +97,22 @@ async def review_scope(db: AsyncSession, user: User) -> ReviewScope:
         # memberships would not widen anything and the query is skipped.
         return ReviewScope(is_admin=True, is_global_reviewer=True, team_ids=frozenset())
 
-    rows = await db.execute(
-        select(TeamMembership.team_id).where(
-            TeamMembership.user_id == user.id,
-            TeamMembership.role.in_(REVIEWING_TEAM_ROLES),
+    rows = (
+        await db.execute(
+            select(TeamMembership.team_id, Team.is_private)
+            .join(Team, Team.id == TeamMembership.team_id)
+            .where(
+                TeamMembership.user_id == user.id,
+                TeamMembership.role.in_(REVIEWING_TEAM_ROLES),
+                or_(Team.visibility_request_status.is_(None), Team.visibility_request_status != "pending"),
+            )
         )
-    )
+    ).all()
     return ReviewScope(
         is_admin=False,
         is_global_reviewer=is_global_reviewer(user),
-        team_ids=frozenset(row[0] for row in rows),
+        team_ids=frozenset(team_id for team_id, _is_private in rows),
+        public_team_ids=frozenset(team_id for team_id, private in rows if not private),
     )
 
 
@@ -114,22 +121,20 @@ def can_review(entity, scope: ReviewScope) -> bool:
 
     Decided from the item's own visibility, never from what the caller asked for.
     A team-private item belongs to its teamspace: only that teamspace's owners and
-    reviewers, plus admins, may act on it, which is what keeps private titles away
-    from a global reviewer who is not in the team. A public item is the global
-    catalog: only a global reviewer and above may act on it, so a team owner cannot
-    walk a listing out of their own namespace into everyone's registry. Reviewing
-    their OWN submission is allowed — team publishes never auto-approve, so
-    self-approval is the recorded decision that replaces the old silent skip.
+    reviewers, plus admins, may act on it. Public items may also be handled by
+    owners and reviewers when their teamspace has passed public visibility review.
+    Reviewing their own submission is allowed: team publishes never auto-approve,
+    so self-approval is the recorded decision replacing the old silent skip.
 
     A private item with no teamspace is a personal listing. Nobody holds a team
     role over it, so it stays admin-only.
     """
     if scope.is_admin:
         return True
+    team_id = getattr(entity, "team_id", None)
     if getattr(entity, "is_private", False):
-        team_id = getattr(entity, "team_id", None)
         return team_id is not None and team_id in scope.team_ids
-    return scope.is_global_reviewer
+    return scope.is_global_reviewer or (team_id is not None and team_id in scope.public_team_ids)
 
 
 async def user_team_ids(db: AsyncSession, user_id: uuid.UUID) -> list[uuid.UUID]:
@@ -141,13 +146,15 @@ def team_visible_to(team: Team, membership: TeamMembership | None, user: User) -
     """Whether this caller may see this teamspace at all.
 
     Public teamspaces are visible to every signed-in user. A private one is
-    visible only to its members and deployment admins. Global reviewers keep
-    their public review scope but receive no private-team metadata. Callers
-    that fail this get 404, never 403, so a private handle's existence is not
-    confirmed.
+    visible only to its members and deployment admins. Global reviewers may
+    also inspect a pending public-visibility request. Other private teamspaces
+    remain hidden, and callers that fail this check receive 404 so a private
+    handle's existence is not confirmed.
     """
     if not team.is_private:
         return True
+    if getattr(team, "visibility_request_status", None) == "pending":
+        return membership is not None or is_global_reviewer(user)
     return membership is not None or is_admin(user)
 
 
@@ -189,6 +196,8 @@ async def resolve_publish_target(
     team = await db.get(Team, team_id, with_for_update=True)
     if not team:
         raise HTTPException(status_code=404, detail="Teamspace not found")
+    if getattr(team, "visibility_request_status", None) == "pending":
+        raise HTTPException(status_code=409, detail="Teamspace is locked pending public visibility review")
     if team.is_private and target_visibility == "public":
         raise HTTPException(status_code=409, detail="Private teamspaces can only publish team-private items")
     membership = await team_membership(db, team.id, user.id)

--- a/observal-server/tests/test_teamspace.py
+++ b/observal-server/tests/test_teamspace.py
@@ -63,6 +63,7 @@ class _FakeDB:
         self.deleted = []
         self.added = []
         self.flush = AsyncMock(side_effect=self._do_flush)
+        self.scalar = AsyncMock(return_value=0)
 
     async def _do_flush(self):
         for obj in self.added:
@@ -123,7 +124,7 @@ async def test_resolve_publish_target_defaults_to_public_user_namespace():
 @pytest.mark.asyncio
 async def test_resolve_publish_target_allows_team_member_and_private_visibility():
     team_id = uuid.uuid4()
-    team = SimpleNamespace(id=team_id, handle="platform-tools")
+    team = SimpleNamespace(id=team_id, handle="platform-tools", is_private=False, is_personal=False)
     member = SimpleNamespace(role=TeamRole.member)
     db = _FakeDB([member])
     db.get = AsyncMock(return_value=team)
@@ -135,33 +136,34 @@ async def test_resolve_publish_target_allows_team_member_and_private_visibility(
 
 
 @pytest.mark.asyncio
-async def test_resolve_publish_target_rejects_non_member():
+@pytest.mark.parametrize("role", [UserRole.user, UserRole.reviewer])
+async def test_resolve_publish_target_rejects_non_member(role):
     team_id = uuid.uuid4()
     db = _FakeDB([None])
-    db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+    db.get = AsyncMock(
+        return_value=SimpleNamespace(id=team_id, handle="platform-tools", is_private=False, is_personal=False)
+    )
     with pytest.raises(HTTPException) as exc:
-        await resolve_publish_target(db, _user(), "Internal Tool", team_id=team_id)
+        await resolve_publish_target(db, _user(role), "Internal Tool", team_id=team_id)
     assert exc.value.status_code == 403
 
 
 # ── auto-approval matrix ────────────────────────────────────────────
-# Team roles are self-service, so they clear review for team-visibility listings
-# only. Publishing PUBLIC out of a team namespace always waits for global review.
+# Team publishing always enters review. Review-capable users may then record an
+# explicit decision, including on their own submission.
 
 # (label, user role, team role or None, visibility, expected auto_approve)
 _AUTO_APPROVE_MATRIX = [
     ("team-owner-public", UserRole.user, TeamRole.owner, "public", False),
-    ("team-owner-team", UserRole.user, TeamRole.owner, "team", True),
+    ("team-owner-team", UserRole.user, TeamRole.owner, "team", False),
     ("team-reviewer-public", UserRole.user, TeamRole.reviewer, "public", False),
-    ("team-reviewer-team", UserRole.user, TeamRole.reviewer, "team", True),
+    ("team-reviewer-team", UserRole.user, TeamRole.reviewer, "team", False),
     ("team-member-public", UserRole.user, TeamRole.member, "public", False),
     ("team-member-team", UserRole.user, TeamRole.member, "team", False),
-    ("global-reviewer-public", UserRole.reviewer, None, "public", True),
-    ("global-reviewer-team", UserRole.reviewer, None, "team", True),
-    ("admin-public", UserRole.admin, None, "public", True),
-    ("admin-team", UserRole.admin, None, "team", True),
-    ("super-admin-public", UserRole.super_admin, None, "public", True),
-    ("super-admin-team", UserRole.super_admin, None, "team", True),
+    ("admin-public", UserRole.admin, None, "public", False),
+    ("admin-team", UserRole.admin, None, "team", False),
+    ("super-admin-public", UserRole.super_admin, None, "public", False),
+    ("super-admin-team", UserRole.super_admin, None, "team", False),
 ]
 
 
@@ -174,7 +176,9 @@ async def test_resolve_publish_target_auto_approve_matrix(user_role, team_role, 
     team_id = uuid.uuid4()
     membership = SimpleNamespace(role=team_role) if team_role is not None else None
     db = _FakeDB([membership])
-    db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools"))
+    db.get = AsyncMock(
+        return_value=SimpleNamespace(id=team_id, handle="platform-tools", is_private=False, is_personal=False)
+    )
 
     target = await resolve_publish_target(db, _user(user_role), "Internal Tool", team_id=team_id, visibility=visibility)
 
@@ -301,6 +305,8 @@ async def test_create_team_slugifies_and_reserves(monkeypatch):
     db = _FakeDB([])
     db.refresh = AsyncMock()
     monkeypatch.setattr(mod, "reserve_handle", _reserve)
+    monkeypatch.setattr(mod, "_emit_visibility_event", AsyncMock())
+    monkeypatch.setattr(mod.inbox_sources, "on_team_visibility_requested", AsyncMock())
 
     req = mod.TeamCreateRequest(name="Platform Tools", handle="Platform Tools!", description="desc")
     resp = await mod.create_team(req, db, creator)
@@ -308,6 +314,8 @@ async def test_create_team_slugifies_and_reserves(monkeypatch):
     assert resp.handle == "platform-tools"
     assert resp.role == TeamRole.owner.value
     assert resp.member_count == 1
+    assert resp.visibility == "private"
+    assert resp.visibility_request_status == "pending"
     assert db.committed is True
 
 
@@ -330,18 +338,20 @@ async def test_create_team_handle_collision_returns_409(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_non_reviewer_cannot_create_team():
-    """create_team requires reviewer role. Call require_role directly with
-    a low-privilege user and assert 403 rejection."""
-    from unittest.mock import AsyncMock, patch
+async def test_any_signed_in_user_can_create_team(monkeypatch):
+    mod = _import_routes()
+    user = _user(UserRole.user)
+    db = _FakeDB([])
+    monkeypatch.setattr(mod, "reserve_handle", AsyncMock(return_value="user-team"))
 
-    from api.deps import require_role
+    response = await mod.create_team(
+        mod.TeamCreateRequest(name="User Team", visibility="private"),
+        db,
+        user,
+    )
 
-    user = SimpleNamespace(id=uuid.uuid4(), role=UserRole.user, username="user", email="user@test.com")
-    dep = require_role(UserRole.reviewer)
-    with patch("api.deps.emit_security_event", new=AsyncMock()), pytest.raises(HTTPException) as exc:
-        await dep(current_user=user)
-    assert exc.value.status_code == 403
+    assert response.role == TeamRole.owner.value
+    assert response.visibility == "private"
 
 
 # ── routes: owner/admin authz for membership ────────────────────────
@@ -350,7 +360,16 @@ async def test_non_reviewer_cannot_create_team():
 @pytest.mark.asyncio
 async def test_upsert_member_requires_owner_or_admin(monkeypatch):
     mod = _import_routes()
-    team = SimpleNamespace(id=uuid.uuid4(), handle="t", name="T", description=None, created_at=None)
+    team = SimpleNamespace(
+        id=uuid.uuid4(),
+        handle="t",
+        name="T",
+        description=None,
+        created_at=None,
+        is_private=False,
+        is_personal=False,
+        visibility_request_status=None,
+    )
     owner = _user(UserRole.user, username="owner")
     outsider = _user(UserRole.user, username="outsider")
 
@@ -365,7 +384,7 @@ async def test_upsert_member_requires_owner_or_admin(monkeypatch):
     async def _membership_none(db, tid, uid):
         return None
 
-    db = _FakeDB([])
+    db = _FakeDB([team, None, team])
     db.get = AsyncMock(side_effect=_get)
     db.flush = AsyncMock()
     db.commit = AsyncMock()
@@ -388,7 +407,16 @@ async def test_upsert_member_requires_owner_or_admin(monkeypatch):
 @pytest.mark.asyncio
 async def test_upsert_member_updates_existing_role(monkeypatch):
     mod = _import_routes()
-    team = SimpleNamespace(id=uuid.uuid4(), handle="t", name="T", description=None, created_at=None)
+    team = SimpleNamespace(
+        id=uuid.uuid4(),
+        handle="t",
+        name="T",
+        description=None,
+        created_at=None,
+        is_private=False,
+        is_personal=False,
+        visibility_request_status=None,
+    )
     owner = _user(UserRole.user, username="owner")
     target = _user(UserRole.user, username="member")
     owner_membership = SimpleNamespace(role=TeamRole.owner, team_id=team.id, user_id=owner.id)
@@ -400,7 +428,7 @@ async def test_upsert_member_updates_existing_role(monkeypatch):
     async def _membership(db, tid, uid):
         return owner_membership if uid == owner.id else target_membership
 
-    db = _FakeDB([])
+    db = _FakeDB([team, None])
     db.get = AsyncMock(side_effect=_get)
     monkeypatch.setattr(mod, "team_membership", _membership)
     monkeypatch.setattr(mod, "_resolve_member", AsyncMock(return_value=target))
@@ -415,7 +443,16 @@ async def test_upsert_member_updates_existing_role(monkeypatch):
 @pytest.mark.asyncio
 async def test_remove_last_owner_blocked(monkeypatch):
     mod = _import_routes()
-    team = SimpleNamespace(id=uuid.uuid4(), handle="t", name="T", description=None, created_at=None)
+    team = SimpleNamespace(
+        id=uuid.uuid4(),
+        handle="t",
+        name="T",
+        description=None,
+        created_at=None,
+        is_private=False,
+        is_personal=False,
+        visibility_request_status=None,
+    )
     owner = _user(UserRole.user, username="owner")
     membership = SimpleNamespace(role=TeamRole.owner, team_id=team.id, user_id=owner.id)
 
@@ -428,7 +465,7 @@ async def test_remove_last_owner_blocked(monkeypatch):
     async def _count(db, tid, **kwargs):
         return 1
 
-    db = _FakeDB([])
+    db = _FakeDB([team])
     db.get = AsyncMock(side_effect=_get)
     monkeypatch.setattr(mod, "team_membership", _membership)
     monkeypatch.setattr(mod, "count_owners", _count)
@@ -441,7 +478,16 @@ async def test_remove_last_owner_blocked(monkeypatch):
 @pytest.mark.asyncio
 async def test_leave_last_owner_blocked(monkeypatch):
     mod = _import_routes()
-    team = SimpleNamespace(id=uuid.uuid4(), handle="t", name="T", description=None, created_at=None)
+    team = SimpleNamespace(
+        id=uuid.uuid4(),
+        handle="t",
+        name="T",
+        description=None,
+        created_at=None,
+        is_private=False,
+        is_personal=False,
+        visibility_request_status=None,
+    )
     owner = _user(UserRole.user, username="owner")
     membership = SimpleNamespace(role=TeamRole.owner, team_id=team.id, user_id=owner.id)
 
@@ -454,7 +500,7 @@ async def test_leave_last_owner_blocked(monkeypatch):
     async def _count(db, tid, **kwargs):
         return 1
 
-    db = _FakeDB([])
+    db = _FakeDB([team])
     db.get = AsyncMock(side_effect=_get)
     monkeypatch.setattr(mod, "team_membership", _membership)
     monkeypatch.setattr(mod, "count_owners", _count)
@@ -467,7 +513,16 @@ async def test_leave_last_owner_blocked(monkeypatch):
 @pytest.mark.asyncio
 async def test_delete_team_owner_or_admin_only(monkeypatch):
     mod = _import_routes()
-    team = SimpleNamespace(id=uuid.uuid4(), handle="t", name="T", description=None, created_at=None)
+    team = SimpleNamespace(
+        id=uuid.uuid4(),
+        handle="t",
+        name="T",
+        description=None,
+        created_at=None,
+        is_private=False,
+        is_personal=False,
+        visibility_request_status=None,
+    )
     owner = _user(UserRole.user, username="owner")
     member = _user(UserRole.user, username="member")
 
@@ -480,7 +535,7 @@ async def test_delete_team_owner_or_admin_only(monkeypatch):
     async def _membership_member(db, tid, uid):
         return SimpleNamespace(role=TeamRole.member)
 
-    db = _FakeDB([])
+    db = _FakeDB([team, team])
     db.get = AsyncMock(side_effect=_get)
     db.delete = AsyncMock()
     db.commit = AsyncMock()
@@ -498,7 +553,16 @@ async def test_delete_team_owner_or_admin_only(monkeypatch):
 @pytest.mark.asyncio
 async def test_list_members_only_for_members(monkeypatch):
     mod = _import_routes()
-    team = SimpleNamespace(id=uuid.uuid4(), handle="t", name="T", description=None, created_at=None)
+    team = SimpleNamespace(
+        id=uuid.uuid4(),
+        handle="t",
+        name="T",
+        description=None,
+        created_at=None,
+        is_private=False,
+        is_personal=False,
+        visibility_request_status=None,
+    )
     member = _user(UserRole.user, username="mem")
     outsider = _user(UserRole.user, username="out")
 

--- a/tests/e2e/shareable-links.spec.ts
+++ b/tests/e2e/shareable-links.spec.ts
@@ -12,29 +12,36 @@ type Principal = { id: string; email: string; role: string; token: string };
 type Team = { id: string; handle: string };
 
 let adminToken: string;
+let superAdminToken: string;
 let owner: Principal;
 let outsider: Principal;
 let teamReviewer: Principal;
 let globalReviewer: Principal;
 let privateTeam: Team;
 let publicTeam: Team;
+let visibilityReviewTeam: Team;
+let personalTeam: Team;
 let inviteToken: string;
 
-async function adminLogin(): Promise<string> {
+async function demoLogin(role: "admin" | "super_admin"): Promise<string> {
+  const superAdmin = role === "super_admin";
+  const email = superAdmin
+    ? (process.env.DEMO_SUPER_ADMIN_EMAIL ?? "super@demo.example")
+    : (process.env.DEMO_ADMIN_EMAIL ?? "admin@demo.example");
+  const password = superAdmin
+    ? (process.env.DEMO_SUPER_ADMIN_PASSWORD ?? "super-changeme")
+    : (process.env.DEMO_ADMIN_PASSWORD ?? "admin-changeme");
   const response = await fetch(`${API_BASE}/api/v1/auth/login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer e2e-shareable-admin-${suffix}-${crypto.randomUUID()}`,
+      Authorization: `Bearer e2e-shareable-${role}-${suffix}-${crypto.randomUUID()}`,
     },
-    body: JSON.stringify({
-      email: process.env.DEMO_ADMIN_EMAIL ?? "admin@demo.example",
-      password: process.env.DEMO_ADMIN_PASSWORD ?? "admin-changeme",
-    }),
+    body: JSON.stringify({ email, password }),
   });
   const body = await response.json();
   if (!response.ok || !body.access_token) {
-    throw new Error(`Admin login failed: ${response.status} ${JSON.stringify(body)}`);
+    throw new Error(`${role} login failed: status=${response.status} has_token=${Boolean(body?.access_token)}`);
   }
   return body.access_token;
 }
@@ -53,6 +60,14 @@ async function api(path: string, token: string, method = "GET", body?: unknown) 
   }
   if (response.status === 204) return null;
   return response.json();
+}
+
+async function cleanup(errors: Error[], label: string, action: () => Promise<unknown>) {
+  try {
+    await action();
+  } catch (error) {
+    errors.push(new Error(`${label}: ${error instanceof Error ? error.message : String(error)}`));
+  }
 }
 
 async function createUser(label: string, role = "user"): Promise<Principal> {
@@ -94,7 +109,8 @@ test.describe("shareable teamspace links", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeAll(async () => {
-    adminToken = await adminLogin();
+    adminToken = await demoLogin("admin");
+    superAdminToken = await demoLogin("super_admin");
     owner = await createUser("owner");
     outsider = await createUser("outsider");
     teamReviewer = await createUser("team-reviewer");
@@ -110,6 +126,13 @@ test.describe("shareable teamspace links", () => {
       handle: `e2e-public-${suffix}`.slice(0, 32),
       visibility: "public",
     });
+    await api(`/api/v1/teams/${publicTeam.id}/visibility-request/approve`, globalReviewer.token, "POST");
+    visibilityReviewTeam = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Visibility Review Team",
+      handle: `e2e-review-${suffix}`.slice(0, 32),
+      visibility: "public",
+    });
+    personalTeam = await api("/api/v1/teams/claim-personal", outsider.token, "POST");
     await api(`/api/v1/teams/${privateTeam.id}/members`, owner.token, "POST", {
       user_id: teamReviewer.id,
       role: "reviewer",
@@ -123,12 +146,167 @@ test.describe("shareable teamspace links", () => {
   });
 
   test.afterAll(async () => {
-    if (privateTeam?.id) await api(`/api/v1/teams/${privateTeam.id}`, owner.token, "DELETE");
-    if (publicTeam?.id) await api(`/api/v1/teams/${publicTeam.id}`, owner.token, "DELETE");
-    adminToken = await adminLogin();
-    for (const principal of [owner, outsider, teamReviewer, globalReviewer]) {
-      if (principal?.id) await api(`/api/v1/admin/users/${principal.id}`, adminToken, "DELETE");
+    const errors: Error[] = [];
+    for (const [team, token] of [
+      [privateTeam, owner?.token],
+      [publicTeam, owner?.token],
+      [visibilityReviewTeam, owner?.token],
+      [personalTeam, outsider?.token],
+    ] as const) {
+      if (team?.id && token) {
+        await cleanup(errors, `delete team ${team.id}`, () => api(`/api/v1/teams/${team.id}`, token, "DELETE"));
+      }
     }
+    if (adminToken) {
+      for (const principal of [owner, outsider, teamReviewer, globalReviewer]) {
+        if (principal?.id) {
+          await cleanup(errors, `delete user ${principal.id}`, () =>
+            api(`/api/v1/admin/users/${principal.id}`, adminToken, "DELETE"),
+          );
+        }
+      }
+    }
+    if (errors.length) throw new AggregateError(errors, "Shareable-links cleanup failed");
+  });
+
+  test("claiming a personal teamspace keeps public teamspaces visible", async ({ page }) => {
+    await loginAs(page, outsider);
+    await page.goto("/teamspaces");
+
+    await expect(page.getByText(personalTeam.handle, { exact: true })).toBeVisible();
+    await expect(page.getByText(publicTeam.handle, { exact: true })).toBeVisible();
+    await expect(page.getByText(privateTeam.handle, { exact: true })).toHaveCount(0);
+  });
+
+  test("public visibility is reviewed before the teamspace unlocks", async ({ page }) => {
+    await loginAs(page, outsider);
+    await page.goto("/teamspaces");
+    await expect(page.getByText(visibilityReviewTeam.handle, { exact: true })).toHaveCount(0);
+
+    await loginAs(page, owner);
+    await page.goto(`/teamspaces/${visibilityReviewTeam.handle}`);
+    await expect(page.getByText(/public visibility review pending/i)).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Agents", exact: true })).toHaveCount(0);
+
+    await loginAs(page, globalReviewer);
+    await page.goto("/review?tab=teamspaces");
+    const reviewCard = page.getByTestId(`teamspace-review-${visibilityReviewTeam.id}`);
+    await expect(reviewCard).toContainText(visibilityReviewTeam.handle);
+    await reviewCard.getByRole("button", { name: "Reject", exact: true }).click();
+    await page.getByLabel("Reason (optional)").fill("Add a clearer team description");
+    await page.getByRole("button", { name: "Reject request", exact: true }).click();
+    await expect(reviewCard).toHaveCount(0);
+
+    await loginAs(page, owner);
+    await page.goto(`/teamspaces/${visibilityReviewTeam.handle}`);
+    await expect(page.getByText(/public visibility request rejected/i)).toBeVisible();
+    await expect(page.getByText("Add a clearer team description", { exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Request public", exact: true }).click();
+    await expect(page.getByText(/public visibility review pending/i)).toBeVisible();
+
+    await loginAs(page, globalReviewer);
+    await page.goto("/review?tab=teamspaces");
+    const approveCard = page.getByTestId(`teamspace-review-${visibilityReviewTeam.id}`);
+    await approveCard.getByRole("button", { name: "Approve", exact: true }).click();
+    await expect(approveCard).toHaveCount(0);
+
+    await loginAs(page, owner);
+    await page.goto(`/teamspaces/${visibilityReviewTeam.handle}`);
+    await expect(page.getByText("Public approved", { exact: true })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Agents", exact: true })).toBeVisible();
+
+    await loginAs(page, outsider);
+    await page.goto("/teamspaces");
+    await expect(page.getByText(visibilityReviewTeam.handle, { exact: true })).toBeVisible();
+  });
+
+  test("inbox rail is rendered to the right of the feed", async ({ page }) => {
+    await loginAs(page, owner);
+    await page.goto("/inbox");
+
+    const feed = page.getByTestId("inbox-feed");
+    const rail = page.getByTestId("inbox-rail");
+    await expect(feed).toBeVisible();
+    await expect(rail).toBeVisible();
+    await expect(rail.getByText("Inbox", { exact: true })).toBeVisible();
+    await expect(rail.getByText("Done", { exact: true })).toBeVisible();
+    await expect(rail.getByText("Dismissed", { exact: true })).toBeVisible();
+    await expect(rail.getByText("Manage notifications", { exact: true })).toBeVisible();
+
+    const feedBox = await feed.boundingBox();
+    const railBox = await rail.boundingBox();
+    expect(feedBox).not.toBeNull();
+    expect(railBox).not.toBeNull();
+    expect(railBox!.x).toBeGreaterThan(feedBox!.x);
+  });
+
+  test("personal teamspaces can be deleted but never joined or left", async ({ page }) => {
+    await loginAs(page, outsider);
+    await page.goto(`/teamspaces/${personalTeam.handle}`);
+
+    await expect(page.getByRole("button", { name: /delete/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /request to join/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /leave/i })).toHaveCount(0);
+  });
+
+  for (const role of ["admin", "super_admin"] as const) {
+    test(`${role} visibility does not masquerade as team membership`, async ({ page }) => {
+      const token = role === "admin" ? adminToken : superAdminToken;
+      await loginAs(page, { id: role, email: "", role, token });
+      await page.goto("/teamspaces");
+      await expect(page.getByText(publicTeam.handle, { exact: true })).toBeVisible();
+      await expect(page.getByText(privateTeam.handle, { exact: true })).toBeVisible();
+      await expect(page.getByText(personalTeam.handle, { exact: true })).toBeVisible();
+
+      const actor = await api("/api/v1/auth/whoami", token);
+      try {
+        await page.goto(`/teamspaces/${privateTeam.handle}`);
+        await expect(page.getByText("admin access", { exact: true })).toBeVisible();
+        await expect(page.getByRole("button", { name: /leave/i })).toHaveCount(0);
+        await page.getByRole("button", { name: /request to join/i }).click();
+        await page.getByRole("button", { name: /send request/i }).click();
+        await expect(page.getByText(/request pending/i)).toBeVisible();
+        await page.getByRole("button", { name: /withdraw/i }).click();
+        await expect(page.getByRole("button", { name: /request to join/i })).toBeVisible();
+      } finally {
+        const requests = await api(`/api/v1/teams/${privateTeam.id}/join-requests?status=pending`, owner.token);
+        const request = requests.find((row: { user_id: string }) => row.user_id === actor.id);
+        if (request) await api(`/api/v1/teams/${privateTeam.id}/join-requests/${request.id}`, token, "DELETE");
+      }
+
+      await page.goto(`/teamspaces/${personalTeam.handle}`);
+      await expect(page.getByText("admin access", { exact: true })).toBeVisible();
+      await expect(page.getByRole("button", { name: /request to join/i })).toHaveCount(0);
+      await expect(page.getByRole("button", { name: /leave/i })).toHaveCount(0);
+      await expect(page.getByRole("button", { name: /delete/i })).toBeVisible();
+    });
+  }
+
+  test("direct private members opening an invite are recognized", async ({ page }) => {
+    await loginAs(page, teamReviewer);
+    await page.goto(`/team-invites/${inviteToken}`);
+
+    await expect(page.getByText(/already a member/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /open teamspace/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /request to join/i })).toHaveCount(0);
+  });
+
+  test("invalid private invite tokens reveal no team metadata", async ({ page }) => {
+    await loginAs(page, outsider);
+    await page.goto(`/team-invites/not-a-real-${suffix}`);
+
+    await expect(page.getByText(/invite unavailable/i)).toBeVisible();
+    await expect(page.getByText(privateTeam.handle, { exact: true })).toHaveCount(0);
+  });
+
+  test("a sole owner cannot leave while members remain", async ({ page }) => {
+    await loginAs(page, owner);
+    await page.goto(`/teamspaces/${privateTeam.handle}`);
+    await page.getByRole("button", { name: /leave/i }).click();
+
+    await expect(page.getByText(/must have at least one owner|transfer ownership/i)).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/teamspaces/${privateTeam.handle}$`));
+    await expect(page.getByRole("button", { name: /leave/i })).toBeVisible();
   });
 
   test("private invite preserves login destination and durable request state", async ({ page }) => {
@@ -144,47 +322,75 @@ test.describe("shareable teamspace links", () => {
     await page.getByRole("button", { name: /sign in/i }).click();
     await expect(page).toHaveURL(new RegExp(`/team-invites/${inviteToken}$`));
 
-    await page.getByRole("button", { name: "Request access", exact: true }).click();
-    await expect(page.getByText(/access requested/i)).toBeVisible();
+    await page.getByRole("button", { name: "Request to join", exact: true }).click();
+    await expect(page.getByText(/join requested/i)).toBeVisible();
     await page.reload();
-    await expect(page.getByText(/access requested/i)).toBeVisible();
+    await expect(page.getByText(/join requested/i)).toBeVisible();
 
     await page.getByRole("button", { name: /withdraw request/i }).click();
-    await expect(page.getByText(/withdrew this access request/i)).toBeVisible();
+    await expect(page.getByText(/withdrew this join request/i)).toBeVisible();
     await page.reload();
-    await expect(page.getByText(/withdrew this access request/i)).toBeVisible();
+    await expect(page.getByText(/withdrew this join request/i)).toBeVisible();
   });
 
   test("private invite approval survives refresh and opens the teamspace", async ({ page }) => {
-    await loginAs(page, outsider);
-    await page.goto(`/team-invites/${inviteToken}`);
-    await page.getByRole("button", { name: /request access again/i }).click();
-    await expect(page.getByText(/access requested/i)).toBeVisible();
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Private Approval",
+      handle: `e2e-private-approval-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    try {
+      const invite = await api(`/api/v1/teams/${team.id}/invites`, owner.token, "POST", {
+        name: "Private approval invite",
+        expires_in_days: 1,
+        max_uses: 1,
+      });
+      await loginAs(page, outsider);
+      await page.goto(`/team-invites/${invite.token}`);
+      await page.getByRole("button", { name: "Request to join", exact: true }).click();
+      await expect(page.getByText(/join requested/i)).toBeVisible();
 
-    const request = await pendingRequest(privateTeam.id, outsider.id);
-    await api(`/api/v1/teams/${privateTeam.id}/join-requests/${request.id}/approve`, owner.token, "POST");
-    await page.reload();
-    await expect(page.getByText(/access approved/i)).toBeVisible();
-    await page.getByRole("link", { name: /open teamspace/i }).click();
-    await expect(page).toHaveURL(new RegExp(`/teamspaces/${privateTeam.handle}$`));
-    await expect(page.getByRole("tab", { name: /members/i })).toBeVisible();
+      const request = await pendingRequest(team.id, outsider.id);
+      await api(`/api/v1/teams/${team.id}/join-requests/${request.id}/approve`, owner.token, "POST");
+      await page.reload();
+      await expect(page.getByText(/join request approved/i)).toBeVisible();
+      await page.getByRole("link", { name: /open teamspace/i }).click();
+      await expect(page).toHaveURL(new RegExp(`/teamspaces/${team.handle}$`));
+      await expect(page.getByRole("tab", { name: /members/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /leave/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /request to join/i })).toHaveCount(0);
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
   });
 
   test("public join request becomes membership after owner approval", async ({ page }) => {
-    await loginAs(page, outsider);
-    await page.goto(`/teamspaces/${publicTeam.handle}`);
-    await page.getByRole("button", { name: /request to join/i }).click();
-    await page.getByRole("button", { name: /send request/i }).click();
-    await expect(page.getByText(/request pending/i)).toBeVisible();
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Public Approval",
+      handle: `e2e-public-approval-${suffix}`.slice(0, 32),
+      visibility: "public",
+    });
+    try {
+      await api(`/api/v1/teams/${team.id}/visibility-request/approve`, globalReviewer.token, "POST");
+      await loginAs(page, outsider);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await page.getByRole("button", { name: /request to join/i }).click();
+      await page.getByRole("button", { name: /send request/i }).click();
+      await expect(page.getByText(/request pending/i)).toBeVisible();
 
-    const request = await pendingRequest(publicTeam.id, outsider.id);
-    await api(`/api/v1/teams/${publicTeam.id}/join-requests/${request.id}/approve`, owner.token, "POST");
-    await page.reload();
-    await expect(page.getByRole("tab", { name: /members/i })).toBeVisible();
-    await expect(page.getByText(/request pending/i)).toHaveCount(0);
+      const request = await pendingRequest(team.id, outsider.id);
+      await api(`/api/v1/teams/${team.id}/join-requests/${request.id}/approve`, owner.token, "POST");
+      await page.reload();
+      await expect(page.getByRole("tab", { name: /members/i })).toBeVisible();
+      await expect(page.getByText(/request pending/i)).toHaveCount(0);
+      await expect(page.getByRole("button", { name: /leave/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /request to join/i })).toHaveCount(0);
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
   });
 
-  test("only owners and admins control private visibility", async ({ page }) => {
+  test("reviewers see public teams and need an invite for private teams", async ({ page }) => {
     await loginAs(page, teamReviewer);
     await page.goto(`/teamspaces/${privateTeam.handle}`);
     await expect(page.getByRole("button", { name: /make public/i })).toHaveCount(0);
@@ -197,10 +403,354 @@ test.describe("shareable teamspace links", () => {
     expect(reviewerChange.status).toBe(403);
 
     const reviewerTeams = await api("/api/v1/teams/all", globalReviewer.token);
+    expect(reviewerTeams.some((team: { id: string }) => team.id === publicTeam.id)).toBe(true);
     expect(reviewerTeams.some((team: { id: string }) => team.id === privateTeam.id)).toBe(false);
+    expect(reviewerTeams.some((team: { id: string }) => team.id === personalTeam.id)).toBe(false);
+
     await loginAs(page, globalReviewer);
+    await page.goto("/teamspaces");
+    await expect(page.getByText(publicTeam.handle, { exact: true })).toBeVisible();
+    await expect(page.getByText(privateTeam.handle, { exact: true })).toHaveCount(0);
+    await expect(page.getByText(personalTeam.handle, { exact: true })).toHaveCount(0);
+
     await page.goto(`/teamspaces/${privateTeam.handle}`);
     await expect(page.getByText(/no teamspace named/i)).toBeVisible();
+
+    await page.goto(`/team-invites/${inviteToken}`);
+    await page.getByRole("button", { name: "Request to join", exact: true }).click();
+    await expect(page.getByText(/join requested/i)).toBeVisible();
+    await page.getByRole("button", { name: /withdraw request/i }).click();
+    await expect(page.getByText(/withdrew this join request/i)).toBeVisible();
+
+    await page.goto(`/teamspaces/${publicTeam.handle}`);
+    await page.getByRole("button", { name: /request to join/i }).click();
+    await page.getByRole("button", { name: /send request/i }).click();
+    await expect(page.getByText(/request pending/i)).toBeVisible();
+    await page.getByRole("button", { name: /withdraw/i }).click();
+    await expect(page.getByRole("button", { name: /request to join/i })).toBeVisible();
+  });
+
+  test("leaving a private team keeps public discovery and allows rejoining", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Private Leave",
+      handle: `e2e-private-leave-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    try {
+      const invite = await api(`/api/v1/teams/${team.id}/invites`, owner.token, "POST", {
+        name: "Private leave invite",
+        expires_in_days: 1,
+        max_uses: 2,
+      });
+      await api(`/api/v1/teams/${team.id}/join-requests`, outsider.token, "POST", { invite_token: invite.token });
+      const request = await pendingRequest(team.id, outsider.id);
+      await api(`/api/v1/teams/${team.id}/join-requests/${request.id}/approve`, owner.token, "POST");
+
+      await loginAs(page, outsider);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await page.getByRole("button", { name: /leave/i }).click();
+      await expect(page).toHaveURL(/\/teamspaces$/);
+      await expect(page.getByText(publicTeam.handle, { exact: true })).toBeVisible();
+      await expect(page.getByText(team.handle, { exact: true })).toHaveCount(0);
+
+      await page.goto(`/team-invites/${invite.token}`);
+      await page.getByRole("button", { name: /request to join again/i }).click();
+      await expect(page.getByText(/join requested/i)).toBeVisible();
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("leaving a public team keeps it discoverable and joinable", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Public Leave",
+      handle: `e2e-public-leave-${suffix}`.slice(0, 32),
+      visibility: "public",
+    });
+    try {
+      await api(`/api/v1/teams/${team.id}/visibility-request/approve`, globalReviewer.token, "POST");
+      await api(`/api/v1/teams/${team.id}/members`, owner.token, "POST", {
+        user_id: outsider.id,
+        role: "member",
+      });
+      await loginAs(page, outsider);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await page.getByRole("button", { name: /leave/i }).click();
+
+      await expect(page).toHaveURL(/\/teamspaces$/);
+      await expect(page.getByText(team.handle, { exact: true })).toBeVisible();
+      await page.getByText(team.handle, { exact: true }).click();
+      await expect(page.getByRole("button", { name: /request to join/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /leave/i })).toHaveCount(0);
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("team reviewers lose private visibility after leaving", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Reviewer Leave",
+      handle: `e2e-reviewer-leave-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    try {
+      await api(`/api/v1/teams/${team.id}/members`, owner.token, "POST", {
+        user_id: teamReviewer.id,
+        role: "reviewer",
+      });
+      await loginAs(page, teamReviewer);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await page.getByRole("button", { name: /leave/i }).click();
+
+      await expect(page).toHaveURL(/\/teamspaces$/);
+      await expect(page.getByText(team.handle, { exact: true })).toHaveCount(0);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await expect(page.getByText(/no teamspace named/i)).toBeVisible();
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("a public pending request closes when the team becomes private", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Public To Private",
+      handle: `e2e-pub-private-${suffix}`.slice(0, 32),
+      visibility: "public",
+    });
+    try {
+      await api(`/api/v1/teams/${team.id}/visibility-request/approve`, globalReviewer.token, "POST");
+      await loginAs(page, outsider);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await page.getByRole("button", { name: /request to join/i }).click();
+      await page.getByRole("button", { name: /send request/i }).click();
+      await expect(page.getByText(/request pending/i)).toBeVisible();
+      const request = await pendingRequest(team.id, outsider.id);
+
+      await api(`/api/v1/teams/${team.id}/visibility`, owner.token, "PATCH", { visibility: "private" });
+      await page.reload();
+      await expect(page.getByText(/no teamspace named/i)).toBeVisible();
+
+      const requests = await api(`/api/v1/teams/${team.id}/join-requests`, owner.token);
+      const closed = requests.find((row: { id: string }) => row.id === request.id);
+      expect(closed).toBeDefined();
+      expect(closed.status).toBe("rejected");
+      expect(closed.decision_reason).toBe("Teamspace became private");
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("a private pending request survives a transition to public", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Private To Public",
+      handle: `e2e-private-pub-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    try {
+      const invite = await api(`/api/v1/teams/${team.id}/invites`, owner.token, "POST", {
+        name: "Visibility transition invite",
+        expires_in_days: 1,
+        max_uses: 1,
+      });
+      await loginAs(page, outsider);
+      await page.goto(`/team-invites/${invite.token}`);
+      await page.getByRole("button", { name: /request to join/i }).click();
+      await expect(page.getByText(/join requested/i)).toBeVisible();
+      const request = await pendingRequest(team.id, outsider.id);
+
+      await api(`/api/v1/teams/${team.id}/visibility`, owner.token, "PATCH", { visibility: "public" });
+      await api(`/api/v1/teams/${team.id}/visibility-request/approve`, globalReviewer.token, "POST");
+      await page.goto(`/teamspaces/${team.handle}`);
+      await expect(page.getByText(/request pending/i)).toBeVisible();
+
+      await api(`/api/v1/teams/${team.id}/join-requests/${request.id}/approve`, owner.token, "POST");
+      await page.reload();
+      await expect(page.getByRole("button", { name: /leave/i })).toBeVisible();
+      await expect(page.getByRole("button", { name: /request to join/i })).toHaveCount(0);
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("deleting a team cascades pending requests without residue", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Delete Pending",
+      handle: `e2e-delete-pending-${suffix}`.slice(0, 32),
+      visibility: "public",
+    });
+    let deleted = false;
+    try {
+      await api(`/api/v1/teams/${team.id}/visibility-request/approve`, globalReviewer.token, "POST");
+      await loginAs(page, outsider);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await page.getByRole("button", { name: /request to join/i }).click();
+      await page.getByRole("button", { name: /send request/i }).click();
+      await expect(page.getByText(/request pending/i)).toBeVisible();
+      await pendingRequest(team.id, outsider.id);
+
+      const deletion = await fetch(`${API_BASE}/api/v1/teams/${team.id}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${owner.token}` },
+      });
+      expect(deletion.status).toBe(204);
+      deleted = deletion.status === 204;
+
+      await page.goto("/teamspaces");
+      await expect(page.getByText(team.handle, { exact: true })).toHaveCount(0);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await expect(page.getByText(/no teamspace named/i)).toBeVisible();
+    } finally {
+      if (!deleted) await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("approval and removal refresh across users and tabs", async ({ page, context }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Cross Tab Access",
+      handle: `e2e-cross-tab-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    const invite = await api(`/api/v1/teams/${team.id}/invites`, owner.token, "POST", {
+      name: "Cross-tab invite",
+      expires_in_days: 1,
+      max_uses: 1,
+    });
+    const ownerPage = await context.newPage();
+    const secondMemberPage = await context.newPage();
+    try {
+      await loginAs(page, outsider);
+      await page.goto(`/team-invites/${invite.token}`);
+      await page.getByRole("button", { name: /request to join/i }).click();
+      await expect(page.getByText(/join requested/i)).toBeVisible();
+      const request = await pendingRequest(team.id, outsider.id);
+
+      await loginAs(ownerPage, owner);
+      await ownerPage.bringToFront();
+      await api(`/api/v1/teams/${team.id}/join-requests/${request.id}/approve`, owner.token, "POST");
+      await page.bringToFront();
+      await expect(page.getByText(/join request approved/i)).toBeVisible({ timeout: 15_000 });
+      await page.getByRole("link", { name: /open teamspace/i }).click();
+      await expect(page.getByRole("button", { name: /leave/i })).toBeVisible();
+
+      await loginAs(secondMemberPage, outsider);
+      await secondMemberPage.goto(`/teamspaces/${team.handle}`);
+      await expect(secondMemberPage.getByRole("button", { name: /leave/i })).toBeVisible();
+
+      await ownerPage.bringToFront();
+      await api(`/api/v1/teams/${team.id}/members/${outsider.id}`, owner.token, "DELETE");
+      await page.bringToFront();
+      await expect(page.getByText(/no teamspace named/i)).toBeVisible({ timeout: 15_000 });
+      await secondMemberPage.bringToFront();
+      await expect(secondMemberPage.getByText(/no teamspace named/i)).toBeVisible({ timeout: 15_000 });
+    } finally {
+      await ownerPage.close();
+      await secondMemberPage.close();
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("only one concurrent request consumes the final invite use", async () => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Final Invite Use",
+      handle: `e2e-final-invite-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    try {
+      const invite = await api(`/api/v1/teams/${team.id}/invites`, owner.token, "POST", {
+        name: "One use invite",
+        expires_in_days: 1,
+        max_uses: 1,
+      });
+      const request = (token: string) =>
+        fetch(`${API_BASE}/api/v1/teams/${team.id}/join-requests`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+          body: JSON.stringify({ invite_token: invite.token }),
+        });
+      const responses = await Promise.all([request(outsider.token), request(globalReviewer.token)]);
+      expect(responses.map((response) => response.status).sort()).toEqual([201, 201]);
+      const requests = await Promise.all(responses.map((response) => response.json()));
+      const approve = (requestId: string) =>
+        fetch(`${API_BASE}/api/v1/teams/${team.id}/join-requests/${requestId}/approve`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${owner.token}` },
+        });
+      const approvals = await Promise.all(requests.map((row) => approve(row.id)));
+      expect(approvals.map((response) => response.status).sort()).toEqual([200, 409]);
+
+      const pending = await api(`/api/v1/teams/${team.id}/join-requests?status=pending`, owner.token);
+      expect(pending).toHaveLength(1);
+      const members = await api(`/api/v1/teams/${team.id}/members`, owner.token);
+      expect(members).toHaveLength(2);
+      const invites = await api(`/api/v1/teams/${team.id}/invites`, owner.token);
+      expect(invites.find((row: { id: string }) => row.id === invite.id)?.use_count).toBe(1);
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("a deleted personal teamspace can be claimed again", async () => {
+    const first: Team = await api("/api/v1/teams/claim-personal", globalReviewer.token, "POST");
+    await api(`/api/v1/teams/${first.id}`, globalReviewer.token, "DELETE");
+    const replacement: Team = await api("/api/v1/teams/claim-personal", globalReviewer.token, "POST");
+    try {
+      expect(replacement.id).not.toBe(first.id);
+      expect(replacement.handle).toBe(first.handle);
+      const teams = await api("/api/v1/teams", globalReviewer.token);
+      expect(teams.filter((team: { is_personal: boolean }) => team.is_personal)).toHaveLength(1);
+    } finally {
+      await api(`/api/v1/teams/${replacement.id}`, globalReviewer.token, "DELETE");
+    }
+  });
+
+  test("an unjoined admin receives private-team publishing actions", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Admin Publish",
+      handle: `e2e-admin-publish-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    try {
+      await loginAs(page, { id: "admin", email: "", role: "admin", token: adminToken });
+      await page.goto(`/teamspaces/${team.handle}`);
+      await expect(page.getByRole("link", { name: /build agent/i })).toBeVisible();
+      await page.getByRole("tab", { name: /components/i }).click();
+      await expect(page.getByRole("button", { name: /create component/i })).toBeVisible();
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
+  });
+
+  test("making a private team public revokes old invites and restores discovery", async ({ page }) => {
+    const team: Team = await api("/api/v1/teams", owner.token, "POST", {
+      name: "E2E Private To Public Invite",
+      handle: `e2e-private-public-${suffix}`.slice(0, 32),
+      visibility: "private",
+    });
+    try {
+      const invite = await api(`/api/v1/teams/${team.id}/invites`, owner.token, "POST", {
+        name: "Visibility invite",
+        expires_in_days: 1,
+        max_uses: 1,
+      });
+      await loginAs(page, owner);
+      await page.goto(`/teamspaces/${team.handle}`);
+      await page.getByRole("button", { name: /request public/i }).click();
+      await expect(page.getByText(/public visibility review pending/i)).toBeVisible();
+
+      await loginAs(page, globalReviewer);
+      await page.goto("/review?tab=teamspaces");
+      const card = page.getByTestId(`teamspace-review-${team.id}`);
+      await card.getByRole("button", { name: "Approve", exact: true }).click();
+      await expect(card).toHaveCount(0);
+
+      await loginAs(page, outsider);
+      await page.goto("/teamspaces");
+      await expect(page.getByText(team.handle, { exact: true })).toBeVisible();
+      await page.goto(`/team-invites/${invite.token}`);
+      await expect(page.getByText(/invite unavailable/i)).toBeVisible();
+    } finally {
+      await api(`/api/v1/teams/${team.id}`, owner.token, "DELETE");
+    }
   });
 
   test("canonical component type route resolves the correct collection", async ({ page }) => {

--- a/tests/test_draft_workflow.py
+++ b/tests/test_draft_workflow.py
@@ -25,7 +25,7 @@ from httpx import ASGITransport, AsyncClient
 from api.deps import get_current_user, get_db
 from api.routes.agent import router
 from models.agent import AgentStatus
-from models.team import TeamRole
+from models.team import Team, TeamRole
 from models.user import User, UserRole
 
 # ── Helpers ──────────────────────────────────────────────
@@ -54,6 +54,14 @@ def _membership(role: TeamRole):
     m = MagicMock()
     m.role = role
     return m
+
+
+def _team_row(agent, *, private=False, visibility_request_status=None):
+    team = MagicMock(spec=Team)
+    team.id = agent.team_id
+    team.is_private = private
+    team.visibility_request_status = visibility_request_status
+    return team
 
 
 def _db_with_membership(membership):
@@ -358,6 +366,7 @@ class TestDraftVisibilityChange:
         component = _component_mock()
         agent = self._team_agent(user, is_private=True, components=[component])
         db = _sequenced_db(
+            _scalar_result(_team_row(agent)),  # lock owning team
             _scalar_result(_membership(TeamRole.owner)),  # team role gate
             _scalar_result(None),  # component is outside the public scope
             _rows_result([(component.component_id, "secret-mcp")]),  # name lookup
@@ -383,6 +392,7 @@ class TestDraftVisibilityChange:
         component = _component_mock()
         agent = self._team_agent(user, is_private=True, components=[component])
         db = _sequenced_db(
+            _scalar_result(_team_row(agent)),
             _scalar_result(_membership(TeamRole.owner)),
             _scalar_result(_approved_listing()),
         )
@@ -396,6 +406,23 @@ class TestDraftVisibilityChange:
         assert agent.is_private is False
         assert r.json()["visibility"] == "public"
         db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    @patch("api.routes.agent.draft._load_agent")
+    async def test_private_team_cannot_make_draft_public(self, mock_load):
+        user = _user()
+        agent = self._team_agent(user, is_private=True, components=[])
+        db = _sequenced_db(_scalar_result(_team_row(agent, private=True)))
+        app, db, _ = _app_with(user=user, db=db)
+        mock_load.return_value = agent
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.put(f"/api/v1/agents/{agent.id}/draft", json={"visibility": "public"})
+
+        assert response.status_code == 409
+        assert "Private teamspaces" in response.json()["detail"]
+        assert agent.is_private is True
+        db.commit.assert_not_awaited()
 
     @pytest.mark.asyncio
     @patch("api.routes.agent.draft._load_agent")
@@ -423,6 +450,7 @@ class TestDraftVisibilityChange:
         component = _component_mock()
         agent = self._team_agent(user, is_private=False, components=[component])
         db = _sequenced_db(
+            _scalar_result(_team_row(agent)),
             _scalar_result(_membership(TeamRole.owner)),
             _scalar_result(_approved_listing()),
         )
@@ -442,7 +470,10 @@ class TestDraftVisibilityChange:
         """A plain team member is refused before any component work happens."""
         user = _user()
         agent = self._team_agent(user, is_private=True, components=[_component_mock()])
-        db = _sequenced_db(_scalar_result(_membership(TeamRole.member)))
+        db = _sequenced_db(
+            _scalar_result(_team_row(agent)),
+            _scalar_result(_membership(TeamRole.member)),
+        )
         app, db, _ = _app_with(user=user, db=db)
         mock_load.return_value = agent
 
@@ -479,6 +510,7 @@ class TestDraftVisibilityChange:
         agent = self._team_agent(user, is_private=True, components=[_component_mock()])
         new_component_id = uuid.uuid4()
         db = _sequenced_db(
+            _scalar_result(_team_row(agent)),
             _scalar_result(_membership(TeamRole.owner)),
             _scalar_result(None),  # the resent component is not public
         )

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -593,48 +593,47 @@ async def test_resolving_stamps_and_clears_resolved_at(sessions):
 
 
 @pytest.mark.asyncio
-async def test_reviewers_for_matches_can_review_exactly(sessions):
-    """``reviewers_for`` is the set inverse of ``teamspace.can_review``.
-
-    They are written in two different directions and must not drift, so this
-    asserts agreement over a matrix of callers rather than trusting the comment
-    that says they agree.
-    """
-    from services.teamspace import can_review, review_scope
-
+async def test_review_notifications_follow_item_and_team_visibility(sessions):
     async with sessions() as db:
         admin = await _user(db, UserRole.admin)
         global_reviewer = await _user(db, UserRole.reviewer)
-        plain = await _user(db, UserRole.user)
         team_owner = await _user(db)
+        team_reviewer = await _user(db)
         team_member = await _user(db)
+        other_owner = await _user(db)
 
         team = Team(id=uuid.uuid4(), name="Team", handle="team", created_by=team_owner.id)
-        db.add(team)
+        other = Team(id=uuid.uuid4(), name="Other", handle="other", created_by=other_owner.id)
+        db.add_all([team, other])
         await db.flush()
-        db.add(TeamMembership(team_id=team.id, user_id=team_owner.id, role=TeamRole.owner))
-        db.add(TeamMembership(team_id=team.id, user_id=team_member.id, role=TeamRole.member))
+        db.add_all(
+            [
+                TeamMembership(team_id=team.id, user_id=team_owner.id, role=TeamRole.owner),
+                TeamMembership(team_id=team.id, user_id=team_reviewer.id, role=TeamRole.reviewer),
+                TeamMembership(team_id=team.id, user_id=team_member.id, role=TeamRole.member),
+                TeamMembership(team_id=other.id, user_id=other_owner.id, role=TeamRole.owner),
+            ]
+        )
         await db.commit()
-
-        everyone = [admin, global_reviewer, plain, team_owner, team_member]
 
         class _Entity:
             def __init__(self, is_private, team_id):
                 self.is_private = is_private
                 self.team_id = team_id
 
-        for label, entity in [
-            ("public", _Entity(False, None)),
-            ("team-private", _Entity(True, team.id)),
-            ("personal-private", _Entity(True, None)),
-        ]:
-            expected = set()
-            for user in everyone:
-                scope = await review_scope(db, user)
-                if can_review(entity, scope):
-                    expected.add(user.id)
+        cases = [
+            ("public", _Entity(False, None), {admin.id, global_reviewer.id}),
+            (
+                "public-team",
+                _Entity(False, team.id),
+                {admin.id, global_reviewer.id, team_owner.id, team_reviewer.id},
+            ),
+            ("team-private", _Entity(True, team.id), {team_owner.id, team_reviewer.id}),
+            ("personal-private", _Entity(True, None), {admin.id}),
+        ]
+        for label, entity, expected in cases:
             actual = set(await recipients.reviewers_for(db, entity))
-            assert actual == expected, f"{label}: recipients drifted from can_review"
+            assert actual == expected, label
 
 
 @pytest.mark.asyncio

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -199,8 +199,8 @@ async def test_authenticated_recipient_previews_and_requests_access(sessions):
 
     async with _client(sessions, outsider) as client:
         durable = await client.post("/api/v1/teams/invites/preview", json={"token": token})
-    assert durable.json()["valid"] is False
-    assert durable.json()["invite_state"] == "exhausted"
+    assert durable.json()["valid"] is True
+    assert durable.json()["invite_state"] == "active"
     assert durable.json()["team_handle"] == team.handle
     assert durable.json()["request"]["status"] == "pending"
 
@@ -217,7 +217,7 @@ async def test_authenticated_recipient_previews_and_requests_access(sessions):
         invite = (await db.execute(select(TeamInvite))).scalar_one()
         assert membership is None
         assert request.user_id == outsider.id
-        assert invite.use_count == 1
+        assert invite.use_count == 0
         second_outsider = await _user(db)
         await db.commit()
 
@@ -227,8 +227,58 @@ async def test_authenticated_recipient_previews_and_requests_access(sessions):
             f"/api/v1/teams/{team.id}/join-requests",
             json={"invite_token": token},
         )
-    assert exhausted_preview.json()["valid"] is False
-    assert exhausted_request.status_code == 404
+    assert exhausted_preview.json()["valid"] is True
+    assert exhausted_request.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_direct_member_add_consumes_invite_quota(sessions):
+    owner, first, _admin, team = await _seed(sessions)
+    async with sessions() as db:
+        second = await _user(db)
+        await db.commit()
+
+    async with _client(sessions, owner) as client:
+        created = await _create(client, team.id, max_uses=1)
+    token = created.json()["token"]
+
+    for requester in (first, second):
+        async with _client(sessions, requester) as client:
+            response = await client.post(
+                f"/api/v1/teams/{team.id}/join-requests",
+                json={"invite_token": token},
+            )
+        assert response.status_code == 201
+
+    async with _client(sessions, owner) as client:
+        added_first = await client.post(
+            f"/api/v1/teams/{team.id}/members",
+            json={"user_id": str(first.id), "role": "member"},
+        )
+        added_second = await client.post(
+            f"/api/v1/teams/{team.id}/members",
+            json={"user_id": str(second.id), "role": "member"},
+        )
+    assert added_first.status_code == 200
+    assert added_second.status_code == 409
+    assert "no remaining uses" in added_second.json()["detail"]
+
+    async with sessions() as db:
+        invite = await db.get(TeamInvite, uuid.UUID(created.json()["id"]))
+        requests = (
+            (await db.execute(select(TeamMembershipRequest).where(TeamMembershipRequest.team_id == team.id)))
+            .scalars()
+            .all()
+        )
+        second_membership = await db.scalar(
+            select(TeamMembership.id).where(
+                TeamMembership.team_id == team.id,
+                TeamMembership.user_id == second.id,
+            )
+        )
+    assert invite.use_count == 1
+    assert {request.status.value for request in requests} == {"approved", "pending"}
+    assert second_membership is None
 
 
 @pytest.mark.asyncio
@@ -272,12 +322,17 @@ async def test_invite_preview_persists_cancelled_rejected_and_approved_status(se
 
 
 @pytest.mark.asyncio
-async def test_making_team_public_revokes_existing_invites(sessions):
-    owner, outsider, _admin, team = await _seed(sessions)
+async def test_approving_public_visibility_revokes_existing_invites(sessions):
+    owner, outsider, admin, team = await _seed(sessions)
     async with _client(sessions, owner) as client:
         created = await _create(client, team.id)
-        public = await client.patch(f"/api/v1/teams/{team.id}/visibility", json={"visibility": "public"})
-    assert public.status_code == 200
+        requested = await client.patch(f"/api/v1/teams/{team.id}/visibility", json={"visibility": "public"})
+    assert requested.status_code == 200
+    assert requested.json()["visibility_request_status"] == "pending"
+
+    async with _client(sessions, admin) as client:
+        approved = await client.post(f"/api/v1/teams/{team.id}/visibility-request/approve")
+    assert approved.status_code == 200
 
     async with sessions() as db:
         invite = await db.get(TeamInvite, uuid.UUID(created.json()["id"]))

--- a/tests/test_registry_types.py
+++ b/tests/test_registry_types.py
@@ -35,6 +35,9 @@ def _mock_db():
     db.commit = AsyncMock()
     db.refresh = AsyncMock()
     db.delete = AsyncMock()
+    empty = MagicMock()
+    empty.all.return_value = []
+    db.execute.return_value = empty
     # A review decision delivers inbox items in the same transaction, wrapping
     # each insert in a SAVEPOINT. A bare AsyncMock returns a coroutine from
     # begin_nested(), which is not an async context manager.

--- a/tests/test_review_queue.py
+++ b/tests/test_review_queue.py
@@ -39,6 +39,9 @@ def _mock_db():
     db.commit = AsyncMock()
     db.refresh = AsyncMock()
     db.delete = AsyncMock()
+    empty = MagicMock()
+    empty.all.return_value = []
+    db.execute.return_value = empty
     # Inbox delivery wraps each insert in a SAVEPOINT so a duplicate cannot roll
     # back the review action it belongs to. A bare AsyncMock returns a coroutine
     # from begin_nested(), which is not an async context manager, so it is given

--- a/tests/test_review_route_coverage.py
+++ b/tests/test_review_route_coverage.py
@@ -35,6 +35,12 @@ OTHER_TEAM_ID = uuid.UUID(int=4)
 ADMIN_SCOPE = ReviewScope(is_admin=True, is_global_reviewer=True, team_ids=frozenset())
 GLOBAL_SCOPE = ReviewScope(is_admin=False, is_global_reviewer=True, team_ids=frozenset())
 TEAM_SCOPE = ReviewScope(is_admin=False, is_global_reviewer=False, team_ids=frozenset({TEAM_ID}))
+PUBLIC_TEAM_SCOPE = ReviewScope(
+    is_admin=False,
+    is_global_reviewer=False,
+    team_ids=frozenset({TEAM_ID}),
+    public_team_ids=frozenset({TEAM_ID}),
+)
 EMPTY_SCOPE = ReviewScope(is_admin=False, is_global_reviewer=False, team_ids=frozenset())
 
 _UNSET = object()
@@ -185,7 +191,7 @@ def _orm_listing(
     return listing, version
 
 
-def _orm_agent(*, latest_status=AgentStatus.approved):
+def _orm_agent(*, latest_status=AgentStatus.approved, team_id=None):
     agent = Agent(
         id=uuid.UUID(int=500),
         name="review agent",
@@ -193,6 +199,7 @@ def _orm_agent(*, latest_status=AgentStatus.approved):
         slug="review-agent",
         owner="acme",
         created_by=SUBMITTER_ID,
+        team_id=team_id,
         is_private=False,
         created_at=NOW,
         updated_at=NOW,
@@ -308,6 +315,7 @@ def test_item_authorization_and_scope_visibility_are_exact():
     other_private = SimpleNamespace(is_private=True, team_id=OTHER_TEAM_ID)
 
     review._authorize_item(public, GLOBAL_SCOPE)
+    review._authorize_item(public, PUBLIC_TEAM_SCOPE)
     review._authorize_item(private, TEAM_SCOPE)
     assert review._in_scope(private, TEAM_SCOPE, TEAM_ID) is True
     assert review._in_scope(private, TEAM_SCOPE, OTHER_TEAM_ID) is False
@@ -322,7 +330,7 @@ def test_item_authorization_and_scope_visibility_are_exact():
     _assert_http(
         public_denied,
         403,
-        "Public items are reviewed by global reviewers, not by teamspace roles",
+        "Public item is outside your review scope",
     )
 
 
@@ -1015,9 +1023,10 @@ async def test_approve_each_component_type_updates_version_then_notifies_and_com
     listing_type,
 ):
     db = _db()
-    actor = _actor()
-    listing, version = _orm_listing(listing_type)
+    actor = _actor(user_id=SUBMITTER_ID)
+    listing, version = _orm_listing(listing_type, team_id=TEAM_ID)
     events = []
+    decision_boundaries.scope.return_value = PUBLIC_TEAM_SCOPE
     monkeypatch.setattr(review, "_find_listing", AsyncMock(return_value=(listing_type, listing)))
     db.flush.side_effect = lambda: events.append("flush")
     db.execute.side_effect = lambda statement: events.append("update") or _result()
@@ -1115,7 +1124,7 @@ async def test_approve_not_found_and_authorization_fail_before_mutation(monkeypa
     _assert_http(
         forbidden,
         403,
-        "Public items are reviewed by global reviewers, not by teamspace roles",
+        "Public item is outside your review scope",
     )
     assert version.status is ListingStatus.pending
     db.flush.assert_not_awaited()
@@ -1164,9 +1173,10 @@ async def test_reject_each_component_type_records_reason_notifies_and_cascades(
     listing_type,
 ):
     db = _db()
-    actor = _actor()
-    listing, version = _orm_listing(listing_type)
+    actor = _actor(user_id=SUBMITTER_ID)
+    listing, version = _orm_listing(listing_type, team_id=TEAM_ID)
     events = []
+    decision_boundaries.scope.return_value = PUBLIC_TEAM_SCOPE
     monkeypatch.setattr(review, "_find_listing", AsyncMock(return_value=(listing_type, listing)))
     decision_boundaries.decide.side_effect = lambda *args, **kwargs: events.append("inbox")
     db.commit.side_effect = lambda: events.append("commit")
@@ -1273,8 +1283,9 @@ async def test_approve_agent_newest_release_supersedes_older_and_notifies_each_a
     decision_boundaries,
 ):
     db = _db()
-    actor = _actor()
-    agent, current = _orm_agent()
+    actor = _actor(user_id=SUBMITTER_ID)
+    agent, current = _orm_agent(team_id=TEAM_ID)
+    decision_boundaries.scope.return_value = PUBLIC_TEAM_SCOPE
     newest = _pending_version(
         agent.id,
         version="2.0.0",
@@ -1408,8 +1419,9 @@ async def test_reject_agent_rejects_every_pending_version_and_notifies_each_auth
     decision_boundaries,
 ):
     db = _db()
-    actor = _actor()
-    agent, _current = _orm_agent()
+    actor = _actor(user_id=SUBMITTER_ID)
+    agent, _current = _orm_agent(team_id=TEAM_ID)
+    decision_boundaries.scope.return_value = PUBLIC_TEAM_SCOPE
     newest = _pending_version(
         agent.id,
         version="2.0.0",
@@ -1858,7 +1870,7 @@ async def test_bulk_approve_missing_wrong_type_and_scope_fail_before_commit(monk
     _assert_http(
         denied,
         403,
-        "Public items are reviewed by global reviewers, not by teamspace roles",
+        "Public item is outside your review scope",
     )
     assert mcp_version.status is ListingStatus.pending
     decision_boundaries.decide.assert_not_awaited()
@@ -1885,7 +1897,7 @@ async def test_bulk_approve_skill_scope_or_database_failure_does_not_commit(monk
     _assert_http(
         denied,
         403,
-        "Public items are reviewed by global reviewers, not by teamspace roles",
+        "Public item is outside your review scope",
     )
     assert skill_version.status is ListingStatus.pending
     db.commit.assert_not_awaited()

--- a/tests/test_sec009_component_source_ownership.py
+++ b/tests/test_sec009_component_source_ownership.py
@@ -281,9 +281,9 @@ async def test_list_sources_hides_private_sources_with_no_teamspace():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
-async def test_list_sources_returns_every_team_private_source_to_global_reviewers(role):
-    """Global reviewers and admins moderate the whole registry, so they see all of it."""
+@pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
+async def test_list_sources_returns_every_team_private_source_to_admins(role):
+    """Deployment admins retain operational access to private team sources."""
     team = _team("platform")
 
     async with _api(_user(role=role)) as (client, sessions):
@@ -299,6 +299,20 @@ async def test_list_sources_returns_every_team_private_source_to_global_reviewer
             "https://github.com/example/private",
             "https://github.com/example/public",
         }
+
+
+@pytest.mark.asyncio
+async def test_list_sources_hides_other_teams_private_sources_from_global_reviewer():
+    team = _team("platform")
+    async with _api(_user(role=UserRole.reviewer)) as (client, sessions):
+        await _seed(
+            sessions,
+            team,
+            _source("https://github.com/example/private", is_public=False, team_id=team.id),
+            _source("https://github.com/example/public", is_public=True),
+        )
+        response = await client.get("/api/v1/component-sources")
+    assert [source["url"] for source in response.json()] == ["https://github.com/example/public"]
 
 
 # ── get_source: non-members get 404 so existence is not leaked ───────────────
@@ -345,9 +359,9 @@ async def test_get_team_private_source_as_member_returns_200():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("role", [UserRole.reviewer, UserRole.admin, UserRole.super_admin])
-async def test_get_team_private_source_as_global_reviewer_returns_200(role):
-    """Global reviewers and admins can read team-private sources."""
+@pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
+async def test_get_team_private_source_as_admin_returns_200(role):
+    """Deployment admins can read team-private sources."""
     team = _team("platform")
     private = _source("https://github.com/example/private", is_public=False, team_id=team.id)
 
@@ -355,6 +369,16 @@ async def test_get_team_private_source_as_global_reviewer_returns_200(role):
         await _seed(sessions, team, private)
         r = await client.get(f"/api/v1/component-sources/{private.id}")
         assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_team_private_source_as_global_reviewer_returns_404():
+    team = _team("platform")
+    private = _source("https://github.com/example/private", is_public=False, team_id=team.id)
+    async with _api(_user(role=UserRole.reviewer)) as (client, sessions):
+        await _seed(sessions, team, private)
+        response = await client.get(f"/api/v1/component-sources/{private.id}")
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_join_requests.py
+++ b/tests/test_team_join_requests.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import uuid
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 
 import pytest
 import pytest_asyncio
@@ -206,6 +207,25 @@ async def _pending_request(sessions, team, requester) -> str:
 
 
 @pytest.mark.asyncio
+async def test_pending_public_visibility_locks_join_decisions(sessions):
+    owner, _second_owner, _member, outsider, team = await _seed(sessions)
+    request_id = await _pending_request(sessions, team, outsider)
+    async with sessions() as db:
+        stored = await db.get(Team, team.id)
+        stored.is_private = True
+        stored.visibility_request_status = "pending"
+        stored.visibility_requested_at = datetime.now(UTC)
+        await db.commit()
+
+    async with _client(sessions, owner) as (client, _):
+        approved = await client.post(f"/api/v1/teams/{team.id}/join-requests/{request_id}/approve")
+        rejected = await client.post(f"/api/v1/teams/{team.id}/join-requests/{request_id}/reject", json={})
+
+    assert approved.status_code == 409
+    assert rejected.status_code == 409
+
+
+@pytest.mark.asyncio
 async def test_owner_approval_grants_member_and_clears_owner_items(sessions):
     owner, second_owner, _member, outsider, team = await _seed(sessions)
     request_id = await _pending_request(sessions, team, outsider)
@@ -329,6 +349,33 @@ async def test_approving_someone_already_added_directly_does_not_duplicate(sessi
 
 
 # ── Withdrawing ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_direct_member_add_reconciles_pending_request_and_allows_future_rerequest(sessions):
+    owner, _second, _member, outsider, team = await _seed(sessions)
+    request_id = await _pending_request(sessions, team, outsider)
+
+    async with _client(sessions, owner) as (client, _):
+        added = await client.post(
+            f"/api/v1/teams/{team.id}/members",
+            json={"user_id": str(outsider.id), "role": "member"},
+        )
+        rejected = await client.post(f"/api/v1/teams/{team.id}/join-requests/{request_id}/reject", json={})
+        removed = await client.delete(f"/api/v1/teams/{team.id}/members/{outsider.id}")
+
+    assert added.status_code == 200
+    assert rejected.status_code == 409
+    assert removed.status_code == 204
+    rows = await _request_rows(sessions, team.id)
+    assert rows[0].status == TeamJoinRequestStatus.approved
+    assert rows[0].decision_reason == "Added directly by a team owner"
+    decisions = await _inbox_rows(sessions, InboxKind.team_join_decided)
+    assert decisions[0].body == "Added directly by a team owner"
+
+    async with _client(sessions, outsider) as (client, _):
+        requested_again = await client.post(f"/api/v1/teams/{team.id}/join-requests", json={})
+    assert requested_again.status_code == 201
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_publishing.py
+++ b/tests/test_team_publishing.py
@@ -141,6 +141,24 @@ class TestResolvePublishTargetAutoApprove:
         assert "team-private" in exc.value.detail
 
     @pytest.mark.asyncio
+    async def test_pending_public_team_rejects_every_publish(self):
+        team_id = uuid.uuid4()
+        db = _mock_db()
+        db.get = AsyncMock(
+            return_value=SimpleNamespace(
+                id=team_id,
+                handle="pending-tools",
+                is_private=True,
+                visibility_request_status="pending",
+            )
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve_publish_target(db, _user(), "Internal Tool", team_id=team_id, visibility="team")
+        assert exc.value.status_code == 409
+        assert "locked" in exc.value.detail
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("team_role", [None, TeamRole.member, TeamRole.reviewer])
     async def test_personal_publish_requires_active_creator_owner(self, team_role):
         team_id = uuid.uuid4()
@@ -198,11 +216,12 @@ class TestResolvePublishTargetAutoApprove:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("role", [UserRole.admin, UserRole.super_admin])
-    async def test_admin_may_publish_into_a_team_they_are_not_in(self, role):
+    @pytest.mark.parametrize("private", [False, True])
+    async def test_admin_may_publish_into_a_team_they_are_not_in(self, role, private):
         """Admins keep the cross-team capability because they can still read the result."""
         team_id = uuid.uuid4()
         db = _mock_db([_membership(None)])
-        db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools", is_private=False))
+        db.get = AsyncMock(return_value=SimpleNamespace(id=team_id, handle="platform-tools", is_private=private))
 
         target = await resolve_publish_target(db, _user(role), "Internal Tool", team_id=team_id, visibility="team")
         # They can publish cross-team, but even admins do not skip review.

--- a/tests/test_team_review.py
+++ b/tests/test_team_review.py
@@ -16,10 +16,9 @@ Review is now capability scoped. The queue, the detail view, and the approve and
 reject actions all read one ReviewScope, so the list and the actions cannot drift
 apart: whatever a caller cannot see in the queue, they also cannot approve.
 
-The escalation this must not open is the mirror of the one team_role_self_publishes
-closes at publish time. Team roles are self-service, so a team owner who could approve
-a PUBLIC listing standing in their own team namespace would have a one-step route into
-the global catalog. Public items therefore stay with global reviewers, team roles or not.
+Team roles may review public content only after the teamspace itself passes global
+public-visibility review. That approval is the trust boundary allowing its owners and
+team reviewers to decide all later team content, including their own submissions.
 """
 
 from __future__ import annotations
@@ -156,7 +155,13 @@ async def _seed(sessions):
     global_reviewer = _user("globalreviewer", role=UserRole.reviewer)
     admin = _user("admin", role=UserRole.admin)
 
-    team = Team(id=uuid.uuid4(), name="Acme", handle="acme", created_by=owner.id)
+    team = Team(
+        id=uuid.uuid4(),
+        name="Acme",
+        handle="acme",
+        visibility_request_status="approved",
+        created_by=owner.id,
+    )
     other_team = Team(id=uuid.uuid4(), name="Other", handle="other", created_by=other_owner.id)
     memberships = [
         TeamMembership(team_id=team.id, user_id=owner.id, role=TeamRole.owner),
@@ -274,12 +279,11 @@ async def test_team_review_roles_see_their_teams_private_items(who):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("who", ["team_owner", "team_reviewer"])
-async def test_team_review_roles_do_not_see_their_teams_public_items(who):
-    """They cannot approve a public item, so listing it would only mislead them."""
+async def test_team_review_roles_see_their_teams_public_items(who):
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _queue(sessions, getattr(seed, who))
-    assert "shared" not in _names(response)
+    assert "shared" in _names(response)
 
 
 @pytest.mark.asyncio
@@ -289,6 +293,39 @@ async def test_team_review_roles_see_their_teams_private_agents():
         seed = await _seed(sessions)
         response = await _queue(sessions, seed.team_owner)
     assert "Triage" in _names(response)
+
+
+@pytest.mark.asyncio
+async def test_private_team_role_cannot_review_public_content():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        async with sessions() as session:
+            team = await session.get(Team, seed.team_id)
+            team.is_private = True
+            await session.commit()
+
+        queue = await _queue(sessions, seed.team_owner)
+        denied = await _approve(sessions, seed.team_owner, seed.public_id)
+
+    assert "internal" in _names(queue)
+    assert "shared" not in _names(queue)
+    assert denied.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_pending_public_team_has_no_team_review_capability():
+    async with _sessions() as sessions:
+        seed = await _seed(sessions)
+        async with sessions() as session:
+            team = await session.get(Team, seed.team_id)
+            team.is_private = True
+            team.visibility_request_status = "pending"
+            team.visibility_requested_at = datetime.now(UTC)
+            await session.commit()
+
+        response = await _queue(sessions, seed.team_owner)
+
+    assert response.status_code == 403
 
 
 @pytest.mark.asyncio
@@ -422,7 +459,8 @@ async def test_team_private_item_is_not_approved_without_a_review_role(who):
 
 
 @pytest.mark.asyncio
-async def test_team_owner_approves_their_own_submission():
+@pytest.mark.parametrize("is_private", [True, False])
+async def test_team_owner_approves_their_own_submission(is_private):
     """Self-approval is deliberate policy, not an oversight.
 
     Team publishing never auto-approves anymore, so a team owner's (or team
@@ -433,7 +471,7 @@ async def test_team_owner_approves_their_own_submission():
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         async with sessions() as session:
-            own = _mcp("owners-own", team_id=seed.team_id, is_private=True, submitted_by=seed.team_owner.id)
+            own = _mcp("owners-own", team_id=seed.team_id, is_private=is_private, submitted_by=seed.team_owner.id)
             session.add(own)
             await session.flush()
             version = _mcp_version(own, released_by=seed.team_owner.id)
@@ -507,28 +545,24 @@ async def test_public_item_is_approved_by_a_global_role(who):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("who", ["team_owner", "team_reviewer"])
-async def test_team_role_cannot_approve_a_public_item_in_its_own_namespace(who):
-    """The escalation this closes: team roles are self-service, so a team owner who
-    could approve a public listing standing in their own namespace would promote
-    anything into the global catalog by first promoting themselves."""
+async def test_team_role_can_approve_a_public_item_in_its_approved_namespace(who):
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _approve(sessions, getattr(seed, who), seed.public_id)
-        assert response.status_code == 403
-        assert response.json()["detail"] == "Public items are reviewed by global reviewers, not by teamspace roles"
+        assert response.status_code == 200
 
         async with sessions() as session:
             listing = await session.get(McpListing, seed.public_id)
             version = await session.get(McpVersion, listing.latest_version_id)
-            assert version.status == ListingStatus.pending
+            assert version.status == ListingStatus.approved
 
 
 @pytest.mark.asyncio
-async def test_team_role_cannot_reject_a_public_item_in_its_own_namespace():
+async def test_team_role_can_reject_a_public_item_in_its_approved_namespace():
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _reject(sessions, seed.team_owner, seed.public_id)
-        assert response.status_code == 403
+        assert response.status_code == 200
 
 
 # ── Agents ─────────────────────────────────────────────────────────────────
@@ -618,12 +652,11 @@ async def test_team_private_agent_detail_is_404_for_a_global_reviewer():
 
 
 @pytest.mark.asyncio
-async def test_public_detail_is_404_for_a_team_role_that_cannot_act_on_it():
-    """The detail view and the queue read one scope, so they cannot drift apart."""
+async def test_public_detail_is_visible_to_a_reviewing_team_role():
     async with _sessions() as sessions:
         seed = await _seed(sessions)
         response = await _detail(sessions, seed.team_owner, seed.public_id)
-    assert response.status_code == 404
+    assert response.status_code == 200
 
 
 # ── Deleting a teamspace must not strip access from its listings ─────────────

--- a/tests/test_team_visibility.py
+++ b/tests/test_team_visibility.py
@@ -8,12 +8,16 @@ Private teamspaces work like private GitHub orgs: hidden from users who are
 not members, including global reviewers. Deployment admins retain operational
 access. Visibility is changed only by team owners and deployment admins.
 Creation is open to every signed-in user, who becomes the new teamspace owner.
+The lifecycle matrix covers every global role across public, private, and
+personal creation, discovery, join-request, leave, and deletion policies.
 """
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
@@ -28,14 +32,17 @@ from models.agent import Agent
 from models.base import Base
 from models.component_source import ComponentSource
 from models.hook import HookListing
-from models.inbox import InboxItem, InboxItemEvent
+from models.inbox import InboxItem, InboxItemEvent, InboxKind, InboxState
 from models.mcp import McpListing
 from models.prompt import PromptListing
 from models.sandbox import SandboxListing
 from models.skill import SkillListing
-from models.team import Team, TeamMembership, TeamMembershipRequest, TeamRole
+from models.team import Team, TeamJoinRequestStatus, TeamMembership, TeamMembershipRequest, TeamRole
 from models.team_invite import TeamInvite
 from models.user import User, UserRole
+
+_GLOBAL_ROLES = (UserRole.user, UserRole.reviewer, UserRole.admin, UserRole.super_admin)
+_ADMIN_ROLES = (UserRole.admin, UserRole.super_admin)
 
 _TABLES = [
     User.__table__,
@@ -80,6 +87,22 @@ async def _user(db, role=UserRole.user) -> User:
     return user
 
 
+async def _team(db, owner: User, *, private: bool = False, personal: bool = False) -> Team:
+    team = Team(
+        id=uuid.uuid4(),
+        name="Test Team",
+        handle=f"team-{uuid.uuid4().hex[:8]}",
+        is_private=private,
+        is_personal=personal,
+        created_by=owner.id,
+    )
+    db.add(team)
+    await db.flush()
+    db.add(TeamMembership(team_id=team.id, user_id=owner.id, role=TeamRole.owner))
+    await db.flush()
+    return team
+
+
 @asynccontextmanager
 async def _client(sessions, actor: User):
     async with sessions() as session:
@@ -100,16 +123,7 @@ async def _seed(sessions):
         outsider = await _user(db)
         global_reviewer = await _user(db, role=UserRole.reviewer)
         admin = await _user(db, role=UserRole.admin)
-        team = Team(
-            id=uuid.uuid4(),
-            name="Secret Ops",
-            handle=f"secret-{uuid.uuid4().hex[:8]}",
-            is_private=True,
-            created_by=owner.id,
-        )
-        db.add(team)
-        await db.flush()
-        db.add(TeamMembership(team_id=team.id, user_id=owner.id, role=TeamRole.owner))
+        team = await _team(db, owner, private=True)
         db.add(TeamMembership(team_id=team.id, user_id=team_reviewer.id, role=TeamRole.reviewer))
         db.add(TeamMembership(team_id=team.id, user_id=member.id, role=TeamRole.member))
         await db.commit()
@@ -120,31 +134,73 @@ async def _seed(sessions):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("role", [UserRole.user, UserRole.reviewer, UserRole.admin, UserRole.super_admin])
-async def test_any_signed_in_user_creates_a_teamspace_and_owns_it(sessions, role):
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+@pytest.mark.parametrize("visibility", ["public", "private"])
+async def test_any_signed_in_user_creates_a_teamspace_and_owns_it(sessions, role, visibility):
     async with sessions() as db:
         creator = await _user(db, role=role)
         await db.commit()
     async with _client(sessions, creator) as (client, _):
-        response = await client.post("/api/v1/teams", json={"name": "My Team", "handle": f"my-{uuid.uuid4().hex[:8]}"})
+        response = await client.post(
+            "/api/v1/teams",
+            json={"name": "My Team", "handle": f"my-{uuid.uuid4().hex[:8]}", "visibility": visibility},
+        )
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["role"] == "owner"
-    assert body["visibility"] == "public"
+    assert body["visibility"] == "private"
+    assert body["visibility_request_status"] == ("pending" if visibility == "public" else None)
 
 
 @pytest.mark.asyncio
-async def test_creation_honors_requested_visibility(sessions):
+async def test_public_team_creation_is_locked_until_review_and_supports_self_approval(sessions):
     async with sessions() as db:
-        creator = await _user(db)
+        reviewer = await _user(db, role=UserRole.reviewer)
+        teammate = await _user(db)
         await db.commit()
-    async with _client(sessions, creator) as (client, _):
-        response = await client.post(
+
+    async with _client(sessions, reviewer) as (client, _):
+        created = await client.post(
             "/api/v1/teams",
-            json={"name": "Quiet Team", "handle": f"quiet-{uuid.uuid4().hex[:8]}", "visibility": "private"},
+            json={"name": "Reviewed Team", "handle": f"reviewed-{uuid.uuid4().hex[:8]}", "visibility": "public"},
         )
-    assert response.status_code == 200
-    assert response.json()["visibility"] == "private"
+        team_id = created.json()["id"]
+        locked = await client.post(
+            f"/api/v1/teams/{team_id}/members",
+            json={"user_id": str(teammate.id), "role": "member"},
+        )
+        locked_update = await client.put(f"/api/v1/teams/{team_id}", json={"description": "Not yet"})
+        queue = await client.get("/api/v1/teams/visibility-requests")
+        approved = await client.post(f"/api/v1/teams/{team_id}/visibility-request/approve")
+
+    assert created.json()["visibility_request_status"] == "pending"
+    assert locked.status_code == 409
+    assert locked_update.status_code == 409
+    assert {row["team_id"] for row in queue.json()} == {team_id}
+    assert approved.json()["visibility"] == "public"
+    assert approved.json()["visibility_request_status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_rejected_public_visibility_can_be_requested_again(sessions):
+    async with sessions() as db:
+        owner = await _user(db)
+        reviewer = await _user(db, role=UserRole.reviewer)
+        team = await _team(db, owner, private=True)
+        await db.commit()
+
+    requested = await _set_visibility(sessions, owner, team.id, "public")
+    assert requested.json()["visibility_request_status"] == "pending"
+    async with _client(sessions, reviewer) as (client, _):
+        rejected = await client.post(
+            f"/api/v1/teams/{team.id}/visibility-request/reject",
+            json={"reason": "Incomplete profile"},
+        )
+    assert rejected.json()["visibility_request_status"] == "rejected"
+    assert rejected.json()["visibility_rejection_reason"] == "Incomplete profile"
+
+    requested_again = await _set_visibility(sessions, owner, team.id, "public")
+    assert requested_again.json()["visibility_request_status"] == "pending"
 
 
 # ── Private teamspaces are hidden from plain non-members ─────────────
@@ -166,16 +222,235 @@ async def test_private_team_is_hidden_from_plain_non_members_everywhere(sessions
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("who", ["member", "admin"])
-async def test_private_team_stays_visible_to_members_and_admins(sessions, who):
-    _owner, _team_reviewer, member, _outsider, _global_reviewer, admin, team = await _seed(sessions)
-    actor = {"member": member, "admin": admin}[who]
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+@pytest.mark.parametrize("as_member", [False, True])
+async def test_private_team_visibility_respects_global_role_and_membership(sessions, role, as_member):
+    async with sessions() as db:
+        owner = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, owner, private=True)
+        if as_member:
+            db.add(TeamMembership(team_id=team.id, user_id=actor.id, role=TeamRole.member))
+        await db.commit()
+
     async with _client(sessions, actor) as (client, _):
         listing = await client.get("/api/v1/teams/all")
         by_handle = await client.get(f"/api/v1/teams/by-handle/{team.handle}")
-    assert team.handle in {row["handle"] for row in listing.json()}
+        detail = await client.get(f"/api/v1/teams/{team.id}")
+
+    listed = {row["id"]: row for row in listing.json()}
+    can_view = as_member or role in _ADMIN_ROLES
+    if not can_view:
+        assert str(team.id) not in listed
+        assert by_handle.status_code == 404
+        assert detail.status_code == 404
+        return
+
+    expected_team_role = "member" if as_member else None
+    assert listed[str(team.id)]["role"] == expected_team_role
     assert by_handle.status_code == 200
-    assert by_handle.json()["visibility"] == "private"
+    assert by_handle.json()["role"] == expected_team_role
+    assert detail.status_code == 200
+    assert detail.json()["role"] == expected_team_role
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+async def test_public_team_is_visible_to_every_global_role_without_granting_membership(sessions, role):
+    async with sessions() as db:
+        owner = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, owner)
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        listing = await client.get("/api/v1/teams/all")
+        by_handle = await client.get(f"/api/v1/teams/by-handle/{team.handle}")
+        detail = await client.get(f"/api/v1/teams/{team.id}")
+
+    listed = {row["id"]: row for row in listing.json()}
+    assert listed[str(team.id)]["role"] is None
+    assert by_handle.status_code == 200
+    assert by_handle.json()["role"] is None
+    assert detail.status_code == 200
+    assert detail.json()["role"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+async def test_personal_team_visibility_is_creator_or_admin_only(sessions, role):
+    async with sessions() as db:
+        creator = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, creator, private=True, personal=True)
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        listing = await client.get("/api/v1/teams/all")
+        by_handle = await client.get(f"/api/v1/teams/by-handle/{team.handle}")
+        detail = await client.get(f"/api/v1/teams/{team.id}")
+
+    listed = {row["id"]: row for row in listing.json()}
+    if role not in _ADMIN_ROLES:
+        assert str(team.id) not in listed
+        assert by_handle.status_code == 404
+        assert detail.status_code == 404
+        return
+
+    assert listed[str(team.id)]["role"] is None
+    assert by_handle.status_code == 200
+    assert by_handle.json()["role"] is None
+    assert detail.status_code == 200
+    assert detail.json()["role"] is None
+
+
+# ── Join requests across visibility and global roles ────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+async def test_public_team_accepts_join_requests_from_every_nonmember_tier(sessions, role):
+    async with sessions() as db:
+        owner = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, owner)
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        response = await client.post(f"/api/v1/teams/{team.id}/join-requests", json={})
+
+    assert response.status_code == 201
+    assert response.json()["status"] == "pending"
+    assert response.json()["invite_id"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+async def test_private_team_requires_an_invite_except_for_admin_tiers(sessions, role):
+    token = f"invite-{uuid.uuid4().hex}"
+    async with sessions() as db:
+        owner = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, owner, private=True)
+        invite = TeamInvite(
+            token_hash=hashlib.sha256(token.encode()).hexdigest(),
+            name="Matrix invite",
+            team_id=team.id,
+            invited_by=owner.id,
+            expires_at=datetime.now(UTC) + timedelta(days=1),
+        )
+        db.add(invite)
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        if role not in _ADMIN_ROLES:
+            hidden = await client.post(f"/api/v1/teams/{team.id}/join-requests", json={})
+            assert hidden.status_code == 404
+            response = await client.post(
+                f"/api/v1/teams/{team.id}/join-requests",
+                json={"invite_token": token},
+            )
+        else:
+            response = await client.post(f"/api/v1/teams/{team.id}/join-requests", json={})
+
+    assert response.status_code == 201
+    assert response.json()["status"] == "pending"
+    assert response.json()["invite_id"] == (str(invite.id) if role not in _ADMIN_ROLES else None)
+    async with sessions() as db:
+        stored_invite = await db.get(TeamInvite, invite.id)
+        assert stored_invite.use_count == 0
+
+
+@pytest.mark.asyncio
+async def test_invite_uses_are_consumed_only_by_approved_memberships(sessions):
+    token = f"invite-{uuid.uuid4().hex}"
+    async with sessions() as db:
+        owner = await _user(db)
+        requester = await _user(db)
+        team = await _team(db, owner, private=True)
+        invite = TeamInvite(
+            token_hash=hashlib.sha256(token.encode()).hexdigest(),
+            name="One member invite",
+            team_id=team.id,
+            invited_by=owner.id,
+            max_uses=1,
+            expires_at=datetime.now(UTC) + timedelta(days=1),
+        )
+        db.add(invite)
+        await db.commit()
+
+    async with _client(sessions, requester) as (client, _):
+        first = await client.post(
+            f"/api/v1/teams/{team.id}/join-requests",
+            json={"invite_token": token},
+        )
+        cancelled = await client.delete(f"/api/v1/teams/{team.id}/join-requests/{first.json()['id']}")
+        second = await client.post(
+            f"/api/v1/teams/{team.id}/join-requests",
+            json={"invite_token": token},
+        )
+    assert cancelled.status_code == 204
+    assert second.status_code == 201
+
+    async with _client(sessions, owner) as (client, _):
+        rejected = await client.post(
+            f"/api/v1/teams/{team.id}/join-requests/{second.json()['id']}/reject",
+            json={},
+        )
+        deleted = await client.delete(f"/api/v1/teams/{team.id}/invites/{invite.id}")
+    assert rejected.status_code == 200
+    assert deleted.status_code == 409
+
+    async with sessions() as db:
+        rows = (
+            (await db.execute(select(TeamMembershipRequest).where(TeamMembershipRequest.team_id == team.id)))
+            .scalars()
+            .all()
+        )
+        membership_count = await db.scalar(
+            select(func.count(TeamMembership.id)).where(
+                TeamMembership.team_id == team.id,
+                TeamMembership.user_id == requester.id,
+            )
+        )
+        stored_invite = await db.get(TeamInvite, invite.id)
+    assert all(row.invite_id == invite.id for row in rows)
+    assert stored_invite is not None
+    assert membership_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+async def test_personal_team_rejects_join_requests_from_every_tier(sessions, role):
+    async with sessions() as db:
+        creator = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, creator, private=True, personal=True)
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        response = await client.post(f"/api/v1/teams/{team.id}/join-requests", json={})
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+@pytest.mark.parametrize("private", [False, True])
+@pytest.mark.parametrize("team_role", [TeamRole.member, TeamRole.reviewer, TeamRole.owner])
+async def test_existing_members_cannot_request_to_join_again(sessions, role, private, team_role):
+    async with sessions() as db:
+        owner = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, owner, private=private)
+        db.add(TeamMembership(team_id=team.id, user_id=actor.id, role=team_role))
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        response = await client.post(f"/api/v1/teams/{team.id}/join-requests", json={})
+
+    assert response.status_code == 409
+    assert "already a member" in response.json()["detail"]
 
 
 # ── Changing visibility ──────────────────────────────────────────────
@@ -188,12 +463,23 @@ async def _set_visibility(sessions, actor, team_id, visibility):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("who", ["owner", "admin"])
-async def test_owners_and_admins_change_visibility(sessions, who):
-    owner, _team_reviewer, _member, _outsider, _gr, admin, team = await _seed(sessions)
+async def test_owners_and_admins_request_public_visibility(sessions, who):
+    owner, _team_reviewer, _member, _outsider, global_reviewer, admin, team = await _seed(sessions)
     actor = {"owner": owner, "admin": admin}[who]
     response = await _set_visibility(sessions, actor, team.id, "public")
     assert response.status_code == 200
-    assert response.json()["visibility"] == "public"
+    assert response.json()["visibility"] == "private"
+    assert response.json()["visibility_request_status"] == "pending"
+
+    async with _client(sessions, global_reviewer) as (client, _):
+        approved = await client.post(f"/api/v1/teams/{team.id}/visibility-request/approve")
+    assert approved.status_code == 200
+    assert approved.json()["visibility"] == "public"
+
+    unchanged = await _set_visibility(sessions, actor, team.id, "public")
+    assert unchanged.status_code == 200
+    assert unchanged.json()["visibility"] == "public"
+    assert unchanged.json()["visibility_request_status"] == "approved"
 
 
 @pytest.mark.asyncio
@@ -224,22 +510,98 @@ async def test_outsider_gets_404_not_403_on_a_private_team(sessions):
     assert response.status_code == 404
 
 
+# ── Leaving regular teamspaces ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+@pytest.mark.parametrize("private", [False, True])
+@pytest.mark.parametrize("team_role", [TeamRole.member, TeamRole.reviewer])
+async def test_non_owner_members_can_leave_at_every_tier(sessions, role, private, team_role):
+    async with sessions() as db:
+        owner = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, owner, private=private)
+        db.add(TeamMembership(team_id=team.id, user_id=actor.id, role=team_role))
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        response = await client.post(f"/api/v1/teams/{team.id}/leave")
+
+    assert response.status_code == 204
+    async with sessions() as db:
+        membership = await db.scalar(
+            select(TeamMembership).where(
+                TeamMembership.team_id == team.id,
+                TeamMembership.user_id == actor.id,
+            )
+        )
+        assert membership is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+@pytest.mark.parametrize("private", [False, True])
+async def test_nonmembers_cannot_leave_at_any_tier(sessions, role, private):
+    async with sessions() as db:
+        owner = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, owner, private=private)
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        response = await client.post(f"/api/v1/teams/{team.id}/leave")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+@pytest.mark.parametrize("private", [False, True])
+@pytest.mark.parametrize("has_second_owner", [False, True])
+async def test_owner_exit_preserves_a_team_owner_at_every_tier(sessions, role, private, has_second_owner):
+    async with sessions() as db:
+        actor = await _user(db, role=role)
+        team = await _team(db, actor, private=private)
+        if has_second_owner:
+            second_owner = await _user(db)
+            db.add(TeamMembership(team_id=team.id, user_id=second_owner.id, role=TeamRole.owner))
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        response = await client.post(f"/api/v1/teams/{team.id}/leave")
+
+    assert response.status_code == (204 if has_second_owner else 409)
+    async with sessions() as db:
+        owners = await db.scalar(
+            select(func.count(TeamMembership.id)).where(
+                TeamMembership.team_id == team.id,
+                TeamMembership.role == TeamRole.owner,
+            )
+        )
+        assert owners == 1
+
+
 # ── Personal private teamspace claim ─────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_claim_creates_a_private_owned_teamspace_and_is_idempotent(sessions):
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+async def test_claim_creates_a_private_owned_teamspace_and_is_idempotent(sessions, role):
     async with sessions() as db:
-        user = await _user(db)
+        user = await _user(db, role=role)
         stranger = await _user(db)
         await db.commit()
 
     async with _client(sessions, user) as (client, _):
         first = await client.post("/api/v1/teams/claim-personal")
+        assert first.status_code == 200, first.text
+        body = first.json()
         again = await client.post("/api/v1/teams/claim-personal")
         mine = await client.get("/api/v1/teams")
-    assert first.status_code == 200, first.text
-    body = first.json()
+        visible = await client.get("/api/v1/teams/all")
+        by_handle = await client.get(f"/api/v1/teams/by-handle/{body['handle']}")
+        leave = await client.post(f"/api/v1/teams/{body['id']}/leave")
     assert body["visibility"] == "private"
     assert body["is_personal"] is True
     assert body["role"] == "owner"
@@ -248,6 +610,9 @@ async def test_claim_creates_a_private_owned_teamspace_and_is_idempotent(session
     assert again.status_code == 200
     assert again.json()["id"] == body["id"]
     assert [team["id"] for team in mine.json() if team["is_personal"]] == [body["id"]]
+    assert body["id"] in {team["id"] for team in visible.json()}
+    assert by_handle.json()["role"] == "owner"
+    assert leave.status_code == 409
 
     async with sessions() as db:
         count = await db.scalar(
@@ -259,6 +624,68 @@ async def test_claim_creates_a_private_owned_teamspace_and_is_idempotent(session
     async with _client(sessions, stranger) as (client, _):
         listing = await client.get("/api/v1/teams/all")
     assert body["handle"] not in {t["handle"] for t in listing.json()}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _GLOBAL_ROLES)
+async def test_empty_personal_teamspace_can_be_deleted(sessions, role):
+    async with sessions() as db:
+        creator = await _user(db, role=role)
+        await db.commit()
+
+    async with _client(sessions, creator) as (client, _):
+        claimed = await client.post("/api/v1/teams/claim-personal")
+        assert claimed.status_code == 200, claimed.text
+        team_id = uuid.UUID(claimed.json()["id"])
+        deleted = await client.delete(f"/api/v1/teams/{team_id}")
+
+    assert deleted.status_code == 204
+    async with sessions() as db:
+        assert await db.get(Team, team_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", _ADMIN_ROLES)
+async def test_admin_tiers_can_delete_someone_elses_empty_personal_team(sessions, role):
+    async with sessions() as db:
+        creator = await _user(db)
+        actor = await _user(db, role=role)
+        team = await _team(db, creator, private=True, personal=True)
+        await db.commit()
+
+    async with _client(sessions, actor) as (client, _):
+        response = await client.delete(f"/api/v1/teams/{team.id}")
+
+    assert response.status_code == 204
+    async with sessions() as db:
+        assert await db.get(Team, team.id) is None
+
+
+@pytest.mark.asyncio
+async def test_personal_team_with_registry_items_cannot_be_deleted(sessions):
+    async with sessions() as db:
+        creator = await _user(db)
+        team = await _team(db, creator, private=True, personal=True)
+        db.add(
+            McpListing(
+                id=uuid.uuid4(),
+                name="Personal Tool",
+                namespace=team.handle,
+                slug="personal-tool",
+                category="general",
+                owner=team.handle,
+                submitted_by=creator.id,
+                team_id=team.id,
+                is_private=True,
+            )
+        )
+        await db.commit()
+
+    async with _client(sessions, creator) as (client, _):
+        response = await client.delete(f"/api/v1/teams/{team.id}")
+
+    assert response.status_code == 409
+    assert "MCP server" in response.json()["detail"]
 
 
 @pytest.mark.asyncio
@@ -285,32 +712,105 @@ async def test_personal_teamspace_repairs_and_enforces_strict_invariants(session
 
     async with _client(sessions, creator) as (client, _):
         repaired = await client.post("/api/v1/teams/claim-personal")
-        visibility = await client.patch(f"/api/v1/teams/{team_id}/visibility", json={"visibility": "public"})
-        add_owner = await client.post(
-            f"/api/v1/teams/{team_id}/members",
-            json={"user_id": str(stranger.id), "role": "owner"},
-        )
-        remove_creator = await client.delete(f"/api/v1/teams/{team_id}/members/{creator.id}")
-        leave = await client.post(f"/api/v1/teams/{team_id}/leave")
-        invite = await client.post(f"/api/v1/teams/{team_id}/invites", json={})
-        deleted = await client.delete(f"/api/v1/teams/{team_id}")
-    async with _client(sessions, stranger) as (client, _):
-        join = await client.post(f"/api/v1/teams/{team_id}/join-requests", json={})
 
-    assert repaired.json()["visibility"] == "private"
-    assert visibility.status_code == 409
-    assert add_owner.status_code == 409
-    assert remove_creator.status_code == 409
-    assert leave.status_code == 409
-    assert invite.status_code == 409
-    assert deleted.status_code == 409
-    assert join.status_code == 404
+    assert repaired.status_code == 409
+    assert "cannot have other members" in repaired.json()["detail"]
 
     async with sessions() as db:
         memberships = (
             (await db.execute(select(TeamMembership).where(TeamMembership.team_id == team_id))).scalars().all()
         )
-    assert [(membership.user_id, membership.role) for membership in memberships] == [(creator.id, TeamRole.owner)]
+    assert {(membership.user_id, membership.role) for membership in memberships} == {
+        (creator.id, TeamRole.member),
+        (stranger.id, TeamRole.owner),
+    }
+
+
+@pytest.mark.asyncio
+async def test_claim_does_not_convert_a_legacy_named_team_with_other_members(sessions):
+    async with sessions() as db:
+        creator = await _user(db)
+        teammate = await _user(db)
+        team = Team(
+            id=uuid.uuid4(),
+            name="Shared Legacy Team",
+            handle=f"{creator.username}-team",
+            description="Your private teamspace for drafts and personal publishing.",
+            is_private=True,
+            created_by=creator.id,
+        )
+        db.add(team)
+        await db.flush()
+        db.add_all(
+            [
+                TeamMembership(team_id=team.id, user_id=creator.id, role=TeamRole.owner),
+                TeamMembership(team_id=team.id, user_id=teammate.id, role=TeamRole.reviewer),
+                McpListing(
+                    id=uuid.uuid4(),
+                    name="Shared Tool",
+                    namespace=team.handle,
+                    slug="shared-tool",
+                    category="general",
+                    owner=team.handle,
+                    submitted_by=teammate.id,
+                    team_id=team.id,
+                    is_private=True,
+                ),
+            ]
+        )
+        await db.commit()
+
+    async with _client(sessions, creator) as (client, _):
+        claimed = await client.post("/api/v1/teams/claim-personal")
+
+    assert claimed.status_code == 200
+    assert claimed.json()["id"] != str(team.id)
+    async with sessions() as db:
+        original = await db.get(Team, team.id)
+        memberships = (
+            (await db.execute(select(TeamMembership).where(TeamMembership.team_id == team.id))).scalars().all()
+        )
+        listing = (
+            await db.execute(select(McpListing.submitted_by, McpListing.team_id).where(McpListing.team_id == team.id))
+        ).one()
+    assert original.is_personal is False
+    assert {membership.user_id for membership in memberships} == {creator.id, teammate.id}
+    assert listing.submitted_by == teammate.id
+    assert listing.team_id == team.id
+
+
+@pytest.mark.asyncio
+async def test_personal_conversion_cannot_approve_a_preexisting_join_request(sessions):
+    async with sessions() as db:
+        creator = await _user(db)
+        requester = await _user(db)
+        team = Team(
+            id=uuid.uuid4(),
+            name="Legacy Personal Team",
+            handle=f"{creator.username}-team",
+            description="Your private teamspace for drafts and personal publishing.",
+            is_private=True,
+            created_by=creator.id,
+        )
+        db.add(team)
+        await db.flush()
+        db.add(TeamMembership(team_id=team.id, user_id=creator.id, role=TeamRole.owner))
+        request = TeamMembershipRequest(team_id=team.id, user_id=requester.id)
+        db.add(request)
+        await db.commit()
+
+    async with _client(sessions, creator) as (client, _):
+        claimed = await client.post("/api/v1/teams/claim-personal")
+        approved = await client.post(f"/api/v1/teams/{team.id}/join-requests/{request.id}/approve")
+
+    assert claimed.status_code == 200
+    assert claimed.json()["id"] == str(team.id)
+    assert approved.status_code == 409
+    async with sessions() as db:
+        member_count = await db.scalar(select(func.count(TeamMembership.id)).where(TeamMembership.team_id == team.id))
+        stored_request = await db.get(TeamMembershipRequest, request.id)
+    assert member_count == 1
+    assert stored_request.status == TeamJoinRequestStatus.pending
 
 
 @pytest.mark.asyncio
@@ -405,6 +905,46 @@ async def test_public_team_owner_routes_still_403_for_non_members(sessions):
 
 
 @pytest.mark.asyncio
+async def test_visibility_review_notifies_reviewers_and_owner(sessions):
+    async with sessions() as db:
+        owner = await _user(db)
+        reviewer = await _user(db, UserRole.reviewer)
+        admin = await _user(db, UserRole.admin)
+        team = await _team(db, owner, private=True)
+        await db.commit()
+
+    requested = await _set_visibility(sessions, owner, team.id, "public")
+    assert requested.status_code == 200
+    async with sessions() as db:
+        pending = (
+            (await db.execute(select(InboxItem).where(InboxItem.kind == InboxKind.team_created_pending)))
+            .scalars()
+            .all()
+        )
+    assert {item.user_id for item in pending} == {reviewer.id, admin.id}
+    assert all(item.action_url == "/review?tab=teamspaces" for item in pending)
+
+    async with _client(sessions, reviewer) as (client, _):
+        rejected = await client.post(
+            f"/api/v1/teams/{team.id}/visibility-request/reject",
+            json={"reason": "More detail needed"},
+        )
+    assert rejected.status_code == 200
+    async with sessions() as db:
+        pending = (
+            (await db.execute(select(InboxItem).where(InboxItem.kind == InboxKind.team_created_pending)))
+            .scalars()
+            .all()
+        )
+        decisions = (
+            (await db.execute(select(InboxItem).where(InboxItem.kind == InboxKind.review_rejected))).scalars().all()
+        )
+    assert all(item.state == InboxState.done for item in pending)
+    assert {item.user_id for item in decisions} == {owner.id}
+    assert decisions[0].body == "More detail needed"
+
+
+@pytest.mark.asyncio
 async def test_team_cannot_go_private_while_it_owns_public_items(sessions):
     async with sessions() as db:
         owner = await _user(db)
@@ -435,6 +975,48 @@ async def test_team_cannot_go_private_while_it_owns_public_items(sessions):
 
 
 @pytest.mark.asyncio
+async def test_team_cannot_go_private_while_it_owns_a_public_component_source(sessions):
+    async with sessions() as db:
+        owner = await _user(db)
+        team = await _team(db, owner)
+        db.add(
+            ComponentSource(
+                id=uuid.uuid4(),
+                url=f"https://github.com/example/{uuid.uuid4().hex}",
+                provider="github",
+                component_type="mcp",
+                is_public=True,
+                team_id=team.id,
+            )
+        )
+        await db.commit()
+
+    response = await _set_visibility(sessions, owner, team.id, "private")
+    assert response.status_code == 409
+    assert "component source" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_going_private_rejects_pending_public_join_requests(sessions):
+    async with sessions() as db:
+        owner = await _user(db)
+        outsider = await _user(db)
+        team = await _team(db, owner)
+        await db.commit()
+
+    async with _client(sessions, outsider) as (client, _):
+        requested = await client.post(f"/api/v1/teams/{team.id}/join-requests", json={})
+    assert requested.status_code == 201
+
+    response = await _set_visibility(sessions, owner, team.id, "private")
+    assert response.status_code == 200
+    async with sessions() as db:
+        row = await db.scalar(select(TeamMembershipRequest).where(TeamMembershipRequest.team_id == team.id))
+    assert row.status == TeamJoinRequestStatus.rejected
+    assert row.decision_reason == "Teamspace became private"
+
+
+@pytest.mark.asyncio
 async def test_going_private_then_public_round_trips_discovery(sessions):
     async with sessions() as db:
         owner = await _user(db)
@@ -450,7 +1032,19 @@ async def test_going_private_then_public_round_trips_discovery(sessions):
         hidden = await client.get(f"/api/v1/teams/by-handle/{team.handle}")
     assert hidden.status_code == 404
 
-    assert (await _set_visibility(sessions, owner, team.id, "public")).status_code == 200
+    requested = await _set_visibility(sessions, owner, team.id, "public")
+    assert requested.status_code == 200
+    assert requested.json()["visibility_request_status"] == "pending"
+    async with _client(sessions, owner) as (client, _):
+        forbidden = await client.post(f"/api/v1/teams/{team.id}/visibility-request/approve")
+    assert forbidden.status_code == 403
+
+    async with sessions() as db:
+        reviewer = await _user(db, role=UserRole.reviewer)
+        await db.commit()
+    async with _client(sessions, reviewer) as (client, _):
+        approved = await client.post(f"/api/v1/teams/{team.id}/visibility-request/approve")
+    assert approved.status_code == 200
     async with _client(sessions, outsider) as (client, _):
         visible = await client.get(f"/api/v1/teams/by-handle/{team.handle}")
     assert visible.status_code == 200

--- a/tests/test_team_visibility_migrations.py
+++ b/tests/test_team_visibility_migrations.py
@@ -27,6 +27,7 @@ VERSIONS_DIR = Path(__file__).resolve().parents[1] / "observal-server" / "alembi
 # repo convention of NNN_slug for the file and the revision id alike.
 TEAM_PUBLISHING_MIGRATION = VERSIONS_DIR / "018_team_publishing.py"
 COMPONENT_SOURCE_MIGRATION = TEAM_PUBLISHING_MIGRATION
+TEAM_VISIBILITY_REVIEW_MIGRATION = VERSIONS_DIR / "025_team_visibility_review.py"
 
 # Schema operations the migration is allowed to perform. alter_column is here
 # because agents.is_private is added with a false server default and then has that
@@ -58,6 +59,34 @@ def _called_op_methods(node: ast.AST) -> set[str]:
             if isinstance(value, ast.Name):
                 calls.add(f"{value.id}.{child.func.attr}")
     return calls
+
+
+def test_public_visibility_review_migration_uses_next_sequential_revision():
+    migration = _load_migration(TEAM_VISIBILITY_REVIEW_MIGRATION)
+    assert migration.revision == "025_team_visibility_review"
+    assert migration.down_revision == "024_shareable_teamspaces"
+
+
+def test_public_visibility_review_model_matches_migration_constraints():
+    from models.team import Team
+
+    assert {
+        "visibility_request_status",
+        "visibility_requested_by",
+        "visibility_requested_at",
+        "visibility_reviewed_by",
+        "visibility_reviewed_at",
+        "visibility_rejection_reason",
+    } <= set(Team.__table__.columns.keys())
+    assert {constraint.name for constraint in Team.__table__.constraints} >= {
+        "ck_teams_visibility_request_status",
+        "ck_teams_pending_visibility_private",
+        "ck_teams_pending_visibility_requested_at",
+    }
+    assert {key.name for key in Team.__table__.foreign_keys} >= {
+        "fk_teams_visibility_requested_by_users",
+        "fk_teams_visibility_reviewed_by_users",
+    }
 
 
 def test_component_source_migration_only_changes_schema():

--- a/tests/test_teams_route_coverage.py
+++ b/tests/test_teams_route_coverage.py
@@ -290,6 +290,8 @@ async def test_team_lists_serialize_roles_counts_and_visibility():
             "description": mine.description,
             "visibility": "private",
             "is_personal": True,
+            "visibility_request_status": None,
+            "visibility_rejection_reason": None,
             "role": "owner",
             "member_count": None,
             "created_at": _NOW.isoformat().replace("+00:00", "Z"),
@@ -301,6 +303,8 @@ async def test_team_lists_serialize_roles_counts_and_visibility():
             "description": public.description,
             "visibility": "public",
             "is_personal": False,
+            "visibility_request_status": None,
+            "visibility_rejection_reason": None,
             "role": "member",
             "member_count": None,
             "created_at": _NOW.isoformat().replace("+00:00", "Z"),
@@ -326,7 +330,7 @@ async def test_team_lists_serialize_roles_counts_and_visibility():
 
 
 @pytest.mark.asyncio
-async def test_team_by_handle_normalizes_input_and_admin_gets_owner_view(monkeypatch):
+async def test_team_by_handle_normalizes_input_and_preserves_admin_membership(monkeypatch):
     admin = _user(role=UserRole.admin, username="admin")
     team = _team(private=True, handle="platform")
     database = _db(_Result(one=team))
@@ -336,7 +340,7 @@ async def test_team_by_handle_normalizes_input_and_admin_gets_owner_view(monkeyp
 
     response = await teams.team_by_handle("  @PLATFORM ", database, admin)
 
-    assert response.role == "owner"
+    assert response.role is None
     assert response.member_count == 4
     assert "teams.handle = 'platform'" in _sql(database.execute.await_args.args[0])
 
@@ -372,11 +376,14 @@ async def test_invite_preview_covers_invalid_expired_personal_and_durable_states
     invite = _invite(team, owner)
 
     lookup = AsyncMock(return_value=None)
+    membership_lookup = AsyncMock(return_value=None)
     monkeypatch.setattr(teams, "team_invite_by_token", lookup)
+    monkeypatch.setattr(teams, "team_membership", membership_lookup)
     invalid = await teams.preview_team_invite(teams.TeamInvitePreviewRequest(token="missing"), _db(), actor)
     assert invalid.model_dump() == {
         "valid": False,
         "invite_state": None,
+        "is_member": False,
         "team_id": None,
         "team_name": None,
         "team_handle": None,
@@ -412,9 +419,16 @@ async def test_invite_preview_covers_invalid_expired_personal_and_durable_states
     durable_db.get.side_effect = [team, owner]
     durable = await teams.preview_team_invite(teams.TeamInvitePreviewRequest(token="active"), durable_db, actor)
     assert durable.valid is True
+    assert durable.is_member is False
     assert durable.invited_by == "Owner Name"
     assert durable.request.status == "rejected"
     assert durable.request.decision_reason == "Not yet"
+
+    membership_lookup.return_value = _membership(team, actor)
+    member_db = _db(_Result(one=request))
+    member_db.get.side_effect = [team, owner]
+    member = await teams.preview_team_invite(teams.TeamInvitePreviewRequest(token="active"), member_db, actor)
+    assert member.is_member is True
 
 
 @pytest.mark.asyncio
@@ -422,16 +436,18 @@ async def test_team_detail_serializes_member_and_admin_roles(monkeypatch):
     member = _user(username="member")
     team = _team()
     membership = _membership(team, member, TeamRole.reviewer)
+    membership_lookup = AsyncMock(return_value=membership)
     monkeypatch.setattr(teams, "_load_visible_team", AsyncMock(return_value=team))
-    monkeypatch.setattr(teams, "team_membership", AsyncMock(return_value=membership))
+    monkeypatch.setattr(teams, "team_membership", membership_lookup)
 
     response = await teams.team_detail(team.id, _db(), member)
     assert response.role == "reviewer"
     assert response.model_dump(mode="json")["visibility"] == "public"
 
     admin = _user(role=UserRole.admin, username="admin")
+    membership_lookup.return_value = None
     response = await teams.team_detail(team.id, _db(), admin)
-    assert response.role == "owner"
+    assert response.role is None
 
 
 @pytest.mark.asyncio
@@ -496,23 +512,28 @@ async def test_create_team_maps_namespace_and_database_conflicts_to_409(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_personal_invariants_repair_owner_and_remove_everyone_else():
+async def test_personal_invariants_repair_only_without_evicting_other_members():
     creator = _user()
     stranger = _user(username="stranger")
     team = _team(owner=creator, private=False, personal=True)
     creator_membership = _membership(team, creator, TeamRole.member)
     stranger_membership = _membership(team, stranger, TeamRole.owner)
-    database = _db(_Result(scalars=[creator_membership, stranger_membership]))
+    conflicted_db = _db(_Result(scalars=[creator_membership, stranger_membership]))
 
+    with pytest.raises(HTTPException) as exc:
+        await teams._ensure_personal_team_invariants(conflicted_db, team, creator)
+    _assert_http(exc, 409, "A personal teamspace cannot have other members")
+    conflicted_db.delete.assert_not_awaited()
+    conflicted_db.commit.assert_not_awaited()
+
+    database = _db(_Result(scalars=[creator_membership]))
     await teams._ensure_personal_team_invariants(database, team, creator)
-
     assert team.is_private is True
     assert creator_membership.role == TeamRole.owner
-    database.delete.assert_awaited_once_with(stranger_membership)
     database.commit.assert_awaited_once()
     assert database.execute.await_args.args[0]._for_update_arg is not None
 
-    missing_owner_db = _db(_Result(scalars=[stranger_membership]))
+    missing_owner_db = _db(_Result(scalars=[]))
     await teams._ensure_personal_team_invariants(missing_owner_db, team, creator)
     added = missing_owner_db.add.call_args.args[0]
     assert (added.team_id, added.user_id, added.role) == (team.id, creator.id, TeamRole.owner)
@@ -565,7 +586,7 @@ async def test_claim_personal_adopts_legacy_space(monkeypatch):
     legacy = _team(owner=creator, private=True, handle="legacy-team")
     legacy.description = teams._PERSONAL_TEAM_DESCRIPTION
     membership = _membership(legacy, creator, TeamRole.owner)
-    database = _db(_Result(one=None), _Result(one=legacy))
+    database = _db(_Result(one=None), _Result(one=legacy), _Result(scalars=[creator.id]))
     monkeypatch.setattr(teams, "team_membership", AsyncMock(return_value=membership))
     monkeypatch.setattr(teams, "_ensure_personal_team_invariants", AsyncMock())
     expected = teams.TeamResponse(
@@ -592,7 +613,12 @@ async def test_claim_personal_recovers_legacy_adoption_race(monkeypatch):
     legacy = _team(owner=creator, private=True, handle="legacy-team")
     legacy.description = teams._PERSONAL_TEAM_DESCRIPTION
     winner = _team(owner=creator, private=True, personal=True, handle="winner")
-    database = _db(_Result(one=None), _Result(one=legacy), _Result(one=winner))
+    database = _db(
+        _Result(one=None),
+        _Result(one=legacy),
+        _Result(scalars=[creator.id]),
+        _Result(one=winner),
+    )
     database.commit.side_effect = _integrity_error()
     monkeypatch.setattr(
         teams,
@@ -614,7 +640,12 @@ async def test_claim_personal_recovers_legacy_adoption_race(monkeypatch):
     database.rollback.assert_awaited_once()
     teams._ensure_personal_team_invariants.assert_awaited_once_with(database, winner, creator)
 
-    failed_db = _db(_Result(one=None), _Result(one=legacy), _Result(one=None))
+    failed_db = _db(
+        _Result(one=None),
+        _Result(one=legacy),
+        _Result(scalars=[creator.id]),
+        _Result(one=None),
+    )
     failed_db.commit.side_effect = _integrity_error()
     with pytest.raises(IntegrityError):
         await teams.claim_personal_teamspace(failed_db, creator)
@@ -739,6 +770,7 @@ async def test_update_team_persists_trimmed_fields(monkeypatch):
     team = _team(owner=actor)
     database = _db()
     monkeypatch.setattr(teams, "_require_owner_or_admin", AsyncMock(return_value=team))
+    monkeypatch.setattr(teams, "team_membership", AsyncMock(return_value=_membership(team, actor, TeamRole.owner)))
 
     response = await teams.update_team(
         team.id,
@@ -801,14 +833,16 @@ async def test_visibility_rejects_unauthorized_personal_and_owned_public_items(m
 
 
 @pytest.mark.asyncio
-async def test_visibility_change_revokes_invites_and_emits_audit_event(monkeypatch):
+async def test_public_visibility_change_creates_and_cancels_review_request(monkeypatch):
     admin = _user(role=UserRole.admin, username="admin")
     team = _team(private=True)
-    database = _db(_Result(rows=[]))
+    database = _db()
     monkeypatch.setattr(teams, "_load_team", AsyncMock(return_value=team))
     monkeypatch.setattr(teams, "team_membership", AsyncMock(return_value=None))
-    emitted = AsyncMock()
-    monkeypatch.setattr(teams, "emit_security_event", emitted)
+    requested = AsyncMock()
+    cancelled_notice = AsyncMock()
+    monkeypatch.setattr(teams.inbox_sources, "on_team_visibility_requested", requested)
+    monkeypatch.setattr(teams.inbox_sources, "on_team_visibility_cancelled", cancelled_notice)
 
     response = await teams.update_team_visibility(
         team.id,
@@ -816,41 +850,20 @@ async def test_visibility_change_revokes_invites_and_emits_audit_event(monkeypat
         database,
         admin,
     )
+    assert response.visibility == "private"
+    assert response.visibility_request_status == "pending"
+    assert team.visibility_requested_by == admin.id
+    requested.assert_awaited_once_with(database, team, requester_id=admin.id)
 
-    assert response.visibility == "public"
-    assert response.role == "owner"
-    statement = database.execute.await_args.args[0]
-    sql = _sql(statement)
-    assert "UPDATE team_invites" in sql
-    assert "team_invites.revoked_at IS NULL" in sql
-    event = emitted.await_args.args[0]
-    assert event.event_type == teams.EventType.TEAM_VISIBILITY_CHANGED
-    assert event.actor_id == str(admin.id)
-    assert event.target_id == str(team.id)
-    assert "is now public" in event.detail
-
-    emitted.reset_mock()
-    database.execute.reset_mock()
-    no_change = await teams.update_team_visibility(
-        team.id,
-        teams.TeamVisibilityUpdateRequest(visibility="public"),
-        database,
-        admin,
-    )
-    assert no_change.visibility == "public"
-    database.execute.assert_not_awaited()
-    emitted.assert_not_awaited()
-
-    monkeypatch.setattr(teams, "_team_owned_listing_counts", AsyncMock(return_value={}))
-    private_response = await teams.update_team_visibility(
+    cancelled = await teams.update_team_visibility(
         team.id,
         teams.TeamVisibilityUpdateRequest(visibility="private"),
         database,
         admin,
     )
-    assert private_response.visibility == "private"
-    database.execute.assert_not_awaited()
-    emitted.assert_awaited_once()
+    assert cancelled.visibility == "private"
+    assert team.visibility_request_status is None
+    cancelled_notice.assert_awaited_once_with(database, team, actor_id=admin.id)
 
 
 @pytest.mark.asyncio
@@ -871,28 +884,31 @@ async def test_owned_listing_counts_names_singular_plural_and_public_predicates(
     assert all("team_id" in _sql(call.args[0]) for call in database.scalar.await_args_list)
 
     public_db = _db()
-    public_db.scalar.side_effect = [0, 1, 0, 0, 0, 0]
+    public_db.scalar.side_effect = [0, 1, 0, 0, 0, 0, 2]
     public_counts = await teams._team_owned_listing_counts(public_db, team_id, public_only=True)
-    assert public_counts == {"MCP server": 1}
-    assert public_db.scalar.await_count == 6
-    assert all("is_private IS false" in _sql(call.args[0]) for call in public_db.scalar.await_args_list)
+    assert public_counts == {"MCP server": 1, "component sources": 2}
+    assert public_db.scalar.await_count == 7
+    statements = [_sql(call.args[0]) for call in public_db.scalar.await_args_list]
+    assert all("is_private IS false" in statement for statement in statements[:-1])
+    assert "is_public IS true" in statements[-1]
 
 
 @pytest.mark.asyncio
-async def test_delete_team_guards_personal_owned_and_constraint_races(monkeypatch):
+async def test_delete_team_allows_empty_personal_and_guards_owned_and_constraint_races(monkeypatch):
     actor = _user()
     team = _team(owner=actor)
     personal = _team(owner=actor, private=True, personal=True)
-    database = _db()
     require = AsyncMock(return_value=personal)
     monkeypatch.setattr(teams, "_require_owner_or_admin", require)
     counts = AsyncMock(return_value={})
     monkeypatch.setattr(teams, "_team_owned_listing_counts", counts)
 
-    with pytest.raises(HTTPException) as exc:
-        await teams.delete_team(personal.id, database, actor)
-    _assert_http(exc, 409, "Personal teamspaces cannot be deleted")
+    personal_db = _db()
+    await teams.delete_team(personal.id, personal_db, actor)
+    personal_db.delete.assert_awaited_once_with(personal)
+    personal_db.commit.assert_awaited_once()
 
+    database = _db()
     require.return_value = team
     counts.return_value = {"skills": 2, "agent": 1}
     with pytest.raises(HTTPException) as exc:
@@ -962,6 +978,8 @@ async def test_member_upsert_adds_changes_and_protects_last_owner(monkeypatch):
     target = _user(username="target")
     team = _team(owner=owner)
     database = _db()
+    database.execute.side_effect = None
+    database.execute.return_value = _Result(one=None)
     monkeypatch.setattr(teams, "_require_owner_or_admin", AsyncMock(return_value=team))
     monkeypatch.setattr(teams, "_resolve_member", AsyncMock(return_value=target))
     membership_lookup = AsyncMock(return_value=None)
@@ -1173,27 +1191,20 @@ async def test_create_and_list_invites_reject_ineligible_teamspaces(monkeypatch)
 async def test_revoke_invite_checks_scope_is_idempotent_and_serializes_inviter(monkeypatch):
     owner = _user(username="owner")
     team = _team(owner=owner, private=True)
-    other = _team(owner=owner, private=True)
     invite = _invite(team, owner)
-    database = _db()
     monkeypatch.setattr(teams, "_require_owner_or_admin", AsyncMock(return_value=team))
     emitted = AsyncMock()
     monkeypatch.setattr(teams, "_emit_team_invite_event", emitted)
     monkeypatch.setattr(teams, "_team_invite_response", MagicMock(return_value="response"))
 
-    database.get.return_value = None
+    missing_db = _db(_Result(one=None))
     with pytest.raises(HTTPException) as exc:
-        await teams.revoke_team_invite(team.id, invite.id, database, owner)
+        await teams.revoke_team_invite(team.id, invite.id, missing_db, owner)
     _assert_http(exc, 404, "Invite not found")
+    assert missing_db.execute.await_args.args[0]._for_update_arg is not None
 
-    invite.team_id = other.id
-    database.get.return_value = invite
-    with pytest.raises(HTTPException) as exc:
-        await teams.revoke_team_invite(team.id, invite.id, database, owner)
-    _assert_http(exc, 404, "Invite not found")
-
-    invite.team_id = team.id
-    database.get.side_effect = [invite, owner]
+    database = _db(_Result(one=invite))
+    database.get.return_value = owner
     assert await teams.revoke_team_invite(team.id, invite.id, database, owner) == "response"
     assert invite.revoked_at is not None
     database.commit.assert_awaited_once()
@@ -1202,7 +1213,7 @@ async def test_revoke_invite_checks_scope_is_idempotent_and_serializes_inviter(m
 
     database.commit.reset_mock()
     emitted.reset_mock()
-    database.get.side_effect = [invite, owner]
+    database.execute.side_effect = [_Result(one=invite)]
     await teams.revoke_team_invite(team.id, invite.id, database, owner)
     database.commit.assert_not_awaited()
     emitted.assert_not_awaited()
@@ -1260,7 +1271,7 @@ async def test_delete_invite_locks_row_retains_used_and_audits_unused(monkeypatc
     _assert_http(exc, 409, "Used invites are retained for audit")
 
     invite.use_count = 0
-    database = _db(_Result(one=invite))
+    database = _db(_Result(one=invite), _Result(one=None), _Result())
     await teams.delete_unused_team_invite(team.id, invite.id, database, owner)
     database.delete.assert_awaited_once_with(invite)
     database.commit.assert_awaited_once()
@@ -1388,7 +1399,7 @@ async def test_create_join_request_persists_invite_usage_inbox_and_audit(monkeyp
     row = database.add.call_args.args[0]
     assert row.message == "Please add me"
     assert row.invite_id == invite.id
-    assert invite.use_count == 1
+    assert invite.use_count == 0
     assert response.status == "pending"
     requested.assert_awaited_once_with(database, team, requester_id=actor.id, message="Please add me")
     database.commit.assert_awaited_once()
@@ -1398,12 +1409,7 @@ async def test_create_join_request_persists_invite_usage_inbox_and_audit(monkeyp
         actor,
         "Requested to join 'platform'",
     )
-    invite_event.assert_awaited_once_with(
-        teams.EventType.TEAM_INVITE_REDEEMED,
-        invite,
-        actor,
-        "Invite used to request access",
-    )
+    invite_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1489,6 +1495,21 @@ async def test_join_request_lists_apply_visibility_status_and_response_fields(mo
     unfiltered_db = _db(_Result(rows=[]))
     assert await teams.list_join_requests(team.id, None, unfiltered_db, owner) == []
     assert "team_membership_requests.status =" not in _sql(unfiltered_db.execute.await_args.args[0])
+
+
+@pytest.mark.asyncio
+async def test_approve_join_request_rejects_personal_team(monkeypatch):
+    owner = _user(username="owner")
+    team = _team(owner=owner, private=True, personal=True)
+    database = _db()
+    monkeypatch.setattr(teams, "_require_owner_or_admin", AsyncMock(return_value=team))
+    load = AsyncMock()
+    monkeypatch.setattr(teams, "_load_join_request", load)
+
+    with pytest.raises(HTTPException) as exc:
+        await teams.approve_join_request(team.id, uuid.uuid4(), database, owner)
+    _assert_http(exc, 409, "Personal teamspaces cannot approve join requests")
+    load.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1620,8 +1641,10 @@ async def test_cancel_join_request_enforces_requester_pending_state_and_persists
     team = _team()
     row = _join_request(team, requester)
     database = _db()
+    database.execute.side_effect = None
+    database.execute.return_value = _Result(one=row)
     monkeypatch.setattr(teams, "_load_team", AsyncMock(return_value=team))
-    monkeypatch.setattr(teams, "_load_join_request", AsyncMock(return_value=row))
+    monkeypatch.setattr(teams, "team_membership", AsyncMock(return_value=None))
     cancelled = AsyncMock()
     monkeypatch.setattr(teams.inbox_sources, "on_team_join_cancelled", cancelled)
 
@@ -1641,3 +1664,16 @@ async def test_cancel_join_request_enforces_requester_pending_state_and_persists
     assert row.decided_at is not None
     cancelled.assert_awaited_once_with(database, team, requester_id=requester.id)
     database.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_join_request_hides_private_team_from_non_requesters(monkeypatch):
+    outsider = _user(username="outsider")
+    team = _team(private=True)
+    database = _db(_Result(one=None))
+    monkeypatch.setattr(teams, "_load_team", AsyncMock(return_value=team))
+    monkeypatch.setattr(teams, "team_membership", AsyncMock(return_value=None))
+
+    with pytest.raises(HTTPException) as exc:
+        await teams.cancel_join_request(team.id, uuid.uuid4(), database, outsider)
+    _assert_http(exc, 404, "Team not found")

--- a/web/src/hooks/use-teams-api.ts
+++ b/web/src/hooks/use-teams-api.ts
@@ -9,13 +9,24 @@ import type { TeamMemberUpsertBody, TeamUpdateBody } from "@/lib/types";
 const JOIN_REQUESTS_KEY = (teamId: string | undefined) => ["teams", teamId, "join-requests"];
 
 const TEAMS_STALE_MS = 5 * 60 * 1000;
+const TEAM_REFRESH_MS = 10 * 1000;
 
 export function useTeams() {
-	return useQuery({ queryKey: ["teams"], queryFn: teams.list, staleTime: TEAMS_STALE_MS });
+	return useQuery({
+		queryKey: ["teams"],
+		queryFn: teams.list,
+		staleTime: TEAMS_STALE_MS,
+		refetchOnWindowFocus: "always",
+	});
 }
 
 export function useAllTeams() {
-	return useQuery({ queryKey: ["teams", "all"], queryFn: teams.listAll, staleTime: TEAMS_STALE_MS });
+	return useQuery({
+		queryKey: ["teams", "all"],
+		queryFn: teams.listAll,
+		staleTime: TEAMS_STALE_MS,
+		refetchOnWindowFocus: "always",
+	});
 }
 
 export function useTeam(id?: string) {
@@ -24,6 +35,8 @@ export function useTeam(id?: string) {
 		queryFn: () => teams.get(id || ""),
 		enabled: !!id,
 		staleTime: TEAMS_STALE_MS,
+		refetchInterval: TEAM_REFRESH_MS,
+		refetchOnWindowFocus: "always",
 	});
 }
 
@@ -42,6 +55,8 @@ export function useTeamByHandle(handle: string | undefined) {
 		queryFn: () => teams.byHandle(handle!),
 		enabled: !!handle,
 		staleTime: TEAMS_STALE_MS,
+		refetchInterval: TEAM_REFRESH_MS,
+		refetchOnWindowFocus: "always",
 		retry: (failureCount, error) =>
 			(error as Error & { status?: number }).status === 404 ? false : failureCount < 2,
 	});
@@ -61,6 +76,7 @@ export function useTeamMembers(teamId?: string, enabled = true) {
 		queryKey: ["teams", teamId, "members"],
 		queryFn: () => teams.members(teamId || ""),
 		enabled: !!teamId && enabled,
+		refetchOnWindowFocus: "always",
 	});
 }
 
@@ -68,9 +84,13 @@ export function useCreateTeam() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: teams.create,
-		onSuccess: () => {
+		onSuccess: (team) => {
 			qc.invalidateQueries({ queryKey: ["teams"] });
-			toast.success("Teamspace created");
+			toast.success(
+				team.visibility_request_status === "pending"
+					? "Public teamspace submitted for review"
+					: "Teamspace created",
+			);
 		},
 		onError: (err: Error) => toast.error(err.message || "Failed to create teamspace"),
 	});
@@ -110,12 +130,37 @@ export function useUpdateTeamVisibility(teamId?: string) {
 		onSuccess: (data) => {
 			qc.invalidateQueries({ queryKey: ["teams"] });
 			toast.success(
-				data.visibility === "private"
-					? "Teamspace is now private — hidden from non-members"
-					: "Teamspace is now public",
+				data.visibility_request_status === "pending"
+					? "Public visibility submitted for review"
+					: data.visibility === "private"
+						? "Teamspace is now private, hidden from non-members"
+						: "Teamspace is now public",
 			);
 		},
 		onError: (err: Error) => toast.error(err.message || "Failed to change visibility"),
+	});
+}
+
+export function useTeamVisibilityRequests() {
+	return useQuery({
+		queryKey: ["review", "team-visibility"],
+		queryFn: teams.visibilityRequests,
+		refetchInterval: TEAM_REFRESH_MS,
+		refetchOnWindowFocus: "always",
+	});
+}
+
+export function useDecideTeamVisibility() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: ({ id, approve, reason }: { id: string; approve: boolean; reason?: string }) =>
+			approve ? teams.approveVisibility(id) : teams.rejectVisibility(id, reason),
+		onSuccess: (_data, vars) => {
+			qc.invalidateQueries({ queryKey: ["review", "team-visibility"] });
+			qc.invalidateQueries({ queryKey: ["teams"] });
+			toast.success(vars.approve ? "Teamspace is now public" : "Public visibility rejected");
+		},
+		onError: (err: Error) => toast.error(err.message || "Failed to review teamspace visibility"),
 	});
 }
 
@@ -213,6 +258,8 @@ export function useTeamInvitePreview(token: string | undefined) {
 		queryKey: ["team-invite", token],
 		queryFn: () => teams.previewInvite(token || ""),
 		enabled: !!token,
+		refetchInterval: TEAM_REFRESH_MS,
+		refetchOnWindowFocus: "always",
 		retry: false,
 	});
 }
@@ -223,6 +270,7 @@ export function useJoinRequests(teamId: string | undefined, enabled = true) {
 		queryKey: JOIN_REQUESTS_KEY(teamId),
 		queryFn: () => teams.joinRequests(teamId || ""),
 		enabled: !!teamId && enabled,
+		refetchOnWindowFocus: "always",
 	});
 }
 
@@ -232,6 +280,7 @@ export function useMyJoinRequests(teamId: string | undefined, enabled = true) {
 		queryKey: ["teams", teamId, "join-requests", "mine"],
 		queryFn: () => teams.myJoinRequests(teamId || ""),
 		enabled: !!teamId && enabled,
+		refetchOnWindowFocus: "always",
 	});
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -77,6 +77,7 @@ import type {
 	TeamInvitePreview,
 	TeamJoinRequest,
 	TeamJoinRequestStatus,
+	TeamVisibilityRequest,
 	TeamMember,
 	TeamMemberUpsertBody,
 	TeamRole,
@@ -598,6 +599,10 @@ export const teams = {
 		put<Team>(`/teams/${id}`, body),
 	updateVisibility: (id: string, visibility: "public" | "private") =>
 		patch<Team>(`/teams/${id}/visibility`, { visibility }),
+	visibilityRequests: () => get<TeamVisibilityRequest[]>("/teams/visibility-requests"),
+	approveVisibility: (id: string) => post<Team>(`/teams/${id}/visibility-request/approve`),
+	rejectVisibility: (id: string, reason?: string) =>
+		post<Team>(`/teams/${id}/visibility-request/reject`, reason ? { reason } : {}),
 	delete: (id: string) => del(`/teams/${id}`),
 	members: (id: string) => get<TeamMember[]>(`/teams/${id}/members`),
 	upsertMember: (

--- a/web/src/lib/types/team.ts
+++ b/web/src/lib/types/team.ts
@@ -14,9 +14,21 @@ export interface Team {
 	description?: string | null;
 	visibility?: TeamVisibility;
 	is_personal?: boolean;
+	visibility_request_status?: "pending" | "approved" | "rejected" | null;
+	visibility_rejection_reason?: string | null;
 	role?: TeamRole | null;
 	member_count?: number | null;
 	created_at?: string;
+}
+
+export interface TeamVisibilityRequest {
+	team_id: string;
+	name: string;
+	handle: string;
+	description?: string | null;
+	requested_by: string | null;
+	requested_by_username?: string | null;
+	requested_at: string;
 }
 
 export interface TeamMember {
@@ -63,6 +75,7 @@ export interface TeamInviteCreated extends TeamInvite {
 export interface TeamInvitePreview {
 	valid: boolean;
 	invite_state?: TeamInviteState | null;
+	is_member: boolean;
 	team_id?: string | null;
 	team_name?: string | null;
 	team_handle?: string | null;

--- a/web/src/pages/admin/review.tsx
+++ b/web/src/pages/admin/review.tsx
@@ -7,15 +7,32 @@
 
 
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { CheckCircle2, LayoutGrid, TableProperties, Eye } from "lucide-react";
+import { Building2, CheckCircle2, LayoutGrid, TableProperties, Eye } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSearch } from "@tanstack/react-router";
-import { useReviewAgents, useReviewComponents, useReviewAction, useReviewSubscription } from "@/hooks/use-api";
+import {
+  useDecideTeamVisibility,
+  useReviewAgents,
+  useReviewComponents,
+  useReviewAction,
+  useReviewSubscription,
+  useTeamVisibilityRequests,
+} from "@/hooks/use-api";
 import { useAuthGuard } from "@/hooks/use-auth";
-import type { ReviewItem } from "@/lib/types";
+import type { ReviewItem, TeamVisibilityRequest } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { PageHeader } from "@/components/layouts/page-header";
 import { CardSkeleton, TableSkeleton } from "@/components/shared/skeleton-layouts";
 import { ErrorState } from "@/components/shared/error-state";
@@ -243,11 +260,13 @@ function ReviewItemList({
 }
 
 export default function ReviewPage() {
-  const { role } = useAuthGuard();
+  useAuthGuard();
   useReviewSubscription();
   const { data: agents, isLoading: agentsLoading, isError: agentsError, error: agentsErr, refetch: refetchAgents } = useReviewAgents();
   const { data: components, isLoading: componentsLoading, isError: componentsError, error: componentsErr, refetch: refetchComponents } = useReviewComponents();
+  const { data: teamspaces, isLoading: teamspacesLoading, isError: teamspacesError, error: teamspacesErr, refetch: refetchTeamspaces } = useTeamVisibilityRequests();
   const reviewAction = useReviewAction();
+  const teamspaceAction = useDecideTeamVisibility();
   const [view, setView] = useState<ViewMode>("grid");
   // ?tab= lets an inbox item open the tab that actually holds the submission it
   // names. Absent, the queue opens on agents as before.
@@ -262,10 +281,13 @@ export default function ReviewPage() {
   const [selectedItem, setSelectedItem] = useState<ReviewItem | null>(null);
   const [diffItem, setDiffItem] = useState<ReviewItem | null>(null);
   const [nestedDiffItem, setNestedDiffItem] = useState<ReviewItem | null>(null);
+  const [rejectTeamspace, setRejectTeamspace] = useState<TeamVisibilityRequest | null>(null);
+  const [teamspaceReason, setTeamspaceReason] = useState("");
 
   const agentCount = (agents ?? []).length;
   const componentCount = (components ?? []).length;
-  const totalPending = agentCount + componentCount;
+  const teamspaceCount = (teamspaces ?? []).length;
+  const totalPending = agentCount + componentCount + teamspaceCount;
 
   const handleApprove = useCallback(
     (id: string, type?: string, category?: string) => reviewAction.mutate({ id, type, action: "approve", category }),
@@ -329,7 +351,7 @@ export default function ReviewPage() {
         ]}
         actionButtonsRight={
           <div className="flex items-center gap-2">
-            {!agentsLoading && !componentsLoading && totalPending > 0 && (
+            {!agentsLoading && !componentsLoading && !teamspacesLoading && totalPending > 0 && (
               <Badge variant="secondary" className="text-xs">
                 {totalPending} pending
               </Badge>
@@ -365,6 +387,9 @@ export default function ReviewPage() {
             </TabsTrigger>
             <TabsTrigger value="components">
               Components{!componentsLoading ? ` (${componentCount})` : ""}
+            </TabsTrigger>
+            <TabsTrigger value="teamspaces">
+              Teamspaces{!teamspacesLoading ? ` (${teamspaceCount})` : ""}
             </TabsTrigger>
           </TabsList>
 
@@ -415,8 +440,115 @@ export default function ReviewPage() {
               />
             )}
           </TabsContent>
+
+          <TabsContent value="teamspaces">
+            {teamspacesLoading ? (
+              <CardSkeleton count={3} columns={3} />
+            ) : teamspacesError ? (
+              <ErrorState message={teamspacesErr?.message} onRetry={() => refetchTeamspaces()} />
+            ) : teamspaceCount === 0 ? (
+              <EmptyState
+                icon={CheckCircle2}
+                title="No teamspaces to review"
+                description="Public visibility requests will appear here."
+              />
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {(teamspaces ?? []).map((team: TeamVisibilityRequest) => (
+                  <div
+                    key={team.team_id}
+                    data-testid={`teamspace-review-${team.team_id}`}
+                    className="space-y-3 rounded-md border border-border bg-card p-4"
+                  >
+                    <div className="flex items-start gap-3">
+                      <Building2 className="mt-0.5 h-4 w-4 text-primary-accent" />
+                      <div className="min-w-0">
+                        <h3 className="truncate text-sm font-semibold">{team.name}</h3>
+                        <p className="font-mono text-xs text-muted-foreground">{team.handle}</p>
+                      </div>
+                    </div>
+                    {team.description && <p className="line-clamp-2 text-xs text-muted-foreground">{team.description}</p>}
+                    <p className="text-xs text-muted-foreground">
+                      Requested by {team.requested_by_username ? `@${team.requested_by_username}` : "a user"}
+                    </p>
+                    <div className="flex gap-2">
+                      <Button
+                        size="sm"
+                        className="flex-1"
+                        disabled={teamspaceAction.isPending}
+                        onClick={() => teamspaceAction.mutate({ id: team.team_id, approve: true })}
+                      >
+                        Approve
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="flex-1"
+                        disabled={teamspaceAction.isPending}
+                        onClick={() => setRejectTeamspace(team)}
+                      >
+                        Reject
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </TabsContent>
         </Tabs>
       </div>
+
+      <Dialog
+        open={!!rejectTeamspace}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRejectTeamspace(null);
+            setTeamspaceReason("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reject public visibility</DialogTitle>
+            <DialogDescription>
+              The teamspace stays private, and its owner can submit another request after making changes.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="teamspace-rejection-reason">Reason (optional)</Label>
+            <Textarea
+              id="teamspace-rejection-reason"
+              value={teamspaceReason}
+              maxLength={500}
+              onChange={(event) => setTeamspaceReason(event.target.value)}
+              placeholder="Explain what needs to change before this teamspace can become public."
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRejectTeamspace(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={teamspaceAction.isPending}
+              onClick={() => {
+                if (!rejectTeamspace) return;
+                teamspaceAction.mutate(
+                  { id: rejectTeamspace.team_id, approve: false, reason: teamspaceReason.trim() || undefined },
+                  {
+                    onSuccess: () => {
+                      setRejectTeamspace(null);
+                      setTeamspaceReason("");
+                    },
+                  },
+                );
+              }}
+            >
+              Reject request
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <ReviewDetailSheet
         item={selectedItem}

--- a/web/src/pages/registry/teamspace-detail.tsx
+++ b/web/src/pages/registry/teamspace-detail.tsx
@@ -431,7 +431,7 @@ function ReviewTab({
 			<EmptyState
 				icon={ClipboardCheck}
 				title="Nothing waiting on you"
-				description="Team-private submissions from this teamspace land here for its owners and reviewers. Anything published as public goes to the global review queue instead."
+				description="This teamspace's pending submissions appear here for its owners and reviewers. Public submissions also appear for global reviewers."
 			/>
 		);
 	}
@@ -554,11 +554,12 @@ function VisibilityControl({ team }: { team: Team }) {
 	const updateVisibility = useUpdateTeamVisibility(team.id);
 	if (!canChange) return null;
 	const isPrivate = team.visibility === "private";
+	const pending = team.visibility_request_status === "pending";
 	return (
 		<Button
 			variant="outline"
 			size="sm"
-			onClick={() => updateVisibility.mutate(isPrivate ? "public" : "private")}
+			onClick={() => updateVisibility.mutate(pending ? "private" : isPrivate ? "public" : "private")}
 			disabled={updateVisibility.isPending}
 			title={
 				isPrivate
@@ -571,7 +572,7 @@ function VisibilityControl({ team }: { team: Team }) {
 			) : (
 				<Lock className="mr-1.5 h-3.5 w-3.5" />
 			)}
-			{isPrivate ? "Make public" : "Make private"}
+			{pending ? "Cancel public request" : isPrivate ? "Request public" : "Make private"}
 		</Button>
 	);
 }
@@ -587,8 +588,7 @@ function requesterLabel(request: TeamJoinRequest): string {
  * path onto the roster.
  */
 function JoinRequestControl({ team }: { team: Team }) {
-	const isAdmin = hasMinRole(getUserRole(), "admin");
-	const eligible = !team.is_personal && !team.role && !isAdmin;
+	const eligible = !team.is_personal && !team.role;
 	const { data: mine = [] } = useMyJoinRequests(team.id, eligible);
 	const requestJoin = useRequestJoin(team.id);
 	const cancelRequest = useCancelJoinRequest(team.id);
@@ -1073,15 +1073,16 @@ export default function TeamspaceDetailPage() {
 	const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const [componentDialogOpen, setComponentDialogOpen] = useState(false);
+	const isAdmin = hasMinRole(getUserRole(), "admin");
 
-	const canReview = team?.role ? REVIEWING_TEAM_ROLES.includes(team.role) : false;
+	const visibilityPending = team?.visibility_request_status === "pending";
+	const canReview = !visibilityPending && (isAdmin || (team?.role ? REVIEWING_TEAM_ROLES.includes(team.role) : false));
 	const reviewQueue = useTeamReviewQueue(team?.id, canReview);
 	const reviewItems = reviewQueue.data ?? [];
 
 	// Membership requests are owners-and-admins only — a narrower audience than
 	// the listing Review tab, which team reviewers also see.
-	const canManageRequests =
-		!team?.is_personal && (team?.role === "owner" || hasMinRole(getUserRole(), "admin"));
+	const canManageRequests = !visibilityPending && !team?.is_personal && (team?.role === "owner" || isAdmin);
 	const canManageInvites = team?.visibility === "private" && canManageRequests;
 	const joinRequestsQuery = useJoinRequests(team?.id, canManageRequests);
 	const joinRequests = joinRequestsQuery.data ?? [];
@@ -1161,6 +1162,8 @@ export default function TeamspaceDetailPage() {
 
 	const isMember = Boolean(team.role);
 	const isOwner = team.role === "owner";
+	const canPublish = !visibilityPending && (isMember || (isAdmin && !team.is_personal));
+	const canDelete = isOwner || isAdmin;
 
 	return (
 		<>
@@ -1186,7 +1189,7 @@ export default function TeamspaceDetailPage() {
 									<span className="font-mono">{team.handle}</span>
 									<span aria-hidden="true">·</span>
 									<Badge variant="outline" className="px-1.5 py-0 text-[11px] font-medium capitalize">
-										{team.role ?? "discoverable"}
+										{team.role ?? (isAdmin ? "admin access" : "discoverable")}
 									</Badge>
 									{team.visibility === "private" && (
 										<Badge
@@ -1194,6 +1197,11 @@ export default function TeamspaceDetailPage() {
 											className="gap-1 border-primary-accent/40 px-1.5 py-0 text-[11px] font-medium text-primary-accent"
 										>
 											<Lock className="h-3 w-3" /> Private
+										</Badge>
+									)}
+									{team.visibility === "public" && team.visibility_request_status === "approved" && (
+										<Badge variant="outline" className="gap-1 px-1.5 py-0 text-[11px] font-medium text-success">
+											<ShieldCheck className="h-3 w-3" /> Public approved
 										</Badge>
 									)}
 									{team.member_count != null && <span>{team.member_count} members</span>}
@@ -1213,7 +1221,7 @@ export default function TeamspaceDetailPage() {
 							) : null}
 							<VisibilityControl team={team} />
 							<JoinRequestControl team={team} />
-							{isMember && !team.is_personal && (
+							{!visibilityPending && isMember && !team.is_personal && (
 								<Button
 									variant="outline"
 									size="sm"
@@ -1223,7 +1231,7 @@ export default function TeamspaceDetailPage() {
 									<LogOut className="mr-1.5 h-3.5 w-3.5" /> Leave
 								</Button>
 							)}
-							{isOwner && !team.is_personal && (
+							{canDelete && (
 								<Button variant="destructive" size="sm" onClick={() => setDeleteOpen(true)} disabled={deleteTeam.isPending}>
 									<Trash2 className="mr-1.5 h-3.5 w-3.5" /> Delete
 								</Button>
@@ -1231,7 +1239,26 @@ export default function TeamspaceDetailPage() {
 						</div>
 					</header>
 
-					<Tabs value={activeTab} onValueChange={(value) => goto({ tab: value })} className="mt-6">
+					{team.visibility_request_status === "pending" && (
+						<div className="mt-6 rounded-lg border border-warning/40 bg-warning/5 p-5">
+							<p className="text-sm font-semibold text-warning">Public visibility review pending</p>
+							<p className="mt-1 text-sm text-muted-foreground">
+								This teamspace is locked until a global reviewer approves or rejects the request.
+							</p>
+						</div>
+					)}
+					{team.visibility_request_status === "rejected" && (
+						<div className="mt-6 rounded-lg border border-destructive/40 bg-destructive/5 p-5">
+							<p className="text-sm font-semibold text-destructive">Public visibility request rejected</p>
+							{team.visibility_rejection_reason && (
+								<p className="mt-1 text-sm text-muted-foreground">{team.visibility_rejection_reason}</p>
+							)}
+						</div>
+					)}
+
+					{team.visibility_request_status !== "pending" && (
+						<>
+							<Tabs value={activeTab} onValueChange={(value) => goto({ tab: value })} className="mt-6">
 						<div className="flex items-center justify-between gap-3">
 							<TabsList>
 								{tabs.map((entry) => (
@@ -1251,14 +1278,14 @@ export default function TeamspaceDetailPage() {
 								))}
 							</TabsList>
 
-							{isMember && activeTab === "agents" && (
+							{canPublish && activeTab === "agents" && (
 								<Button asChild size="sm">
 									<Link to="/agents/builder" search={{ team: team.id }}>
 										<Bot /> Build agent
 									</Link>
 								</Button>
 							)}
-							{isMember && activeTab === "components" && (
+							{canPublish && activeTab === "components" && (
 								<Button size="sm" onClick={() => setComponentDialogOpen(true)}>
 									<Plus /> Create component
 								</Button>
@@ -1302,9 +1329,9 @@ export default function TeamspaceDetailPage() {
 								<InviteLinksTab team={team} />
 							</TabsContent>
 						)}
-					</Tabs>
+							</Tabs>
 
-					<footer className="mt-6 flex flex-col gap-3 rounded-lg border border-border/80 bg-card/70 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+							<footer className="mt-6 flex flex-col gap-3 rounded-lg border border-border/80 bg-card/70 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
 						<div className="flex items-start gap-2.5">
 							<Terminal className="mt-0.5 h-4 w-4 shrink-0 text-primary-accent" />
 							<div>
@@ -1317,7 +1344,9 @@ export default function TeamspaceDetailPage() {
 						<code className="rounded-md border border-border/80 bg-background px-3 py-2 font-mono text-xs text-foreground">
 							observal pull {team.handle}/agent-name
 						</code>
-					</footer>
+							</footer>
+						</>
+					)}
 				</div>
 			</main>
 
@@ -1347,7 +1376,7 @@ export default function TeamspaceDetailPage() {
 					<AlertDialogHeader>
 						<AlertDialogTitle>Delete {team.name}?</AlertDialogTitle>
 						<AlertDialogDescription>
-							This permanently removes the teamspace and its membership records. Published items are not deleted.
+							This permanently removes the empty teamspace and its membership records. Teamspaces that own registry items cannot be deleted.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/web/src/pages/registry/teamspaces.tsx
+++ b/web/src/pages/registry/teamspaces.tsx
@@ -11,8 +11,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { useAllTeams, useClaimPersonalTeamspace, useCreateTeam, useTeams } from "@/hooks/use-api";
+import { useAllTeams, useClaimPersonalTeamspace, useCreateTeam } from "@/hooks/use-api";
+import { hasMinRole } from "@/hooks/use-role-guard";
+import { getUserRole } from "@/lib/api";
 import { slugifyRegistryText } from "@/lib/registry-name";
+import { cn } from "@/lib/utils";
 import type { Team } from "@/lib/types";
 
 const CONTROL_CLASS_NAME =
@@ -23,7 +26,7 @@ function slugifyHandle(value: string) {
 	return base && base.length < 3 ? `${base}-team` : base;
 }
 
-function TeamspaceCard({ team }: { team: Team }) {
+function TeamspaceCard({ team, isAdmin }: { team: Team; isAdmin: boolean }) {
 	return (
 		<Link
 			to="/teamspaces/$handle"
@@ -51,8 +54,28 @@ function TeamspaceCard({ team }: { team: Team }) {
 			)}
 
 			<div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+				{team.visibility_request_status &&
+					(team.visibility_request_status !== "approved" || team.visibility === "public") && (
+					<Badge
+						variant="outline"
+						className={cn(
+							"px-1.5 py-0 text-[10px] font-medium",
+							team.visibility_request_status === "pending"
+								? "text-warning"
+								: team.visibility_request_status === "approved"
+									? "text-success"
+									: "text-destructive",
+						)}
+					>
+						{team.visibility_request_status === "pending"
+							? "Pending public review"
+							: team.visibility_request_status === "approved"
+								? "Public approved"
+								: "Public request rejected"}
+					</Badge>
+				)}
 				<Badge variant="outline" className="px-1.5 py-0 text-[10px] font-medium capitalize">
-					{team.role ?? "discoverable"}
+					{team.role ?? (isAdmin ? "admin access" : "discoverable")}
 				</Badge>
 				{team.member_count != null && (
 					<span className="inline-flex items-center gap-1">
@@ -227,12 +250,12 @@ function CreatePanel({
 										{
 											value: "public" as const,
 											title: "Public",
-											blurb: "Discoverable by every signed-in user; anyone can request to join.",
+											blurb: "Requires reviewer approval. The teamspace stays locked and private until approved.",
 										},
 										{
 											value: "private" as const,
 											title: "Private",
-											blurb: "Hidden from non-members. Admins and global reviewers still see it.",
+											blurb: "Hidden from non-members. Admins and super admins still see it.",
 										},
 									]
 								).map((option) => (
@@ -293,7 +316,7 @@ function CreatePanel({
 								disabled={!name.trim() || createTeam.isPending}
 							>
 								{createTeam.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-								Create teamspace
+								{visibility === "public" ? "Submit for review" : "Create teamspace"}
 							</Button>
 						</div>
 					</footer>
@@ -304,22 +327,19 @@ function CreatePanel({
 }
 
 export default function TeamspacesPage() {
-	const { data: teams = [], isLoading: isTeamsLoading } = useTeams();
-	const { data: allTeams = [], isLoading: isAllTeamsLoading } = useAllTeams();
+	const { data: teams = [], isLoading } = useAllTeams();
+	const isAdmin = hasMinRole(getUserRole(), "admin");
 	const [showCreate, setShowCreate] = useState(false);
 	const [teamQuery, setTeamQuery] = useState("");
 
-	const browse = teams.length === 0 ? allTeams : teams;
-	const isLoading = isTeamsLoading || (teams.length === 0 && isAllTeamsLoading);
 	const query = teamQuery.trim().toLowerCase();
-	const filteredTeams = browse.filter(
+	const filteredTeams = teams.filter(
 		(team) => !query || team.name.toLowerCase().includes(query) || team.handle.toLowerCase().includes(query),
 	);
 	// Any signed-in user can create a teamspace, so the first-run panel needs
 	// no role gate.
-	const firstTeamspace = !isLoading && browse.length === 0;
-	const personalClaimed = teams.some((team) => team.is_personal);
-	const listTitle = teams.length > 0 ? "Your teamspaces" : "Discover teamspaces";
+	const firstTeamspace = !isLoading && teams.length === 0;
+	const personalClaimed = teams.some((team) => team.is_personal && team.role === "owner");
 
 	return (
 		<>
@@ -337,14 +357,14 @@ export default function TeamspacesPage() {
 						<>
 							<header className="flex flex-col gap-4 border-b border-border/80 pb-5 sm:flex-row sm:items-end sm:justify-between">
 								<div>
-									<h2 className="text-xl font-semibold tracking-tight">{listTitle}</h2>
+									<h2 className="text-xl font-semibold tracking-tight">All visible teamspaces</h2>
 									<p className="mt-1 text-sm text-muted-foreground">
 										Shared publishing namespaces. Open one to browse its agents and components, manage members, and
 										clear its review queue.
 									</p>
 								</div>
 								<div className="flex items-center gap-2">
-									{browse.length > 0 && (
+									{teams.length > 0 && (
 										<div className="relative">
 											<Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
 											<Input
@@ -375,7 +395,7 @@ export default function TeamspacesPage() {
 										<div className="h-32 animate-pulse rounded-lg bg-muted/60" />
 										<div className="h-32 animate-pulse rounded-lg bg-muted/60" />
 									</div>
-								) : browse.length === 0 ? (
+								) : teams.length === 0 ? (
 									<EmptyState
 										icon={Users}
 										title="No teamspaces to browse"
@@ -385,12 +405,12 @@ export default function TeamspacesPage() {
 									<EmptyState
 										icon={Search}
 										title="No matching teamspaces"
-										description={`Nothing matches "${teamQuery.trim()}". Clear the search to see all ${browse.length}.`}
+										description={`Nothing matches "${teamQuery.trim()}". Clear the search to see all ${teams.length}.`}
 									/>
 								) : (
 									<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
 										{filteredTeams.map((team) => (
-											<TeamspaceCard key={team.id} team={team} />
+											<TeamspaceCard key={team.id} team={team} isAdmin={isAdmin} />
 										))}
 									</div>
 								)}

--- a/web/src/pages/user/inbox.tsx
+++ b/web/src/pages/user/inbox.tsx
@@ -4,7 +4,7 @@
 /**
  * The inbox, laid out as a notifications feed.
  *
- * The shape is deliberately GitHub's: a filter rail on the left, an
+ * The shape is deliberately GitHub's: a filter rail beside the feed, an
  * All/Unread split with search and sort above the list, and rows that carry
  * their subject, their reason and their age on one line. That layout is worth
  * copying because it solves the same problem — a long list of heterogeneous
@@ -365,7 +365,7 @@ function InboxRail({
 		b === "open" ? counts?.open : b === "done" ? counts?.done : counts?.dismissed;
 
 	return (
-		<aside className="hidden w-56 shrink-0 overflow-y-auto border-r p-2 md:block">
+		<aside data-testid="inbox-rail" className="hidden w-56 shrink-0 overflow-y-auto border-l p-2 md:block">
 			<nav className="space-y-0.5">
 				{BUCKETS.map((entry) => (
 					<RailRow
@@ -841,33 +841,7 @@ export default function InboxPage() {
 			    shell's own overflow-y-auto in place produces two nested scrollbars. */}
 			<DashboardContent className="min-h-0 overflow-hidden p-0">
 				<div className="flex h-full min-h-0">
-					<InboxRail
-						bucket={bucket}
-						kind={kind}
-						subjectType={subjectType}
-						actionOnly={actionOnly}
-						counts={counts}
-						onBucket={(b) => {
-							setBucket(b);
-							resetPage();
-						}}
-						onKind={(k) => {
-							setKind(k);
-							resetPage();
-						}}
-						onSubjectType={(t) => {
-							setSubjectType(t);
-							resetPage();
-						}}
-						onActionOnly={(v) => {
-							setActionOnly(v);
-							resetPage();
-						}}
-						onMarkAllRead={() => readAll.mutate(listFilters)}
-						markAllDisabled={readAll.isPending || items.length === 0}
-					/>
-
-					<div className="flex min-h-0 min-w-0 flex-1 flex-col">
+					<div data-testid="inbox-feed" className="flex min-h-0 min-w-0 flex-1 flex-col">
 						{/* Toolbar */}
 						<div className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
 							<div className="flex overflow-hidden rounded-md border">
@@ -1123,6 +1097,32 @@ export default function InboxPage() {
 							</div>
 						</div>
 					</div>
+
+					<InboxRail
+						bucket={bucket}
+						kind={kind}
+						subjectType={subjectType}
+						actionOnly={actionOnly}
+						counts={counts}
+						onBucket={(b) => {
+							setBucket(b);
+							resetPage();
+						}}
+						onKind={(k) => {
+							setKind(k);
+							resetPage();
+						}}
+						onSubjectType={(t) => {
+							setSubjectType(t);
+							resetPage();
+						}}
+						onActionOnly={(v) => {
+							setActionOnly(v);
+							resetPage();
+						}}
+						onMarkAllRead={() => readAll.mutate(listFilters)}
+						markAllDisabled={readAll.isPending || items.length === 0}
+					/>
 				</div>
 			</DashboardContent>
 

--- a/web/src/routes/_authed/_admin/review.tsx
+++ b/web/src/routes/_authed/_admin/review.tsx
@@ -6,7 +6,7 @@ import { lazy } from "react";
 const ReviewPage = lazy(() => import("@/pages/admin/review"));
 
 export type ReviewSearch = {
-  tab?: "agents" | "components";
+  tab?: "agents" | "components" | "teamspaces";
 };
 
 export const Route = createFileRoute("/_authed/_admin/review")({
@@ -15,6 +15,13 @@ export const Route = createFileRoute("/_authed/_admin/review")({
   // a component review always opened on the agents tab, which does not contain
   // it, and the link read as broken.
   validateSearch: (search: Record<string, unknown>): ReviewSearch => ({
-    tab: search.tab === "components" ? "components" : search.tab === "agents" ? "agents" : undefined,
+    tab:
+      search.tab === "components"
+        ? "components"
+        : search.tab === "teamspaces"
+          ? "teamspaces"
+          : search.tab === "agents"
+            ? "agents"
+            : undefined,
   }),
 });

--- a/web/src/routes/_authed/team-invites.$token.tsx
+++ b/web/src/routes/_authed/team-invites.$token.tsx
@@ -16,8 +16,9 @@ function TeamInvitePage() {
 	const requestJoin = useRequestJoin(teamId);
 	const cancelRequest = useCancelJoinRequest(teamId);
 	const request = preview.data?.request;
+	const isMember = preview.data?.is_member === true;
 
-	function requestAccess() {
+	function requestToJoin() {
 		requestJoin.mutate({ invite_token: token }, { onSuccess: () => preview.refetch() });
 	}
 
@@ -45,7 +46,7 @@ function TeamInvitePage() {
 					</div>
 				) : (
 					<div className="w-full max-w-lg rounded-lg border bg-card p-8 text-center shadow-sm">
-						{request?.status === "approved" ? (
+						{isMember ? (
 							<CheckCircle2 className="mx-auto h-10 w-10 text-success" />
 						) : request?.status === "pending" ? (
 							<Clock className="mx-auto h-10 w-10 text-primary-accent" />
@@ -59,32 +60,39 @@ function TeamInvitePage() {
 						{preview.data?.team_description && <p className="mt-4 text-sm text-muted-foreground">{preview.data.team_description}</p>}
 						{preview.data?.invited_by && <p className="mt-3 text-xs text-muted-foreground">Invited by {preview.data.invited_by}</p>}
 
-						{request?.status === "pending" ? (
+						{isMember ? (
 							<div className="mt-6 space-y-3">
-								<p className="text-sm text-primary-accent">Access requested. A teamspace owner must approve you.</p>
+								<p className="text-sm text-success">
+									{request?.status === "approved" ? "Join request approved. You are now a member." : "You are already a member."}
+								</p>
+								<Button asChild><Link to="/teamspaces/$handle" params={{ handle: preview.data?.team_handle ?? "" }}>Open teamspace</Link></Button>
+							</div>
+						) : request?.status === "pending" ? (
+							<div className="mt-6 space-y-3">
+								<p className="text-sm text-primary-accent">Join requested. A teamspace owner must approve you.</p>
 								<Button variant="outline" disabled={cancelRequest.isPending} onClick={withdrawRequest}>
 									{cancelRequest.isPending && <Loader2 className="animate-spin" />} Withdraw request
 								</Button>
 							</div>
 						) : request?.status === "approved" ? (
 							<div className="mt-6 space-y-3">
-								<p className="text-sm text-success">Access approved. You are now a member.</p>
-								<Button asChild><Link to="/teamspaces/$handle" params={{ handle: preview.data?.team_handle ?? "" }}>Open teamspace</Link></Button>
+								<p className="text-sm text-muted-foreground">You left this teamspace.</p>
+								{preview.data?.valid && <Button disabled={requestJoin.isPending} onClick={requestToJoin}>Request to join again</Button>}
 							</div>
 						) : request?.status === "rejected" ? (
 							<div className="mt-6 space-y-3">
-								<p className="text-sm text-destructive">Access request rejected.</p>
+								<p className="text-sm text-destructive">Join request rejected.</p>
 								{request.decision_reason && <p className="text-xs text-muted-foreground">{request.decision_reason}</p>}
-								{preview.data?.valid && <Button disabled={requestJoin.isPending} onClick={requestAccess}>Request access again</Button>}
+								{preview.data?.valid && <Button disabled={requestJoin.isPending} onClick={requestToJoin}>Request to join again</Button>}
 							</div>
 						) : request?.status === "cancelled" ? (
 							<div className="mt-6 space-y-3">
-								<p className="text-sm text-muted-foreground">You withdrew this access request.</p>
-								{preview.data?.valid && <Button disabled={requestJoin.isPending} onClick={requestAccess}>Request access again</Button>}
+								<p className="text-sm text-muted-foreground">You withdrew this join request.</p>
+								{preview.data?.valid && <Button disabled={requestJoin.isPending} onClick={requestToJoin}>Request to join again</Button>}
 							</div>
 						) : (
-							<Button className="mt-6" disabled={requestJoin.isPending} onClick={requestAccess}>
-								{requestJoin.isPending && <Loader2 className="animate-spin" />} Request access
+							<Button className="mt-6" disabled={requestJoin.isPending} onClick={requestToJoin}>
+								{requestJoin.isPending && <Loader2 className="animate-spin" />} Request to join
 							</Button>
 						)}
 					</div>


### PR DESCRIPTION
## Purpose / Description

Fix the teamspace lifecycle so discovery, membership state, join requests, and personal teamspace deletion follow the same policy across the API and web UI.

The previous behavior hid public teamspaces after a user joined or claimed one, represented every deployment admin as a team owner, hid the join action while showing Leave to admin nonmembers, and blocked deletion of every personal teamspace even when empty.

## Fixes

* No linked issue. The defects were reported directly during active development.

## Approach

* Use the complete visible teamspace list for browsing instead of switching to membership-only results.
* Keep deployment administration and actual team membership separate. API `role` fields now report only real memberships, while the UI gates admin capabilities independently.
* Show Request to join to all eligible nonmembers and show Leave only to actual members.
* Keep private teamspaces hidden from normal nonmembers while preserving the signed invite request flow. Admin and super admin visibility remains unrestricted.
* Allow empty personal teamspaces to be deleted through the existing ownership and registry-item safety checks.
* Return current membership on invite previews so a user who leaves an approved private team can request to join again instead of seeing stale member status.
* Refuse personal-team conversion when other members exist and reject approvals against personal teamspaces.
* Count invite uses only when membership is approved, preserve reusable rejected or withdrawn links, and serialize the final use with a PostgreSQL row lock.
* Reconcile pending requests when an owner adds a member directly and reject pending public requests when a team becomes private.
* Refresh team access on focus and at a short interval so approval and revocation propagate across users and tabs.
* Return uniform not-found responses when unauthorized callers probe private request cancellation.
* Add a table-driven lifecycle matrix covering user, reviewer, admin, and super admin tiers across public, private, and personal teamspaces.

## How Has This Been Tested?

* `HOME="$(mktemp -d)" make test`: 8,286 passed, 21 skipped.
* `make lint`: passed.
* `pnpm -F web typecheck`: passed.
* `pnpm -F web lint`: passed.
* Changed-file pre-commit hooks: passed.
* `CI=1 PLAYWRIGHT_HTML_OPEN=never pnpm exec playwright test shareable-links.spec.ts` from `web/`: 23 passed.
* `make rebuild-fast`: passed and the API health check reported PostgreSQL, ClickHouse, and Redis healthy.

The lifecycle tests cover public and private creation, personal claims, safe legacy conversion, list and detail visibility, actual membership serialization, direct and invite-backed join requests, duplicate member requests, nonmember exits, member and team-reviewer exits, sole-owner protection, multi-owner exits, personal leave denial, empty personal deletion and replacement, occupied personal deletion, discovery after joining, discovery after leaving, private rejoin after an approved member leaves, direct members opening invite links, invalid invite privacy, privileged personal-team controls, invite revocation when a team becomes public, pending requests across both visibility transitions, team deletion with a pending request, cross-user and cross-tab access refresh, concurrent final invite use on PostgreSQL, direct-member reconciliation, personal-team approval rejection, and private cancellation privacy.

The expanded browser run found additional lifecycle defects: an approved private invite still claimed the user was a member after they left, cached access survived membership changes in other tabs, and invite capacity was consumed before membership approval. Invite previews now use current membership, team access refreshes promptly, and invite capacity is consumed atomically at approval. The regressions pass in the 23-case suite.

The repository-wide Playwright command is blocked before discovery by an existing syntax error in `tests/e2e/review-diff-screenshots.spec.ts:38`. The separate `teamspace-review.spec.ts` also cannot authenticate its expected pre-seeded `f3.*@demo.example` fixtures on the default rebuilt stack, so its six cases stop at setup rather than product assertions.

Full `make check` also reaches three existing repository-wide failures unrelated to this change: end-of-file normalization for `.coderabbit.yaml` and `tests/fixtures/fake_api_keys.json`, the fake key fixture in `tests/test_encryption_fake_keys.py`, and existing Dockerfile hadolint findings. All hooks pass when scoped to the files changed by this pull request.

UI screenshots are not attached because they were not requested during this run. The human author will add them before merge.

## Learning (optional, can help others)

Deployment role and team membership are independent permissions. An admin may manage, inspect, and publish into a non-personal teamspace without being a member, so membership-derived UI such as Leave must never be inferred from global administration rights. Cross-team admin publishing is an existing explicit server policy and remains review-gated.

No external libraries or resources were added.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

Screenshot applicability: this pull request changes teamspace list, detail, and invite strings. The human author will add the required screenshots before merge.

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes(Please Specify the tool): OpenAI coding assistant through pi. The model version was not exposed in the session environment.
- [ ] Was the generated code manually reviewed and tested?

Automated tests and assistant self-review are complete. Human author review remains required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public teamspace visibility now requires administrator review, with approval, rejection, and status messaging.
  - Team owners and reviewers can manage content decisions after visibility approval.
  - Teamspace listings include personal, private, and public spaces with clearer access indicators.
  - Invitations show membership status and support renewed join requests.
  - Inbox filters now appear on the right.

- **Bug Fixes**
  - Improved join requests, invitations, membership roles, publishing, and deletion workflows.
  - Empty personal teamspaces can be deleted while protected spaces remain restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->