### PR TITLE
refactor(cli)!: standardize help examples

### DIFF
--- a/docs/registry-hook-helper.md
+++ b/docs/registry-hook-helper.md
@@ -60,10 +60,10 @@ Use blocking only when the hook must stop unsafe behavior. Use async for logging
 
 ## CLI example
 
-Run the submit command with the example flag to print ready-to-edit examples:
+Submit a hook from a JSON file like the examples above:
 
 ```bash
-observal registry hook submit --example
+observal registry hook submit --from-file hook.json
 ```
 
 ## Sources

--- a/docs/registry-mcp-helper.md
+++ b/docs/registry-mcp-helper.md
@@ -62,10 +62,10 @@ Use either command plus args for stdio, or URL for remote MCP. Do not put secret
 
 ## CLI example
 
-Run the submit command with the example flag to print a ready-to-edit payload:
+Paste a configuration like the examples above into the submit command:
 
 ```bash
-observal registry mcp submit --example
+observal registry mcp submit
 ```
 
 ## Sources

--- a/docs/registry-sandbox-helper.md
+++ b/docs/registry-sandbox-helper.md
@@ -113,10 +113,10 @@ docker build -t ghcr.io/acme/python-pytest:1.0.0 .
 
 ## CLI example
 
-Run the submit command with the example flag to print ready-to-edit examples:
+Submit a sandbox from a JSON file like the examples above:
 
 ```bash
-observal registry sandbox submit --example
+observal registry sandbox submit --from-file sandbox.json
 ```
 
 ## Sources

--- a/docs/registry-skill-helper.md
+++ b/docs/registry-skill-helper.md
@@ -50,10 +50,10 @@ Reference supporting files from `SKILL.md` only when they are useful. Keep the m
 
 ## CLI example
 
-Run the submit command with the example flag to print ready-to-edit examples:
+Submit a skill directly from its `SKILL.md` file:
 
 ```bash
-observal registry skill submit --example
+observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo
 ```
 
 ## Sources

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -101,7 +101,15 @@ def _save_agent_yaml(directory: Path, data: dict) -> None:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
 
-agent_app = typer.Typer(help="Agent registry commands")
+agent_app = typer.Typer(
+    help=(
+        "Agent registry commands\n\n"
+        "Examples:\n"
+        "  observal agent list\n"
+        "  observal agent show my-agent\n"
+        "  observal agent pull my-agent --harness claude-code"
+    )
+)
 
 
 @agent_app.command(name="create")
@@ -465,10 +473,7 @@ def agent_list(
     Examples:
       observal agent list
       observal agent list --search my-agent
-      observal agent list --page 2 --limit 20
-      observal agent list --interactive
       observal agent list --output json
-      observal agent list --full-id
     """
     params: dict = {"limit": limit, "offset": (page - 1) * limit}
     if search:
@@ -600,7 +605,6 @@ def agent_show(
 
     Examples:
       observal agent show my-agent
-      observal agent show 3
       observal agent show @myalias
       observal agent show a1b2c3d4-... --output json
     """
@@ -664,7 +668,6 @@ def agent_install(
 
     Examples:
       observal agent install my-agent --harness claude-code
-      observal agent install my-agent --harness kiro
       observal agent install my-agent --harness cursor --raw > config.json
       observal agent install @myalias --harness opencode
     """
@@ -742,6 +745,10 @@ def agent_archive(
 
     Marks the agent as archived. It will no longer appear in public
     listings but can be restored with the unarchive command.
+
+    Examples:
+      observal agent archive my-agent
+      observal agent archive my-agent --yes
     """
     _archive_agent(agent_id, yes)
 
@@ -751,7 +758,12 @@ def agent_delete(
     agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
 ):
-    """Archive an agent. Prefer the archive command."""
+    """Archive an agent. Prefer the archive command.
+
+    Examples:
+      observal agent delete my-agent
+      observal agent delete my-agent --yes
+    """
     _archive_agent(agent_id, yes)
 
 
@@ -1002,7 +1014,6 @@ def agent_publish(
       observal agent publish
       observal agent publish --update
       observal agent publish --draft
-      observal agent publish --dir /tmp/my-agent
     """
     if draft and submit:
         rprint(

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -106,8 +106,8 @@ agent_app = typer.Typer(
         "Agent registry commands\n\n"
         "Examples:\n"
         "  observal agent list\n"
-        "  observal agent show my-agent\n"
-        "  observal agent pull my-agent --harness claude-code"
+        "  observal agent show alice/my-agent\n"
+        "  observal agent pull alice/my-agent --harness claude-code"
     )
 )
 
@@ -747,8 +747,8 @@ def agent_archive(
     listings but can be restored with the unarchive command.
 
     Examples:
-      observal agent archive my-agent
-      observal agent archive my-agent --yes
+      observal agent archive alice/my-agent
+      observal agent archive alice/my-agent --yes
     """
     _archive_agent(agent_id, yes)
 
@@ -761,8 +761,8 @@ def agent_delete(
     """Archive an agent. Prefer the archive command.
 
     Examples:
-      observal agent delete my-agent
-      observal agent delete my-agent --yes
+      observal agent delete alice/my-agent
+      observal agent delete alice/my-agent --yes
     """
     _archive_agent(agent_id, yes)
 

--- a/observal_cli/cmd_archive.py
+++ b/observal_cli/cmd_archive.py
@@ -17,6 +17,13 @@ _ENTITY_LABELS = {
     "prompts": "prompt",
     "sandboxes": "sandbox",
 }
+_COMMAND_NAMES = {
+    "mcps": "mcp",
+    "skills": "skill",
+    "hooks": "hook",
+    "prompts": "prompt",
+    "sandboxes": "sandbox",
+}
 
 
 def _archive_component(entity_type: str, entity_id: str, yes: bool) -> None:
@@ -42,18 +49,30 @@ def _unarchive_component(entity_type: str, entity_id: str, yes: bool) -> None:
 
 
 def add_archive_commands(app: typer.Typer, entity_type: str) -> None:
-    @app.command(name="archive")
+    command = _COMMAND_NAMES[entity_type]
+
     def archive(
         entity_id: str = typer.Argument(help="Entity UUID or name"),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
     ):
-        """Archive this component."""
         _archive_component(entity_type, entity_id, yes)
 
-    @app.command(name="unarchive")
+    archive.__doc__ = f"""Archive this component.
+
+    Examples:
+      observal registry {command} archive my-component
+    """
+    app.command(name="archive")(archive)
+
     def unarchive(
         entity_id: str = typer.Argument(help="Entity UUID or name"),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
     ):
-        """Restore an archived component."""
         _unarchive_component(entity_type, entity_id, yes)
+
+    unarchive.__doc__ = f"""Restore an archived component.
+
+    Examples:
+      observal registry {command} unarchive my-component
+    """
+    app.command(name="unarchive")(unarchive)

--- a/observal_cli/cmd_archive.py
+++ b/observal_cli/cmd_archive.py
@@ -60,7 +60,7 @@ def add_archive_commands(app: typer.Typer, entity_type: str) -> None:
     archive.__doc__ = f"""Archive this component.
 
     Examples:
-      observal registry {command} archive my-component
+      observal registry {command} archive alice/my-component
     """
     app.command(name="archive")(archive)
 
@@ -73,6 +73,6 @@ def add_archive_commands(app: typer.Typer, entity_type: str) -> None:
     unarchive.__doc__ = f"""Restore an archived component.
 
     Examples:
-      observal registry {command} unarchive my-component
+      observal registry {command} unarchive alice/my-component
     """
     app.command(name="unarchive")(unarchive)

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -37,11 +37,25 @@ from observal_shared.namespace_rules import NAMESPACE_RULE_TEXT, is_valid_namesp
 
 auth_app = typer.Typer(
     name="auth",
-    help="Authentication and account commands",
+    help=(
+        "Authentication and account commands\n\n"
+        "Examples:\n"
+        "  observal auth login\n"
+        "  observal auth whoami\n"
+        "  observal auth logout"
+    ),
     no_args_is_help=True,
 )
 
-config_app = typer.Typer(help="CLI configuration")
+config_app = typer.Typer(
+    help=(
+        "CLI configuration\n\n"
+        "Examples:\n"
+        "  observal config show\n"
+        "  observal config set output json\n"
+        "  observal config path"
+    )
+)
 
 
 # ── Auth commands (registered on auth_app) ──────────────────
@@ -151,9 +165,7 @@ def login(
     Examples:
         observal auth login
         observal auth login --server http://observal.internal:80
-        observal auth login -e admin@example.com -p 'MyP@ss1234!'
         observal auth login --sso
-        observal auth login --saml
     """
     welcome_banner()
 

--- a/observal_cli/cmd_co_authors.py
+++ b/observal_cli/cmd_co_authors.py
@@ -58,7 +58,7 @@ def make_co_authors_typer(entity_type: str) -> typer.Typer:
         "sandboxes": "registry sandbox",
     }[entity_type]
     prefix = f"observal {command} co-authors"
-    co_app = typer.Typer(help=f"Manage co-authors for {entity_type}\n\nExamples:\n  {prefix} list my-component")
+    co_app = typer.Typer(help=f"Manage co-authors for {entity_type}\n\nExamples:\n  {prefix} list alice/my-component")
 
     def list_cmd(
         entity_id: str = typer.Argument(help="Entity UUID or name"),
@@ -68,7 +68,7 @@ def make_co_authors_typer(entity_type: str) -> typer.Typer:
     list_cmd.__doc__ = f"""List co-authors.
 
     Examples:
-      {prefix} list my-component
+      {prefix} list alice/my-component
     """
     co_app.command(name="list")(list_cmd)
 
@@ -81,7 +81,7 @@ def make_co_authors_typer(entity_type: str) -> typer.Typer:
     add_cmd.__doc__ = f"""Add a co-author.
 
     Examples:
-      {prefix} add my-component alice@example.com
+      {prefix} add alice/my-component alice@example.com
     """
     co_app.command(name="add")(add_cmd)
 
@@ -94,7 +94,7 @@ def make_co_authors_typer(entity_type: str) -> typer.Typer:
     remove_cmd.__doc__ = f"""Remove a co-author.
 
     Examples:
-      {prefix} remove my-component 550e8400-e29b-41d4-a716-446655440000
+      {prefix} remove alice/my-component 550e8400-e29b-41d4-a716-446655440000
     """
     co_app.command(name="remove")(remove_cmd)
 

--- a/observal_cli/cmd_co_authors.py
+++ b/observal_cli/cmd_co_authors.py
@@ -49,29 +49,53 @@ def _remove_co_author(entity_type: str, entity_id: str, user_id: str) -> None:
 
 def make_co_authors_typer(entity_type: str) -> typer.Typer:
     """Create a co-authors sub-typer for a given entity type (agents, mcps, skills, etc.)."""
-    co_app = typer.Typer(help=f"Manage co-authors for {entity_type}")
+    command = {
+        "agents": "agent",
+        "mcps": "registry mcp",
+        "skills": "registry skill",
+        "hooks": "registry hook",
+        "prompts": "registry prompt",
+        "sandboxes": "registry sandbox",
+    }[entity_type]
+    prefix = f"observal {command} co-authors"
+    co_app = typer.Typer(help=f"Manage co-authors for {entity_type}\n\nExamples:\n  {prefix} list my-component")
 
-    @co_app.command(name="list")
     def list_cmd(
         entity_id: str = typer.Argument(help="Entity UUID or name"),
     ):
-        """List co-authors."""
         _list_co_authors(entity_type, entity_id)
 
-    @co_app.command(name="add")
+    list_cmd.__doc__ = f"""List co-authors.
+
+    Examples:
+      {prefix} list my-component
+    """
+    co_app.command(name="list")(list_cmd)
+
     def add_cmd(
         entity_id: str = typer.Argument(help="Entity UUID or name"),
         user: str = typer.Argument(help="Email or username of the user to add"),
     ):
-        """Add a co-author."""
         _add_co_author(entity_type, entity_id, user)
 
-    @co_app.command(name="remove")
+    add_cmd.__doc__ = f"""Add a co-author.
+
+    Examples:
+      {prefix} add my-component alice@example.com
+    """
+    co_app.command(name="add")(add_cmd)
+
     def remove_cmd(
         entity_id: str = typer.Argument(help="Entity UUID or name"),
         user_id: str = typer.Argument(help="UUID of the co-author to remove"),
     ):
-        """Remove a co-author."""
         _remove_co_author(entity_type, entity_id, user_id)
+
+    remove_cmd.__doc__ = f"""Remove a co-author.
+
+    Examples:
+      {prefix} remove my-component 550e8400-e29b-41d4-a716-446655440000
+    """
+    co_app.command(name="remove")(remove_cmd)
 
     return co_app

--- a/observal_cli/cmd_component.py
+++ b/observal_cli/cmd_component.py
@@ -41,7 +41,12 @@ component_app = typer.Typer(
 )
 
 version_app = typer.Typer(
-    help="Manage component versions",
+    help=(
+        "Manage component versions\n\n"
+        "Examples:\n"
+        "  observal registry version list mcp my-server\n"
+        "  observal registry version publish mcp my-server --version 2.0.0 --description 'Breaking change'"
+    ),
     no_args_is_help=True,
 )
 
@@ -86,11 +91,9 @@ def version_publish(
 
     \b
     Examples:
-      observal component version publish mcp my-server -v 2.0.0 -d "Breaking change"
-      observal component version publish hook guard-hook -v 1.1.0 -d "Add timeout" --changelog "Fixed race"
-      observal component version publish skill my-skill -v 1.0.0 -d "Initial" --harness claude-code --harness cursor
-      observal component version publish mcp analyzer --extra '{"transport": "http"}' -d "HTTP support"
-      observal registry version publish sandbox py -v 1.1.0 -d "Python 3.12" --extra '{"runtime_type":"docker","image":"python:3.12-slim","resource_limits":{"timeout":60}}'
+      observal registry version publish mcp my-server -v 2.0.0 -d "Breaking change"
+      observal registry version publish hook guard-hook -v 1.1.0 -d "Add timeout" --changelog "Fixed race"
+      observal registry version publish skill my-skill -v 1.0.0 -d "Initial" --harness claude-code
     """
     optic.trace("component_type={}", component_type)
     _require_valid_type(component_type)
@@ -164,9 +167,9 @@ def version_list(
 
     \b
     Examples:
-      observal component version list mcp my-server
-      observal component version list hook guard-hook --output json
-      observal component version list skill @my-skill-alias
+      observal registry version list mcp my-server
+      observal registry version list hook guard-hook --output json
+      observal registry version list skill @my-skill-alias
     """
     _require_valid_type(component_type)
 

--- a/observal_cli/cmd_component.py
+++ b/observal_cli/cmd_component.py
@@ -44,8 +44,8 @@ version_app = typer.Typer(
     help=(
         "Manage component versions\n\n"
         "Examples:\n"
-        "  observal registry version list mcp my-server\n"
-        "  observal registry version publish mcp my-server --version 2.0.0 --description 'Breaking change'"
+        "  observal registry version list mcp alice/my-server\n"
+        "  observal registry version publish mcp alice/my-server --version 2.0.0 --description 'Breaking change'"
     ),
     no_args_is_help=True,
 )
@@ -91,9 +91,9 @@ def version_publish(
 
     \b
     Examples:
-      observal registry version publish mcp my-server -v 2.0.0 -d "Breaking change"
-      observal registry version publish hook guard-hook -v 1.1.0 -d "Add timeout" --changelog "Fixed race"
-      observal registry version publish skill my-skill -v 1.0.0 -d "Initial" --harness claude-code
+      observal registry version publish mcp alice/my-server -v 2.0.0 -d "Breaking change"
+      observal registry version publish hook alice/guard-hook -v 1.1.0 -d "Add timeout" --changelog "Fixed race"
+      observal registry version publish skill alice/my-skill -v 1.0.0 -d "Initial" --harness claude-code
     """
     optic.trace("component_type={}", component_type)
     _require_valid_type(component_type)
@@ -167,8 +167,8 @@ def version_list(
 
     \b
     Examples:
-      observal registry version list mcp my-server
-      observal registry version list hook guard-hook --output json
+      observal registry version list mcp alice/my-server
+      observal registry version list hook alice/guard-hook --output json
       observal registry version list skill @my-skill-alias
     """
     _require_valid_type(component_type)

--- a/observal_cli/cmd_doctor.py
+++ b/observal_cli/cmd_doctor.py
@@ -41,7 +41,15 @@ from observal_cli.shared.utils import (
 )
 from observal_shared.harness_registry import get_valid_harnesses
 
-doctor_app = typer.Typer(help="Diagnose and patch harness settings for Observal telemetry")
+doctor_app = typer.Typer(
+    help=(
+        "Diagnose and patch harness settings for Observal telemetry\n\n"
+        "Examples:\n"
+        "  observal doctor\n"
+        "  observal doctor patch --all-harnesses\n"
+        "  observal doctor cleanup --harness claude-code --dry-run"
+    )
+)
 
 
 # ── Helpers ──────────────────────────────────────────────────
@@ -707,10 +715,9 @@ def doctor_cleanup(
 
     \b
     Examples:
-      observal doctor cleanup                          # Clean all supported harnesses
-      observal doctor cleanup --harness claude-code        # Claude Code only
-      observal doctor cleanup --harness kiro               # Kiro only
-      observal doctor cleanup --harness claude-code --dry-run  # Preview without changes
+      observal doctor cleanup
+      observal doctor cleanup --harness claude-code
+      observal doctor cleanup --harness claude-code --dry-run
     """
     optic.trace("harness={}, exclude={}, dry_run={}", harness, exclude, dry_run)
     targets = [harness] if harness else get_valid_harnesses()

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -41,8 +41,8 @@ hook_app = typer.Typer(
         "Hook registry commands\n\n"
         "Examples:\n"
         "  observal registry hook list\n"
-        "  observal registry hook show my-hook\n"
-        "  observal registry hook install my-hook --harness claude-code"
+        "  observal registry hook show alice/my-hook\n"
+        "  observal registry hook install alice/my-hook --harness claude-code"
     )
 )
 

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -36,7 +36,15 @@ from observal_cli.render import (
     status_badge,
 )
 
-hook_app = typer.Typer(help="Hook registry commands")
+hook_app = typer.Typer(
+    help=(
+        "Hook registry commands\n\n"
+        "Examples:\n"
+        "  observal registry hook list\n"
+        "  observal registry hook show my-hook\n"
+        "  observal registry hook install my-hook --harness claude-code"
+    )
+)
 
 
 def register_hook(app: typer.Typer):
@@ -50,38 +58,6 @@ HOOK_TIMEOUT_CAPS: dict[str, int] = {
     "sync": 10,
     "async": 60,
 }
-
-
-def _print_hook_examples() -> None:
-    output_json(
-        {
-            "command_hook": {
-                "name": "block-rm",
-                "version": "1.0.0",
-                "description": "Block destructive shell commands before they run",
-                "owner": "your-team",
-                "event": "PreToolUse",
-                "handler_type": "command",
-                "handler_config": {"command": "./hooks/block-rm.sh", "timeout": 10},
-                "execution_mode": "blocking",
-                "scope": "agent",
-                "source_url": "https://github.com/acme/agent-hooks",
-                "source_ref": "main",
-                "source_path": "hooks/security",
-            },
-            "http_hook": {
-                "name": "audit-bash",
-                "version": "1.0.0",
-                "description": "Send Bash tool calls to an audit endpoint",
-                "owner": "your-team",
-                "event": "PreToolUse",
-                "handler_type": "http",
-                "handler_config": {"url": "https://hooks.example.com/pre-tool-use", "timeout": 10},
-                "execution_mode": "sync",
-                "scope": "session",
-            },
-        }
-    )
 
 
 def _validate_timeout(execution_mode: str, handler_config: dict) -> None:
@@ -119,7 +95,6 @@ def hook_submit(
     execution_mode: str | None = typer.Option(None, "--execution-mode", help="async, sync, or blocking"),
     scope: str | None = typer.Option(None, "--scope", help="agent, session, or global"),
     supported_harnesses: list[str] | None = typer.Option(None, "--harness", help="Supported harness (repeatable)"),
-    example: bool = typer.Option(False, "--example", help="Print example hook payloads and exit"),
     team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
     visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
@@ -128,14 +103,10 @@ def hook_submit(
     Only submit hooks you created or are the point-of-contact for.
 
     Examples:
-      observal registry hook submit
       observal registry hook submit --script ./protect-files.sh
       observal registry hook submit --source-url https://github.com/org/hooks --source-path hooks/guard/
       observal registry hook submit --from-file hook.json
     """
-    if example:
-        _print_hook_examples()
-        return
     rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     if draft and submit_draft:
         rprint(
@@ -317,7 +288,6 @@ def hook_list(
       observal registry hook list
       observal registry hook list --event Stop
       observal registry hook list --search guard --output json
-      observal registry hook list -o json
     """
     params = {}
     if event:
@@ -376,8 +346,7 @@ def hook_show(
     \b
     Examples:
       observal registry hook show my-hook
-      observal registry hook show 1              # Row number from last list
-      observal registry hook show @guard         # Using alias
+      observal registry hook show @guard
       observal registry hook show abc123 -o json
     """
     resolved = client.resolve_registry_reference("hook", hook_id)
@@ -433,7 +402,6 @@ def hook_install(
       observal registry hook install my-hook --harness claude-code
       observal registry hook install @guard --harness kiro --dir ./project
       observal registry hook install my-hook --harness cursor --raw
-      observal registry hook install my-hook --harness claude-code --platform darwin
     """
     resolved = client.resolve_registry_reference("hook", hook_id)
     listing = client.get(f"/api/v1/hooks/{resolved}")
@@ -556,7 +524,6 @@ def hook_edit(
       observal registry hook edit my-hook --description "Updated guard hook"
       observal registry hook edit my-hook --event Stop --version 1.1.0
       observal registry hook edit @guard --from-file updated-hook.json
-      observal registry hook edit 1 --name new-name
     """
     resolved = client.resolve_registry_reference("hook", hook_id)
     if from_file:

--- a/observal_cli/cmd_inbox.py
+++ b/observal_cli/cmd_inbox.py
@@ -24,7 +24,13 @@ from observal_cli.render import OutputMode, console, esc, output_json, spinner
 
 inbox_app = typer.Typer(
     name="inbox",
-    help="Your work and event feed: reviews, decisions, and update notices",
+    help=(
+        "Your work and event feed: reviews, decisions, and update notices\n\n"
+        "Examples:\n"
+        "  observal inbox\n"
+        "  observal inbox --action-required\n"
+        "  observal inbox list --state open --output json"
+    ),
     no_args_is_help=False,
     invoke_without_command=True,
 )

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -17,9 +17,9 @@ insights_app = typer.Typer(
     help=(
         "Agent insight reports\n\n"
         "Examples:\n"
-        "  observal ops insights list my-agent\n"
-        "  observal ops insights show my-agent latest\n"
-        "  observal ops insights generate my-agent"
+        "  observal ops insights list alice/my-agent\n"
+        "  observal ops insights show alice/my-agent latest\n"
+        "  observal ops insights generate alice/my-agent"
     )
 )
 

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -13,7 +13,15 @@ from rich.table import Table
 from observal_cli import client
 from observal_cli.render import OutputMode, console, esc, output_json, relative_time, spinner, status_badge
 
-insights_app = typer.Typer(help="Agent insight reports")
+insights_app = typer.Typer(
+    help=(
+        "Agent insight reports\n\n"
+        "Examples:\n"
+        "  observal ops insights list my-agent\n"
+        "  observal ops insights show my-agent latest\n"
+        "  observal ops insights generate my-agent"
+    )
+)
 
 _registry_name_cache: str | None = None
 
@@ -141,8 +149,6 @@ def insights_show(
         observal ops insights show my-agent 3
 
         observal ops insights show my-agent --section suggestions
-
-        observal ops insights show my-agent 3 --output json
     """
     with spinner("Fetching report..."):
         data = _resolve_report_for_show(target, report_ref)

--- a/observal_cli/cmd_logs.py
+++ b/observal_cli/cmd_logs.py
@@ -23,7 +23,16 @@ import typer
 from rich.console import Console
 from rich.text import Text
 
-logs_app = typer.Typer(name="logs", help="Live log viewer (open in a separate tab)")
+logs_app = typer.Typer(
+    name="logs",
+    help=(
+        "Live log viewer (open in a separate tab)\n\n"
+        "Examples:\n"
+        "  observal ops logs\n"
+        "  observal ops logs --remote\n"
+        "  observal ops logs --level WARNING --no-follow"
+    ),
+)
 
 LOG_PATH = Path.home() / ".observal" / "logs" / "dev.log"
 

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -44,8 +44,8 @@ mcp_app = typer.Typer(
         "MCP server registry commands\n\n"
         "Examples:\n"
         "  observal registry mcp list\n"
-        "  observal registry mcp show my-server\n"
-        "  observal registry mcp install my-server --harness claude-code"
+        "  observal registry mcp show alice/my-server\n"
+        "  observal registry mcp install alice/my-server --harness claude-code"
     )
 )
 

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -39,7 +39,15 @@ from observal_cli.render import (
     status_badge,
 )
 
-mcp_app = typer.Typer(help="MCP server registry commands")
+mcp_app = typer.Typer(
+    help=(
+        "MCP server registry commands\n\n"
+        "Examples:\n"
+        "  observal registry mcp list\n"
+        "  observal registry mcp show my-server\n"
+        "  observal registry mcp install my-server --harness claude-code"
+    )
+)
 
 
 # ── Env var configuration helpers ────────────────────────────
@@ -1215,40 +1223,6 @@ def _install_impl(
 # ── Canonical commands (on mcp_app) ─────────────────────────
 
 
-def _print_mcp_examples() -> None:
-    console.print_json(
-        json.dumps(
-            {
-                "filesystem": {
-                    "mcpServers": {
-                        "filesystem": {
-                            "command": "npx",
-                            "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/dev/project"],
-                        }
-                    }
-                },
-                "git": {
-                    "mcpServers": {
-                        "git": {
-                            "command": "uvx",
-                            "args": ["mcp-server-git", "--repository", "/home/dev/project"],
-                        }
-                    }
-                },
-                "postgres": {
-                    "mcpServers": {
-                        "postgres": {
-                            "command": "npx",
-                            "args": ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"],
-                        }
-                    }
-                },
-            },
-            indent=2,
-        )
-    )
-
-
 @mcp_app.command()
 def submit(
     git_url: str = typer.Option(None, "--git", "-g", help="Optional git repo for local OCI setup detection"),
@@ -1258,7 +1232,6 @@ def submit(
     config: bool = typer.Option(False, "--config", hidden=True, help="(deprecated) JSON paste is now the default"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (MCP ID)"),
-    example: bool = typer.Option(False, "--example", help="Print example MCP configs and exit"),
     team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
     visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
@@ -1277,24 +1250,10 @@ def submit(
     header values are auto-detected and become install-time prompts.
 
     Examples:
-        # Interactive JSON paste (default)
         observal registry mcp submit
-
-        # Paste JSON and attach a git repo for local OCI setup hints
         observal registry mcp submit --git https://github.com/org/mcp-server --yes
-
-        # Submit with name and category pre-filled
-        observal registry mcp submit --git https://github.com/org/server -n my-server -c developer-tools
-
-        # Save as draft for later editing
-        observal registry mcp submit --draft
-
-        # Submit an existing draft for review
         observal registry mcp submit --submit my-server
     """
-    if example:
-        _print_mcp_examples()
-        return
     if draft and submit_draft:
         rprint(
             "[red]Cannot use --draft and --submit together.[/red] Use --draft to save a new draft, or --submit to submit an existing draft."
@@ -1345,20 +1304,9 @@ def list_mcps(
     displays full details of the selected server.
 
     Examples:
-        # List all approved servers
         observal registry mcp list
-
-        # Search for database-related servers
         observal registry mcp list --search postgres
-
-        # Filter by category, output as JSON
         observal registry mcp list --category ai --output json
-
-        # Interactive fuzzy picker
-        observal registry mcp list --interactive
-
-        # Sort by category, limit to 10 results
-        observal registry mcp list --sort category --limit 10
     """
     _list_impl(category, search, limit, sort, output, interactive=interactive, namespace=namespace, team=team)
 
@@ -1425,16 +1373,8 @@ def show(
     row number from the last list command, or an @alias.
 
     Examples:
-        # Show by name
         observal registry mcp show my-server
-
-        # Show by row number from last list
-        observal registry mcp show 3
-
-        # Show by alias
         observal registry mcp show @fav
-
-        # JSON output
         observal registry mcp show my-server --output json
     """
     optic.trace("mcp_id={}, output={}", mcp_id, output)
@@ -1468,23 +1408,9 @@ def install(
     config files, with placeholder values for any missing env vars.
 
     Examples:
-        # Generate config for Claude Code
         observal registry mcp install my-server --harness claude-code
-
-        # Non-interactive with env vars
-        observal registry mcp install my-server --harness kiro --no-prompt --env API_KEY=sk-123
-
-        # Multiple env vars
-        observal registry mcp install my-server --harness cursor --env API_KEY=sk-123 --env SECRET=abc
-
-        # From env file
         observal registry mcp install my-server --harness claude-code --env-file .env --no-prompt
-
-        # Generate for Cursor and pipe to config file
         observal registry mcp install my-server --harness cursor --raw > .cursor/mcp.json
-
-        # With headers for SSE servers
-        observal registry mcp install my-server --harness kiro --header Authorization='Bearer token'
     """
     optic.trace("mcp_id={}, harness={}", mcp_id, harness)
     env_overrides = {}
@@ -1534,20 +1460,9 @@ def edit_mcp(
     complete update from a JSON file with --from-file.
 
     Examples:
-        # Interactive JSON paste edit
         observal registry mcp edit my-server
-
-        # Update description and category
         observal registry mcp edit my-server -d "New description" -c databases
-
-        # Load updates from a file
         observal registry mcp edit my-server --from-file updates.json
-
-        # Bump version on an approved listing
-        observal registry mcp edit my-server --version 1.2.0
-
-        # Change the git URL
-        observal registry mcp edit my-server --git-url https://github.com/org/new-repo
     """
     optic.trace("mcp_id={}, from_file={}", mcp_id, from_file)
     resolved = client.resolve_registry_reference("mcp", mcp_id)

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -136,7 +136,9 @@ migrate_app = typer.Typer(
         "Examples:\n"
         "  observal server migrate export --db-url postgresql://user:pass@host/observal\n"
         "  observal server migrate validate --archive backup.tar.gz\n"
-        "  observal server migrate export-telemetry --output-dir ./telemetry-export"
+        "  observal server migrate export-telemetry "
+        "--clickhouse-url clickhouse://default:@localhost:8123/observal "
+        "--manifest ./migration_manifest.json --output-dir ./telemetry-export"
     )
 )
 

--- a/observal_cli/cmd_migrate.py
+++ b/observal_cli/cmd_migrate.py
@@ -130,7 +130,15 @@ def _warn_clickhouse_cleartext(url: str) -> None:
 
 # ── Typer app ────────────────────────────────────────────
 
-migrate_app = typer.Typer(help="PostgreSQL shallow-copy migration tools")
+migrate_app = typer.Typer(
+    help=(
+        "PostgreSQL shallow-copy migration tools\n\n"
+        "Examples:\n"
+        "  observal server migrate export --db-url postgresql://user:pass@host/observal\n"
+        "  observal server migrate validate --archive backup.tar.gz\n"
+        "  observal server migrate export-telemetry --output-dir ./telemetry-export"
+    )
+)
 
 
 @migrate_app.callback()
@@ -156,8 +164,8 @@ def export_cmd(
     Alembic migration version for compatibility verification on import.
 
     Examples:
-        observal migrate export --db-url postgresql://user:pass@host/observal
-        observal migrate export --db-url $DATABASE_URL -o backup.tar.gz
+        observal server migrate export --db-url postgresql://user:pass@host/observal
+        observal server migrate export --db-url $DATABASE_URL -o backup.tar.gz
     """
     _require_admin()
 
@@ -221,8 +229,8 @@ def import_cmd(
     Requires super_admin role.
 
     Examples:
-        observal migrate import --db-url postgresql://user:pass@host/observal --archive backup.tar.gz
-        observal migrate import --db-url $DATABASE_URL -a backup.tar.gz
+        observal server migrate import --db-url postgresql://user:pass@host/observal --archive backup.tar.gz
+        observal server migrate import --db-url $DATABASE_URL -a backup.tar.gz
     """
     _require_admin()
 
@@ -278,8 +286,8 @@ def validate_cmd(
     database to detect drift or partial imports. Requires super_admin role.
 
     Examples:
-        observal migrate validate --archive backup.tar.gz
-        observal migrate validate -a backup.tar.gz --db-url $DATABASE_URL
+        observal server migrate validate --archive backup.tar.gz
+        observal server migrate validate -a backup.tar.gz --db-url $DATABASE_URL
     """
     _require_admin()
 
@@ -345,13 +353,13 @@ def export_telemetry_cmd(
 
     Phase 2 of migration: exports session, audit, security, and webhook telemetry
     tables as monthly Parquet partitions. Requires a completed Phase 1 export
-    (the migration_manifest.json produced by 'observal migrate export').
+    (the migration_manifest.json produced by 'observal server migrate export').
 
     Uses a time cutoff recorded at export start for consistency. The output
     directory must be empty or non-existent. Requires super_admin role.
 
     Examples:
-        observal migrate export-telemetry \\
+        observal server migrate export-telemetry \\
             --clickhouse-url clickhouse://default:@localhost:8123/observal \\
             --manifest ./observal-export-20260101-120000.manifest.json \\
             --output-dir ./telemetry-export
@@ -399,7 +407,7 @@ def import_telemetry_cmd(
     can continue where they left off. Requires super_admin role.
 
     Examples:
-        observal migrate import-telemetry \\
+        observal server migrate import-telemetry \\
             --clickhouse-url clickhouse://default:@localhost:8123/observal \\
             --input-dir ./telemetry-export
     """
@@ -456,8 +464,8 @@ def validate_telemetry_cmd(
     PostgreSQL to detect orphaned telemetry records. Requires super_admin role.
 
     Examples:
-        observal migrate validate-telemetry --input-dir ./telemetry-export
-        observal migrate validate-telemetry \\
+        observal server migrate validate-telemetry --input-dir ./telemetry-export
+        observal server migrate validate-telemetry \\
             --input-dir ./telemetry-export \\
             --clickhouse-url $CLICKHOUSE_URL \\
             --target-db-url $DATABASE_URL

--- a/observal_cli/cmd_models.py
+++ b/observal_cli/cmd_models.py
@@ -14,7 +14,17 @@ from rich.table import Table
 from observal_cli import model_catalog
 from observal_cli.render import OutputMode, output_json
 
-models_app = typer.Typer(name="models", help="Inspect registry-backed harness model data.", no_args_is_help=False)
+models_app = typer.Typer(
+    name="models",
+    help=(
+        "Inspect registry-backed harness model data.\n\n"
+        "Examples:\n"
+        "  observal registry models\n"
+        "  observal registry models --harness claude-code\n"
+        "  observal registry models list --output json"
+    ),
+    no_args_is_help=False,
+)
 
 
 def _emit(harness: str | None, output: OutputMode) -> None:
@@ -54,4 +64,11 @@ def list_models(
     harness: str | None = typer.Option(None, "--harness", help="Filter to one harness."),
     output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
+    """List registry-backed harness models.
+
+    Examples:
+      observal registry models list
+      observal registry models list --harness pi
+      observal registry models list --output json
+    """
     _emit(harness, output)

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -35,14 +35,28 @@ from observal_cli.render import (
 
 ops_app = typer.Typer(
     name="ops",
-    help="Observability and operational commands (traces, telemetry, dashboard, feedback)",
+    help=(
+        "Observability and operational commands (traces, telemetry, dashboard, feedback)\n\n"
+        "Examples:\n"
+        "  observal ops traces\n"
+        "  observal ops metrics my-agent --type agent\n"
+        "  observal ops telemetry status"
+    ),
     no_args_is_help=True,
 )
 
 
 # ── Review ───────────────────────────────────────────────
 
-review_app = typer.Typer(help="Admin review commands")
+review_app = typer.Typer(
+    help=(
+        "Admin review commands\n\n"
+        "Examples:\n"
+        "  observal admin review list\n"
+        "  observal admin review show 1\n"
+        "  observal admin review approve 1"
+    )
+)
 
 
 @review_app.command(name="list")
@@ -172,8 +186,6 @@ def review_approve(
         observal admin review approve my-mcp-server
 
         observal admin review approve my-agent --agent
-
-        observal admin review approve my-bundle --bundle
     """
     resolved = config.resolve_alias(review_id)
     if agent:
@@ -233,7 +245,9 @@ def review_reject(
 
 # ── Telemetry ────────────────────────────────────────────
 
-telemetry_app = typer.Typer(help="Telemetry commands")
+telemetry_app = typer.Typer(
+    help=("Telemetry commands\n\nExamples:\n  observal ops telemetry status\n  observal ops telemetry test")
+)
 
 
 @telemetry_app.command(name="status")
@@ -322,8 +336,6 @@ def _metrics(
         observal ops metrics my-agent --type agent
 
         observal ops metrics @mcp-alias --watch
-
-        observal ops metrics my-mcp --output json
     """
     _metrics_impl(item_id, item_type, output, watch)
 
@@ -589,7 +601,15 @@ def _feedback_impl(listing_id, listing_type, output):
 
 # ── Admin ────────────────────────────────────────────────
 
-admin_app = typer.Typer(help="Admin commands")
+admin_app = typer.Typer(
+    help=(
+        "Admin commands\n\n"
+        "Examples:\n"
+        "  observal admin diagnostics\n"
+        "  observal admin users\n"
+        "  observal admin review list"
+    )
+)
 
 
 @admin_app.command(name="settings")
@@ -1059,8 +1079,6 @@ def admin_security_events(
         observal admin security-events --type auth.login --severity critical
 
         observal admin security-events --actor alice@example.com -n 100
-
-        observal admin security-events --output json
     """
     params: dict = {"limit": str(limit)}
     if event_type:
@@ -1130,8 +1148,6 @@ def admin_audit_log(
         observal admin audit-log --action auth.login --limit 100
 
         observal admin audit-log --actor alice@example.com -r agent
-
-        observal admin audit-log --output json
     """
     from urllib.parse import urlencode
 
@@ -1337,8 +1353,6 @@ def _traces(
         observal ops traces
 
         observal ops traces --turn
-
-        observal ops traces --span --limit 5
 
         observal ops traces --platform kiro --days 7
     """
@@ -1576,7 +1590,13 @@ def _spans_impl(trace_id, output):
 
 self_app = typer.Typer(
     name="self",
-    help="CLI self-management commands (upgrade, downgrade, rollback, status)",
+    help=(
+        "CLI self-management commands (upgrade, downgrade, rollback, status)\n\n"
+        "Examples:\n"
+        "  observal self status\n"
+        "  observal self upgrade\n"
+        "  observal self rollback"
+    ),
     no_args_is_help=True,
 )
 
@@ -1610,7 +1630,6 @@ def upgrade(
         observal self upgrade
         observal self upgrade --version 0.9.0
         observal self upgrade --pre
-        observal self upgrade --force
     """
     from packaging.version import InvalidVersion, Version
 

--- a/observal_cli/cmd_outdated.py
+++ b/observal_cli/cmd_outdated.py
@@ -47,7 +47,6 @@ def register_outdated(app: typer.Typer):
           observal outdated
           observal outdated --harness claude-code
           observal outdated --output json
-          observal outdated --no-report
         """
         from observal_cli.lockfile import get_all_entries
 

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -36,8 +36,8 @@ prompt_app = typer.Typer(
         "Prompt registry commands\n\n"
         "Examples:\n"
         "  observal registry prompt list\n"
-        "  observal registry prompt show my-prompt\n"
-        "  observal registry prompt render my-prompt --var lang=python"
+        "  observal registry prompt show alice/my-prompt\n"
+        "  observal registry prompt render alice/my-prompt --var lang=python"
     )
 )
 

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -31,7 +31,15 @@ from observal_cli.render import (
     status_badge,
 )
 
-prompt_app = typer.Typer(help="Prompt registry commands")
+prompt_app = typer.Typer(
+    help=(
+        "Prompt registry commands\n\n"
+        "Examples:\n"
+        "  observal registry prompt list\n"
+        "  observal registry prompt show my-prompt\n"
+        "  observal registry prompt render my-prompt --var lang=python"
+    )
+)
 
 
 def register_prompt(app: typer.Typer):
@@ -62,7 +70,6 @@ def prompt_submit(
     Only submit prompts you created or are the point-of-contact for.
 
     Examples:
-        observal registry prompt submit
         observal registry prompt submit --from-file prompt.json
         observal registry prompt submit --draft
         observal registry prompt submit --submit abc123
@@ -262,7 +269,6 @@ def prompt_show(
 
     Examples:
         observal registry prompt show my-prompt
-        observal registry prompt show 1
         observal registry prompt show @refactor-prompt
         observal registry prompt show abc123 --output json
     """
@@ -336,7 +342,6 @@ def prompt_edit(
         observal registry prompt edit my-prompt --description "Updated desc"
         observal registry prompt edit abc123 --from-file updates.json
         observal registry prompt edit @tpl --template "New template: {{var}}"
-        observal registry prompt edit 2 --version 2.0.0 --category debugging
     """
     resolved = client.resolve_registry_reference("prompt", prompt_id)
     if from_file:

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -633,10 +633,7 @@ def register_pull(app: typer.Typer):
         Examples:
           observal agent pull my-agent --harness claude-code --no-prompt
           observal agent pull my-agent --harness claude-code --version 1.2.0
-          observal agent pull my-agent --harness kiro --no-prompt --scope user
           observal agent pull my-agent --harness cursor --no-prompt --dry-run
-          observal agent pull my-agent --harness kiro --no-prompt --env API_KEY=sk-123 --env SECRET=abc
-          observal agent pull my-agent --harness cursor --header Authorization="Bearer sk-123"
         """
         resolved = client.resolve_registry_reference("agent", agent_id)
         target_dir = Path(directory).resolve()

--- a/observal_cli/cmd_recommend.py
+++ b/observal_cli/cmd_recommend.py
@@ -21,7 +21,13 @@ from observal_cli.render import OutputMode, console, esc, output_json, spinner
 
 recommend_app = typer.Typer(
     name="recommend",
-    help="Components recommended for you, based on your own sessions",
+    help=(
+        "Components recommended for you, based on your own sessions\n\n"
+        "Examples:\n"
+        "  observal registry recommend\n"
+        "  observal registry recommend --type mcp\n"
+        "  observal registry recommend list --output json"
+    ),
     no_args_is_help=False,
     invoke_without_command=True,
 )

--- a/observal_cli/cmd_reconcile_cli.py
+++ b/observal_cli/cmd_reconcile_cli.py
@@ -18,7 +18,16 @@ from observal_cli.sessions.base import (
     recover_cursor_from_server,
 )
 
-reconcile_app = typer.Typer(name="reconcile", help="Push local session transcripts to the server")
+reconcile_app = typer.Typer(
+    name="reconcile",
+    help=(
+        "Push local session transcripts to the server\n\n"
+        "Examples:\n"
+        "  observal reconcile\n"
+        "  observal reconcile --harness kiro\n"
+        "  observal reconcile --since 24 --dry-run"
+    ),
+)
 
 
 @reconcile_app.callback(invoke_without_command=True)

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -35,7 +35,7 @@ sandbox_app = typer.Typer(
         "Sandbox registry commands\n\n"
         "Examples:\n"
         "  observal registry sandbox list\n"
-        "  observal registry sandbox show my-sandbox\n"
+        "  observal registry sandbox show alice/my-sandbox\n"
         "  observal registry sandbox submit --from-file sandbox.json"
     )
 )

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -30,58 +30,15 @@ from observal_cli.render import (
     status_badge,
 )
 
-sandbox_app = typer.Typer(help="Sandbox registry commands")
-
-
-def _print_sandbox_examples() -> None:
-    examples = {
-        "python-pytest": {
-            "name": "python-pytest",
-            "version": "1.0.0",
-            "description": "Run Python tests in a reviewed Docker image",
-            "owner": "your-team",
-            "runtime_type": "docker",
-            "image": "python:3.12-slim",
-            "resource_limits": {"timeout": 60, "memory_mb": 512, "cpu_count": 1},
-            "network_policy": "none",
-            "entrypoint": "pytest",
-            "runtime_config": {},
-            "source_url": "https://github.com/docker-library/python",
-            "source_ref": "master",
-            "sandbox_path": "3.12/slim-bookworm",
-        },
-        "node-tests": {
-            "name": "node-tests",
-            "version": "1.0.0",
-            "description": "Run Node test and build commands",
-            "owner": "your-team",
-            "runtime_type": "docker",
-            "image": "node:22-alpine",
-            "resource_limits": {"timeout": 120, "memory_mb": 1024, "cpu_count": 2},
-            "network_policy": "none",
-            "entrypoint": "npm test",
-            "runtime_config": {},
-            "source_url": "https://github.com/nodejs/docker-node",
-            "source_ref": "main",
-            "sandbox_path": "22/alpine3.22",
-        },
-        "go-tests": {
-            "name": "go-tests",
-            "version": "1.0.0",
-            "description": "Run Go tests in an Alpine Go image",
-            "owner": "your-team",
-            "runtime_type": "docker",
-            "image": "golang:1.24-alpine",
-            "resource_limits": {"timeout": 180, "memory_mb": 1024, "cpu_count": 2},
-            "network_policy": "none",
-            "entrypoint": "go test ./...",
-            "runtime_config": {},
-            "source_url": "https://github.com/docker-library/golang",
-            "source_ref": "master",
-            "sandbox_path": "1.24/alpine3.21",
-        },
-    }
-    output_json(examples)
+sandbox_app = typer.Typer(
+    help=(
+        "Sandbox registry commands\n\n"
+        "Examples:\n"
+        "  observal registry sandbox list\n"
+        "  observal registry sandbox show my-sandbox\n"
+        "  observal registry sandbox submit --from-file sandbox.json"
+    )
+)
 
 
 def register_sandbox(app: typer.Typer):
@@ -106,7 +63,6 @@ def sandbox_submit(
     sandbox_path: str | None = typer.Option(None, "--sandbox-path", help="Path in source repo"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (sandbox ID)"),
-    example: bool = typer.Option(False, "--example", help="Print example sandbox payloads and exit"),
     team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
     visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
@@ -119,14 +75,10 @@ def sandbox_submit(
     Only submit sandboxes you created or are the point-of-contact for.
 
     Examples:
-        observal registry sandbox submit
         observal registry sandbox submit --from-file sandbox.json
         observal registry sandbox submit --draft
         observal registry sandbox submit --submit abc123
     """
-    if example:
-        _print_sandbox_examples()
-        return
     rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     if draft and submit_draft:
         rprint(

--- a/observal_cli/cmd_server.py
+++ b/observal_cli/cmd_server.py
@@ -37,7 +37,13 @@ except ImportError:
 
 server_app = typer.Typer(
     name="server",
-    help="Manage the embedded Observal server (PostgreSQL + ClickHouse + Redis + API).",
+    help=(
+        "Manage the embedded Observal server (PostgreSQL + ClickHouse + Redis + API).\n\n"
+        "Examples:\n"
+        "  observal server status\n"
+        "  observal server start\n"
+        "  observal server logs api"
+    ),
     no_args_is_help=True,
 )
 
@@ -231,11 +237,10 @@ def logs(
 ) -> None:
     """Show service logs.
 
-    Example:
+    Examples:
         observal server logs
         observal server logs postgres
         observal server logs -f
-        observal server logs api -n 100
     """
     optic.trace("service={}, follow={}", service, follow)
     log_files = {
@@ -466,7 +471,6 @@ def server_upgrade(
         observal server upgrade
         observal server upgrade --version 0.9.0
         observal server upgrade --dry-run
-        observal server upgrade --skip-backup --force
     """
     optic.trace("version={}, skip_backup={}", version, skip_backup)
     _require_super_admin()

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -36,7 +36,15 @@ from observal_cli.render import (
 )
 from observal_cli.shared.utils import sanitize_name as _sanitize_name
 
-skill_app = typer.Typer(help="Skill registry commands")
+skill_app = typer.Typer(
+    help=(
+        "Skill registry commands\n\n"
+        "Examples:\n"
+        "  observal registry skill list\n"
+        "  observal registry skill show my-skill\n"
+        "  observal registry skill install my-skill --harness claude-code"
+    )
+)
 
 
 def register_skill(app: typer.Typer):
@@ -79,35 +87,6 @@ def _parse_frontmatter(content: str) -> dict:
 # ── Submit ────────────────────────────────────────────────────────────────────
 
 
-def _print_skill_examples() -> None:
-    output_json(
-        {
-            "registry_direct": {
-                "name": "summarize-changes",
-                "version": "1.0.0",
-                "description": "Summarize uncommitted changes and flag risks",
-                "owner": "your-team",
-                "task_type": "code-review",
-                "delivery_mode": "registry_direct",
-                "skill_md_content": "---\nname: summarize-changes\ndescription: Summarizes uncommitted changes and flags risky edits.\n---\n\n## Current changes\n\n!`git diff HEAD`\n\n## Instructions\n\nSummarize the diff and list risks.",
-                "supported_harnesses": ["claude-code", "kiro"],
-            },
-            "git_fetch": {
-                "name": "api-conventions",
-                "version": "1.0.0",
-                "description": "Apply API design conventions for this repo",
-                "owner": "your-team",
-                "task_type": "code-generation",
-                "delivery_mode": "git_fetch",
-                "git_url": "https://github.com/acme/agent-skills",
-                "git_ref": "main",
-                "skill_path": "skills/api-conventions",
-                "supported_harnesses": ["claude-code", "kiro"],
-            },
-        }
-    )
-
-
 @skill_app.command(name="submit")
 def skill_submit(
     from_file: str | None = typer.Option(None, "--from-file", "-f", help="Create from JSON file"),
@@ -126,7 +105,6 @@ def skill_submit(
     supported_harnesses: list[str] | None = typer.Option(None, "--harness", help="Supported harness (repeatable)"),
     draft: bool = typer.Option(False, "--draft", help="Save as draft instead of submitting for review"),
     submit_draft: str | None = typer.Option(None, "--submit", help="Submit a draft for review (skill ID)"),
-    example: bool = typer.Option(False, "--example", help="Print example skill payloads and exit"),
     team: str | None = typer.Option(None, "--team", help="Teamspace UUID or handle"),
     visibility: str | None = typer.Option(None, "--visibility", help="Visibility: public or team"),
 ):
@@ -148,15 +126,9 @@ def skill_submit(
 
     Examples:
         observal registry skill submit --git-url https://github.com/org/repo
-        observal registry skill submit --from-file skill.json
         observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo
         observal registry skill submit --skill-md ./SKILL.md --script ./run.sh --delivery-mode registry_direct
-        observal registry skill submit --draft
-        observal registry skill submit --submit abc123
     """
-    if example:
-        _print_skill_examples()
-        return
     rprint("[dim]Note: Only submit components you created (private) or are the point-of-contact for (external).[/dim]")
     if draft and submit_draft:
         rprint(
@@ -307,7 +279,6 @@ def skill_list(
         observal registry skill list
         observal registry skill list --task-type coding
         observal registry skill list --target-agent claude-code --output json
-        observal registry skill list --search "refactor"
     """
     params = {}
     if task_type:
@@ -522,7 +493,6 @@ def skill_install(
         observal registry skill install my-skill --harness claude-code
         observal registry skill install @sk --harness kiro --scope project
         observal registry skill install 2 --harness cursor --raw > config.json
-        observal registry skill install my-skill --harness opencode --no-write
     """
     resolved = client.resolve_registry_reference("skill", skill_id)
     listing = client.get(f"/api/v1/skills/{resolved}")
@@ -786,7 +756,6 @@ def skill_edit(
         observal registry skill edit my-skill --description "Better desc"
         observal registry skill edit abc123 --from-file updates.json
         observal registry skill edit @sk --git-url https://github.com/org/new-repo
-        observal registry skill edit 2 --version 2.0.0 --task-type debugging
     """
     resolved = client.resolve_registry_reference("skill", skill_id)
     if from_file:

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -41,8 +41,8 @@ skill_app = typer.Typer(
         "Skill registry commands\n\n"
         "Examples:\n"
         "  observal registry skill list\n"
-        "  observal registry skill show my-skill\n"
-        "  observal registry skill install my-skill --harness claude-code"
+        "  observal registry skill show alice/my-skill\n"
+        "  observal registry skill install alice/my-skill --harness claude-code"
     )
 )
 

--- a/observal_cli/cmd_support.py
+++ b/observal_cli/cmd_support.py
@@ -40,7 +40,12 @@ from observal_cli.support.redaction import RedactionStats, redact_value
 CURRENT_SCHEMA_VERSION = 1
 
 support_app = typer.Typer(
-    help="Generate and inspect diagnostic support bundles. Bundles contain no customer data or row contents.",
+    help=(
+        "Generate and inspect diagnostic support bundles. Bundles contain no customer data or row contents.\n\n"
+        "Examples:\n"
+        "  observal doctor support bundle\n"
+        "  observal doctor support inspect ./observal-support.tar.gz"
+    ),
     no_args_is_help=True,
 )
 
@@ -213,9 +218,9 @@ def bundle(
     exposing sensitive data. Archive permissions are set to 0600.
 
     Examples:
-        observal support bundle
-        observal support bundle -o /tmp/diag.tar.gz --logs-since 2h
-        observal support bundle --no-include-system
+        observal doctor support bundle
+        observal doctor support bundle -o /tmp/diag.tar.gz --logs-since 2h
+        observal doctor support bundle --no-include-system
     """
     # Determine output path
     if output is None:
@@ -508,8 +513,8 @@ def inspect(
     specific file from the archive using --show.
 
     Examples:
-        observal support inspect ./observal-support-20260101-120000.tar.gz
-        observal support inspect bundle.tar.gz --show health/postgres.json
+        observal doctor support inspect ./observal-support-20260101-120000.tar.gz
+        observal doctor support inspect bundle.tar.gz --show health/postgres.json
     """
     if not bundle_path.exists():
         render.error(f"Bundle not found: {bundle_path}")

--- a/observal_cli/cmd_support.py
+++ b/observal_cli/cmd_support.py
@@ -461,7 +461,7 @@ def bundle(
 
     archive_size = output.stat().st_size
     rprint(f"[green]✓[/green] Support bundle written to [bold]{output}[/bold] ({_human_size(archive_size)})")
-    rprint("[dim]  Review contents with: observal support inspect " + str(output) + "[/dim]")
+    rprint("[dim]  Review contents with: observal doctor support inspect " + str(output) + "[/dim]")
 
 
 # ── Inspect helpers ──────────────────────────────────────────────────

--- a/observal_cli/cmd_team.py
+++ b/observal_cli/cmd_team.py
@@ -12,9 +12,39 @@ from rich.table import Table
 from observal_cli import client
 from observal_cli.render import OutputMode, output_json
 
-team_app = typer.Typer(name="team", help="Manage teamspaces: creation, membership, and listing.", no_args_is_help=True)
-members_app = typer.Typer(name="members", help="Manage team membership.", no_args_is_help=True)
-invite_app = typer.Typer(name="invite", help="Manage private-team invitation links.", no_args_is_help=True)
+team_app = typer.Typer(
+    name="team",
+    help=(
+        "Manage teamspaces: creation, membership, and listing.\n\n"
+        "Examples:\n"
+        "  observal team list\n"
+        "  observal team show platform-tools\n"
+        "  observal team members list platform-tools"
+    ),
+    no_args_is_help=True,
+)
+members_app = typer.Typer(
+    name="members",
+    help=(
+        "Manage team membership.\n\n"
+        "Examples:\n"
+        "  observal team members list platform-tools\n"
+        "  observal team members add platform-tools alice@example.com\n"
+        "  observal team members remove platform-tools @alice"
+    ),
+    no_args_is_help=True,
+)
+invite_app = typer.Typer(
+    name="invite",
+    help=(
+        "Manage private-team invitation links.\n\n"
+        "Examples:\n"
+        "  observal team invite list platform-tools\n"
+        "  observal team invite create platform-tools\n"
+        "  observal team invite revoke platform-tools INVITE_ID"
+    ),
+    no_args_is_help=True,
+)
 team_app.add_typer(members_app, name="members")
 team_app.add_typer(invite_app, name="invite")
 
@@ -223,7 +253,12 @@ def create_invite(
     expires_days: int = typer.Option(7, min=1, max=365, help="Days until the link expires."),
     max_uses: int | None = typer.Option(None, min=1, help="Maximum access requests; unlimited when omitted."),
 ):
-    """Create a private-team invitation link. Owner or global admin only."""
+    """Create a private-team invitation link. Owner or global admin only.
+
+    Examples:
+      observal team invite create platform-tools
+      observal team invite create platform-tools --name onboarding --expires-days 30
+    """
     team_id = _resolve_team_id(team)
     body: dict = {"expires_in_days": expires_days}
     if name:
@@ -239,7 +274,12 @@ def list_invites(
     team: str = typer.Argument(help="Private team UUID or handle."),
     output: OutputMode = typer.Option("table", help="Output format: table | json"),
 ):
-    """List invitation links for a private teamspace."""
+    """List invitation links for a private teamspace.
+
+    Examples:
+      observal team invite list platform-tools
+      observal team invite list platform-tools --output json
+    """
     team_id = _resolve_team_id(team)
     rows = client.get(f"/api/v1/teams/{team_id}/invites")
     if output == "json":
@@ -275,7 +315,11 @@ def revoke_invite(
     team: str = typer.Argument(help="Private team UUID or handle."),
     invite_id: str = typer.Argument(help="Invitation UUID."),
 ):
-    """Revoke a private-team invitation link. Owner or global admin only."""
+    """Revoke a private-team invitation link. Owner or global admin only.
+
+    Examples:
+      observal team invite revoke platform-tools 550e8400-e29b-41d4-a716-446655440000
+    """
     team_id = _resolve_team_id(team)
     response = client.post(f"/api/v1/teams/{team_id}/invites/{invite_id}/revoke")
     rprint(f"[green]Invite {response.get('state')}.[/green]")

--- a/observal_cli/cmd_transfer.py
+++ b/observal_cli/cmd_transfer.py
@@ -21,19 +21,19 @@ _ENTITY_LABELS = {
 
 
 def add_transfer_owner_command(app: typer.Typer, entity_type: str) -> None:
-    @app.command(name="transfer-owner")
+    label = _ENTITY_LABELS[entity_type]
+    command = "agent" if entity_type == "agents" else f"registry {label}"
+
     def transfer_owner(
         entity_id: str = typer.Argument(help="Entity UUID or name"),
         username: str = typer.Argument(help="New owner's username"),
         yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
     ):
-        """Transfer ownership to another username."""
         target = username.strip().lstrip("@")
         if not target:
             rprint("[red]Error:[/red] username is required")
             raise typer.Exit(1)
 
-        label = _ENTITY_LABELS.get(entity_type, entity_type)
         if not yes and not typer.confirm(
             f"Transfer {label} '{entity_id}' to @{target}? You will no longer be the owner."
         ):
@@ -42,3 +42,10 @@ def add_transfer_owner_command(app: typer.Typer, entity_type: str) -> None:
         resolved = client.resolve_registry_reference(entity_type, entity_id)
         resp = client.post(f"/api/v1/{entity_type}/{resolved}/transfer-ownership", json_data={"username": target})
         rprint(f"[green]Ownership transferred to:[/green] @{resp.get('owner', target)}")
+
+    transfer_owner.__doc__ = f"""Transfer ownership to another username.
+
+    Examples:
+      observal {command} transfer-owner my-component alice
+    """
+    app.command(name="transfer-owner")(transfer_owner)

--- a/observal_cli/cmd_transfer.py
+++ b/observal_cli/cmd_transfer.py
@@ -46,6 +46,6 @@ def add_transfer_owner_command(app: typer.Typer, entity_type: str) -> None:
     transfer_owner.__doc__ = f"""Transfer ownership to another username.
 
     Examples:
-      observal {command} transfer-owner my-component alice
+      observal {command} transfer-owner alice/my-component bob
     """
     app.command(name="transfer-owner")(transfer_owner)

--- a/observal_cli/cmd_uninstall.py
+++ b/observal_cli/cmd_uninstall.py
@@ -229,7 +229,7 @@ def _uninstall_cli() -> bool:
 
 
 def register_uninstall(app: typer.Typer):
-    """Register the root-level `observal uninstall` command."""
+    """Register the `observal self uninstall` command."""
 
     @app.command("uninstall")
     def uninstall(
@@ -249,9 +249,9 @@ def register_uninstall(app: typer.Typer):
         deferred to a background PowerShell process after the CLI exits.
 
         Examples:
-            observal uninstall
-            observal uninstall --keep-config --keep-cli
-            observal uninstall --repo-dir ~/code/Observal --keep-repo
+            observal self uninstall
+            observal self uninstall --keep-config --keep-cli
+            observal self uninstall --repo-dir ~/code/Observal --keep-repo
         """
         optic.trace("repo_dir={}", repo_dir)
         repo_root = _find_repo_root(repo_dir)

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -68,7 +68,13 @@ def _version_option(value: bool):
 
 app = typer.Typer(
     name="observal",
-    help="Observal: MCP Server & Agent Registry CLI",
+    help=(
+        "Observal: MCP Server & Agent Registry CLI\n\n"
+        "Examples:\n"
+        "  observal scan\n"
+        "  observal agent list\n"
+        "  observal registry mcp list"
+    ),
     no_args_is_help=True,
     rich_markup_mode="rich",
     pretty_exceptions_enable=False,
@@ -179,7 +185,13 @@ from observal_cli.cmd_uninstall import register_uninstall
 
 registry_app = typer.Typer(
     name="registry",
-    help="Component registry (MCPs, skills, hooks, prompts, sandboxes)",
+    help=(
+        "Component registry (MCPs, skills, hooks, prompts, sandboxes)\n\n"
+        "Examples:\n"
+        "  observal registry mcp list\n"
+        "  observal registry skill list\n"
+        "  observal registry recommend"
+    ),
     no_args_is_help=True,
 )
 

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -83,7 +83,6 @@ Dismissals are per-user and permanent until overwritten, so confirm before dismi
 Paste the MCP JSON config. Optionally include `--git` so Observal clones the repo and detects local OCI setup for Dockerfile, Containerfile, or compose `build:`.
 
 ```bash
-observal registry mcp submit --example
 observal registry mcp submit --name my-mcp --category developer-tools --yes
 observal registry mcp submit --git https://github.com/org/mcp-server --name my-mcp --category developer-tools --yes
 observal registry mcp submit --name internal-mcp --category developer-tools --team platform-tools --visibility team --yes
@@ -97,7 +96,6 @@ There are two delivery modes for skills:
 
 **Git-based** (server validates SKILL.md from repo, recommended for open-source):
 ```bash
-observal registry skill submit --example
 observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --git-ref main --name my-skill --description 'What it does' --task-type general
 observal registry skill submit --skill-md ./SKILL.md --git-url https://github.com/org/repo --name internal-skill --description 'Team skill' --task-type general --team platform-tools --visibility team
 ```
@@ -117,7 +115,6 @@ On install, registry_direct skills write `<skill-name>/SKILL.md` and `<skill-nam
 ### Hook
 
 ```bash
-observal registry hook submit --example
 observal registry hook submit --name guard --description 'Guard prompts' --event UserPromptSubmit --handler-command './guard.sh' --execution-mode sync --timeout 10 --scope agent --harness claude-code
 observal registry hook submit --from-file hook.json --script ./pre-commit.sh
 ```
@@ -138,13 +135,12 @@ observal registry prompt submit --from-file prompt.json
 ### Sandbox
 
 ```bash
-observal registry sandbox submit --example
 observal registry sandbox submit --name node-runner --description 'Node sandbox' --runtime-type docker --image node:22-alpine --resource-limits '{"memory_mb":512}' --runtime-config '{}' --network-policy none --entrypoint node --harness claude-code
 observal registry sandbox submit --name lxc-runner --description 'LXC sandbox' --runtime-type lxc --image images:ubuntu/22.04 --runtime-config '{"profile":"default"}' --network-policy none --entrypoint 'sh' --harness kiro
 observal registry sandbox submit --from-file sandbox.json
 ```
 
-All types support `--example` to print ready-to-edit example payloads, `--draft` to save without review, and `--submit NAME` to submit an existing draft.
+All types support `--draft` to save without review and `--submit NAME` to submit an existing draft. Use each command's help screen for copyable examples.
 
 ---
 ## Procedure: Install Component

--- a/observal_cli/skills/observal-registry/SKILL.md
+++ b/observal_cli/skills/observal-registry/SKILL.md
@@ -140,7 +140,7 @@ observal registry sandbox submit --name lxc-runner --description 'LXC sandbox' -
 observal registry sandbox submit --from-file sandbox.json
 ```
 
-All types support `--draft` to save without review and `--submit NAME` to submit an existing draft. Use each command's help screen for copyable examples.
+All types support `--draft` to save without review and `--submit namespace/slug` (or a UUID) to submit an existing draft. Bare names are a legacy fallback and work only when unambiguous. Use each command's help screen for copyable examples.
 
 ---
 ## Procedure: Install Component

--- a/observal_cli/skills/observal/references/commands.md
+++ b/observal_cli/skills/observal/references/commands.md
@@ -156,7 +156,7 @@ Every command available in the installed CLI. This block is generated from the T
   - `observal registry mcp transfer-owner`: Transfer ownership to another username.
   - `observal registry mcp unarchive`: Restore an archived component.
 - `observal registry models`: Inspect registry-backed harness model data.
-  - `observal registry models list`
+  - `observal registry models list`: List registry-backed harness models.
 - `observal registry prompt`: Prompt registry commands
   - `observal registry prompt co-authors`: Manage co-authors for prompts
     - `observal registry prompt co-authors add`: Add a co-author.

--- a/observal_cli/tests/test_cmd_component_submit_flags.py
+++ b/observal_cli/tests/test_cmd_component_submit_flags.py
@@ -5,11 +5,47 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+from click import Group
+from typer.main import get_command
 from typer.testing import CliRunner
 
 from observal_cli.main import app
 
 runner = CliRunner()
+
+
+def _command_tree(command, path="observal"):
+    yield path, command
+    if isinstance(command, Group):
+        for name, child in command.commands.items():
+            yield from _command_tree(child, f"{path} {name}")
+
+
+def _help_examples(help_text: str) -> list[str]:
+    marker = "Examples:" if "Examples:" in help_text else "Example:"
+    if marker not in help_text:
+        return []
+    return [
+        line.strip()
+        for line in help_text.split(marker, 1)[1].splitlines()
+        if line.strip() == "observal" or line.strip().startswith("observal ")
+    ]
+
+
+def test_every_cli_help_screen_has_copyable_examples():
+    for path, command in _command_tree(get_command(app)):
+        examples = _help_examples(command.help or "")
+        assert 1 <= len(examples) <= 3, path
+        assert all(example == path or example.startswith(f"{path} ") for example in examples), path
+
+
+@pytest.mark.parametrize("component", ["mcp", "skill", "hook", "sandbox"])
+def test_submit_rejects_removed_example_flag(component):
+    result = runner.invoke(app, ["registry", component, "submit", "--example"])
+
+    assert result.exit_code == 2
+    assert "No such option" in result.output
 
 
 def test_skill_submit_flags_post_payload(tmp_path):

--- a/observal_cli/tests/test_cmd_component_submit_flags.py
+++ b/observal_cli/tests/test_cmd_component_submit_flags.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import shlex
 from unittest.mock import patch
 
 import pytest
@@ -26,11 +27,46 @@ def _help_examples(help_text: str) -> list[str]:
     marker = "Examples:" if "Examples:" in help_text else "Example:"
     if marker not in help_text:
         return []
-    return [
-        line.strip()
-        for line in help_text.split(marker, 1)[1].splitlines()
-        if line.strip() == "observal" or line.strip().startswith("observal ")
-    ]
+
+    lines = help_text.split(marker, 1)[1].splitlines()
+    examples: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index].strip()
+        index += 1
+        if line != "observal" and not line.startswith("observal "):
+            continue
+        parts = [line]
+        while parts[-1].endswith("\\") and index < len(lines):
+            parts[-1] = parts[-1][:-1].rstrip()
+            parts.append(lines[index].strip())
+            index += 1
+        examples.append(" ".join(parts))
+    return examples
+
+
+def _parse_without_invoking(command, args: list[str], parent=None) -> None:
+    """Parse a command chain without invoking command callbacks."""
+    ctx = command.make_context(command.name or "observal", args, parent=parent)
+    try:
+        if isinstance(command, Group):
+            protected = list(getattr(ctx, "_protected_args", ()))
+            remaining = [*protected, *ctx.args]
+            if remaining:
+                _, child, child_args = command.resolve_command(ctx, remaining)
+                _parse_without_invoking(child, child_args, parent=ctx)
+    finally:
+        ctx.close()
+
+
+def _assert_example_parses(command, path: str, example: str) -> None:
+    tokens = shlex.split(example, comments=True)
+    prefix = shlex.split(path)
+    args = tokens[len(prefix) :]
+    for operator in ("|", ">", ">>"):
+        if operator in args:
+            args = args[: args.index(operator)]
+    _parse_without_invoking(command, args)
 
 
 def test_every_cli_help_screen_has_copyable_examples():
@@ -38,14 +74,18 @@ def test_every_cli_help_screen_has_copyable_examples():
         examples = _help_examples(command.help or "")
         assert 1 <= len(examples) <= 3, path
         assert all(example == path or example.startswith(f"{path} ") for example in examples), path
+        for example in examples:
+            _assert_example_parses(command, path, example)
 
 
 @pytest.mark.parametrize("component", ["mcp", "skill", "hook", "sandbox"])
 def test_submit_rejects_removed_example_flag(component):
-    result = runner.invoke(app, ["registry", component, "submit", "--example"])
+    with patch("observal_cli.client.post") as post:
+        result = runner.invoke(app, ["registry", component, "submit", "--example"])
 
     assert result.exit_code == 2
     assert "No such option" in result.output
+    post.assert_not_called()
 
 
 def test_skill_submit_flags_post_payload(tmp_path):

--- a/tests/test_cmd_hook_coverage.py
+++ b/tests/test_cmd_hook_coverage.py
@@ -49,20 +49,10 @@ def _hook_item(**overrides):
     return item
 
 
-def test_register_and_example_output(monkeypatch):
+def test_register_hook_commands():
     parent = Mock()
     hook.register_hook(parent)
     parent.add_typer.assert_called_once_with(hook.hook_app, name="hook")
-
-    post = Mock()
-    monkeypatch.setattr(hook.client, "post", post)
-    result = runner.invoke(app, ["registry", "hook", "submit", "--example"])
-
-    assert result.exit_code == 0, result.output
-    examples = json.loads(result.output)
-    assert examples["command_hook"]["handler_config"]["command"] == "./hooks/block-rm.sh"
-    assert examples["http_hook"]["handler_type"] == "http"
-    post.assert_not_called()
 
 
 def test_submit_existing_draft_and_rejects_conflicting_modes(monkeypatch):

--- a/tests/test_cmd_mcp_coverage.py
+++ b/tests/test_cmd_mcp_coverage.py
@@ -899,12 +899,7 @@ def test_install_env_file_no_prompt_warns_and_ignores_lock_failure(tmp_path, mon
     assert "MISSING" in output
 
 
-def test_submit_example_and_edit_all_flags(monkeypatch):
-    example = runner.invoke(app, ["registry", "mcp", "submit", "--example"])
-    assert example.exit_code == 0
-    assert "filesystem" in example.output
-    assert "postgres" in example.output
-
+def test_edit_all_flags(monkeypatch):
     monkeypatch.setattr(mcp.client, "resolve_registry_reference", Mock(return_value="resolved"))
     monkeypatch.setattr(
         mcp.client,

--- a/tests/test_cmd_skill_coverage.py
+++ b/tests/test_cmd_skill_coverage.py
@@ -87,18 +87,11 @@ def test_parse_frontmatter_valid_invalid_and_missing_yaml(monkeypatch):
     assert skill._parse_frontmatter(content) == {}
 
 
-def test_submit_example_and_existing_draft(monkeypatch):
+def test_submit_existing_draft(monkeypatch):
     post = Mock(return_value={"id": "skill-1"})
     resolve = Mock(return_value="resolved-draft")
     monkeypatch.setattr(skill.client, "post", post)
     monkeypatch.setattr(skill.client, "resolve_registry_reference", resolve)
-
-    example = runner.invoke(app, ["registry", "skill", "submit", "--example"])
-    assert example.exit_code == 0, example.output
-    examples = json.loads(example.output)
-    assert examples["registry_direct"]["delivery_mode"] == "registry_direct"
-    assert examples["git_fetch"]["skill_path"] == "skills/api-conventions"
-    post.assert_not_called()
 
     submitted = runner.invoke(app, ["registry", "skill", "submit", "--submit", "alice/draft"])
     assert submitted.exit_code == 0, submitted.output


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

This is **PR 2 of 3** in a stack. It depends on PR #1687 (output modes), and PR #1688 (stable error contract) is stacked above this PR. Review in that order.

Complete the help-and-examples slice of the agent-ready CLI contract. This change gives the root command, every command group, and every leaf command a concise set of realistic, copyable examples while removing the redundant component submission `--example` flags.

This PR is limited to help text and examples; it does not attempt to complete the broader Agent-ready CLI initiative.

## Fixes

* N/A — no linked issue was provided.

## Approach

* Audited all 218 CLI help screens: the root command, 34 nested groups, and 183 leaf commands.
* Added one to three examples to each help screen using its canonical command path.
* Corrected stale paths for support bundles, component versions, migration commands, and self-uninstall.
* Kept generated archive, ownership-transfer, and co-author help context-specific.
* Removed `--example` and its payload-printer helpers from MCP, skill, hook, and sandbox submission.
* Updated the related CLI documentation, bundled registry skill instructions, and generated command reference.
* Added regression coverage for help examples and removal of the four `--example` flags.

## How Has This Been Tested?

The following checks were run locally on macOS with Python 3.14.6:

* `uv run pytest -q observal_cli/tests/test_cmd_component_submit_flags.py tests/test_cmd_hook_coverage.py tests/test_cmd_mcp_coverage.py tests/test_cmd_skill_coverage.py` — 128 passed.
* `uv run ruff check observal_cli tests` — passed.
* `uv run ruff format --check observal_cli tests` — passed.
* `git diff --check` — passed.
* `make test` — 8,297 passed and 21 skipped; two unrelated server-package setup tests failed because macOS Bash 3.2 treats an empty `profile_args` array as unbound.
* `uv run pytest -q observal_cli/tests` — 81 passed; three existing agent-pull tests failed because the local environment had no configured server URL for lockfile operations.

## Learning (optional, can help others)

Typer's generated Click command tree can be traversed to validate every registered help screen. The regression test uses that tree to ensure each command has one to three examples and that every invocation begins with the command's canonical path.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (not applicable — no UI changes)

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes (pi coding agent using `gpt-5.6-sol`; used to apply and validate the supplied patch and prepare this PR)
- [ ] Was the generated code manually reviewed and tested? (Automated tests were run; human review is still required.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded CLI help with clearer descriptions and copyable examples across commands.
  - Updated registry submission guidance to use JSON files, local skill files, or pasted configurations.
  - Corrected command paths for registry versions, migrations, support tools, and self-uninstall.
  - Refreshed generated command references and registry workflow guidance.

- **Bug Fixes**
  - Removed outdated `--example` submission guidance and options for supported registry component types.
  - Simplified obsolete examples and clarified current command usage throughout the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

