### PR TITLE
refactor(cli): standardize table and JSON output modes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,10 +207,10 @@ Treat the CLI as an agent-facing API while preserving a clear human default:
 
 - Add copy-pasteable examples to root and every command and subcommand help screen; remove duplicate example options.
 - Make errors identify the failed operation and resource, the precise safe cause, a remediation, and a request ID; expose internal detail only under debug mode.
-- Add universal explicit JSON and plain modes. Finite JSON uses natural payloads: paginated lists return `{items, total, page, page_size}` and detail and mutation commands return direct result objects. JSON errors go to stderr with categorized non-zero exit codes; streams use JSON Lines. Plain output is colorless, headerless, and tab-separated.
+- Keep human-readable tables as the default and add universal explicit JSON mode. Finite JSON uses natural payloads: paginated lists return `{items, total, page, page_size}` and detail and mutation commands return direct result objects. JSON errors go to stderr with categorized non-zero exit codes; streams use JSON Lines.
 - Keep formatting separate from prompting, dry-run behavior, file writes, and output destinations. Retire inconsistent format options through a compatibility window. Use external `jq` rather than embedding another query language.
 
-**Complete when:** every command has deterministic human, JSON, and plain behavior; empty and error paths remain parseable; JSON mode never emits prompts, spinners, banners, or Rich text; and the bundled skills use JSON explicitly.
+**Complete when:** every command has deterministic table and JSON behavior; empty and error paths remain parseable; JSON mode never emits prompts, spinners, banners, or Rich text; and the bundled skills use JSON explicitly.
 
 #### Agent-readiness audit for every CLI command, P1
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -77,7 +77,6 @@ Read-heavy commands (`list`, `show`, `traces`, `spans`) support `--output`:
 ```bash
 observal registry mcp list --output table    # default, TTY-friendly
 observal registry mcp list --output json     # machine-readable
-observal registry mcp list --output plain    # CSV-like, script-friendly
 ```
 
 ## Aliases

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -101,7 +101,7 @@ observal agent list --full-id
 | `--page`, `-p` | Page number (1-indexed) |
 | `--id` | Include the agent ID column |
 | `--full-id` | Show full UUID (implies --id) |
-| `--output`, `-o` | Output format: table, json, plain |
+| `--output`, `-o` | Output format: table or json |
 
 ---
 
@@ -112,12 +112,11 @@ List your own agents across all statuses: pending, approved, rejected, and archi
 ```bash
 observal agent my
 observal agent my --output json
-observal agent my --output plain
 ```
 
 | Option | Description |
 | --- | --- |
-| `--output`, `-o` | Output format: table, json, plain |
+| `--output`, `-o` | Output format: table or json |
 
 ---
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -9,8 +9,8 @@ Display registry-backed harness model data.
 ## Synopsis
 
 ```bash
-observal registry models [--harness <name>] [--output table|json|plain]
-observal registry models list [--harness <name>] [--output table|json|plain]
+observal registry models [--harness <name>] [--output table|json]
+observal registry models list [--harness <name>] [--output table|json]
 ```
 
 ## Options
@@ -18,7 +18,7 @@ observal registry models list [--harness <name>] [--output table|json|plain]
 | Option | Description |
 | --- | --- |
 | `--harness <name>` | Filter to one harness, such as `claude-code`, `cursor`, or `pi`. |
-| `--output, -o <format>` | Output format: `table` (default), `json`, or `plain`. |
+| `--output, -o <format>` | Output format: `table` (default) or `json`. |
 
 ## Data source
 
@@ -28,6 +28,6 @@ The command reads the harness model JSON files packaged with Observal under `obs
 
 ```bash
 observal registry models
-observal registry models --harness pi --output plain
+observal registry models --harness pi --output json
 observal registry models list --harness claude-code --output json
 ```

--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -138,7 +138,7 @@ observal registry mcp submit --submit my-server
 List approved MCP servers in the registry.
 
 ```bash
-observal registry mcp list [--search TERM] [--category CAT] [--limit N] [--sort name|category|version] [--output table|json|plain] [--interactive]
+observal registry mcp list [--search TERM] [--category CAT] [--limit N] [--sort name|category|version] [--output table|json] [--interactive]
 ```
 
 | Option | Short | Description |
@@ -147,7 +147,7 @@ observal registry mcp list [--search TERM] [--category CAT] [--limit N] [--sort 
 | `--category` | `-c` | Filter by category |
 | `--limit` | `-n` | Max results (default: 50) |
 | `--sort` | | Sort by: `name`, `category`, `version` |
-| `--output` | `-o` | Output format: `table`, `json`, `plain` |
+| `--output` | `-o` | Output format: `table`, `json` |
 | `--interactive` | `-i` | Open a fuzzy-search picker |
 
 ```bash
@@ -164,7 +164,7 @@ observal registry mcp list --sort category --limit 10
 List your own MCP servers across all statuses (draft, pending, approved, rejected).
 
 ```bash
-observal registry mcp my [--output table|json|plain]
+observal registry mcp my [--output table|json]
 ```
 
 ```bash
@@ -297,7 +297,7 @@ observal registry skill submit --submit abc123
 List approved skills in the registry.
 
 ```bash
-observal registry skill list [--task-type TYPE] [--target-agent AGENT] [--search TERM] [--output table|json|plain]
+observal registry skill list [--task-type TYPE] [--target-agent AGENT] [--search TERM] [--output table|json]
 ```
 
 | Option | Short | Description |
@@ -305,7 +305,7 @@ observal registry skill list [--task-type TYPE] [--target-agent AGENT] [--search
 | `--task-type` | `-t` | Filter by task type |
 | `--target-agent` | | Filter by target agent |
 | `--search` | `-s` | Search by name or description |
-| `--output` | `-o` | Output format: `table`, `json`, `plain` |
+| `--output` | `-o` | Output format: `table`, `json` |
 
 ```bash
 observal registry skill list
@@ -321,7 +321,7 @@ observal registry skill list --search "refactor"
 List your own skills across all statuses (draft, pending, approved, rejected).
 
 ```bash
-observal registry skill my [--output table|json|plain]
+observal registry skill my [--output table|json]
 ```
 
 ```bash
@@ -437,14 +437,14 @@ observal registry hook submit --submit abc123
 List approved hooks from the registry.
 
 ```bash
-observal registry hook list [--event EVENT] [--search TERM] [--output table|json|plain]
+observal registry hook list [--event EVENT] [--search TERM] [--output table|json]
 ```
 
 | Option | Short | Description |
 | --- | --- | --- |
 | `--event` | `-e` | Filter by event type |
 | `--search` | `-s` | Search by name or description |
-| `--output` | `-o` | Output format: `table`, `json`, `plain` |
+| `--output` | `-o` | Output format: `table`, `json` |
 
 ```bash
 observal registry hook list
@@ -550,14 +550,14 @@ observal registry prompt submit --submit abc123
 List approved prompts in the registry.
 
 ```bash
-observal registry prompt list [--category CAT] [--search TERM] [--output table|json|plain]
+observal registry prompt list [--category CAT] [--search TERM] [--output table|json]
 ```
 
 | Option | Short | Description |
 | --- | --- | --- |
 | `--category` | `-c` | Filter by category |
 | `--search` | `-s` | Search by name or description |
-| `--output` | `-o` | Output format: `table`, `json`, `plain` |
+| `--output` | `-o` | Output format: `table`, `json` |
 
 ```bash
 observal registry prompt list
@@ -572,7 +572,7 @@ observal registry prompt list --search "refactor" --output json
 List your own prompts across all statuses (draft, pending, approved, rejected).
 
 ```bash
-observal registry prompt my [--output table|json|plain]
+observal registry prompt my [--output table|json]
 ```
 
 ```bash
@@ -691,14 +691,14 @@ observal registry sandbox submit --submit abc123
 List approved sandboxes in the registry.
 
 ```bash
-observal registry sandbox list [--runtime TYPE] [--search TERM] [--output table|json|plain]
+observal registry sandbox list [--runtime TYPE] [--search TERM] [--output table|json]
 ```
 
 | Option | Short | Description |
 | --- | --- | --- |
 | `--runtime` | `-r` | Filter by runtime type |
 | `--search` | `-s` | Search by name or description |
-| `--output` | `-o` | Output format: `table`, `json`, `plain` |
+| `--output` | `-o` | Output format: `table`, `json` |
 
 ```bash
 observal registry sandbox list

--- a/docs/cli/skill.md
+++ b/docs/cli/skill.md
@@ -80,7 +80,7 @@ observal skill list --search "refactor"
 | `--task-type`, `-t` | Filter by task type |
 | `--target-agent` | Filter by target agent |
 | `--search`, `-s` | Filter by search term |
-| `--output`, `-o` | Output format: table, json, plain (default: table) |
+| `--output`, `-o` | Output format: table or json (default: table) |
 
 ---
 
@@ -96,7 +96,7 @@ observal skill my --output json
 
 | Option | Description |
 | --- | --- |
-| `--output`, `-o` | Output format: table, json, plain (default: table) |
+| `--output`, `-o` | Output format: table or json (default: table) |
 
 ---
 

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -26,6 +26,7 @@ from observal_cli import client, config
 from observal_cli.constants import AGENT_NAME_REGEX, VALID_HARNESSES
 from observal_cli.prompts import fuzzy_select, select_many, select_one, text_input
 from observal_cli.render import (
+    OutputMode,
     console,
     display_name,
     handle,
@@ -453,7 +454,7 @@ def agent_list(
     page: int = typer.Option(1, "--page", "-p", min=1, help="Page number (1-indexed)"),
     show_id: bool = typer.Option(False, "--id", help="Include the agent ID column"),
     full_id: bool = typer.Option(False, "--full-id", help="Show full UUID (implies --id)"),
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List active agents (paginated).
 
@@ -495,6 +496,10 @@ def agent_list(
     total = int(headers.get("x-total-count", str(len(data))))
     total_pages = max(1, (total + limit - 1) // limit)
 
+    if output == "json":
+        output_json({"items": data, "total": total, "page": page, "page_size": limit})
+        return
+
     if not data:
         if total == 0:
             rprint("[dim]No agents found.[/dim]")
@@ -504,15 +509,6 @@ def agent_list(
 
     # Cache IDs for numeric shorthand
     config.save_last_results(data)
-
-    if output == "json":
-        output_json(data)
-        return
-
-    if output == "plain":
-        for item in data:
-            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('model_name', '')}")
-        return
 
     include_id = show_id or full_id
     table = Table(
@@ -547,7 +543,7 @@ def agent_list(
 
 @agent_app.command(name="my")
 def agent_my(
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List your own agents (all statuses).
 
@@ -558,7 +554,6 @@ def agent_my(
     Examples:
       observal agent my
       observal agent my --output json
-      observal agent my --output plain
     """
     with spinner("Fetching your agents..."):
         data = client.get("/api/v1/agents/my")
@@ -568,10 +563,6 @@ def agent_my(
     config.save_last_results(data)
     if output == "json":
         output_json(data)
-        return
-    if output == "plain":
-        for item in data:
-            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My Agents ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -597,7 +588,7 @@ def agent_my(
 @agent_app.command(name="show")
 def agent_show(
     agent_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show full agent details.
 
@@ -1193,7 +1184,7 @@ def agent_release(
 @agent_app.command(name="versions")
 def agent_versions(
     name: str = typer.Argument(..., help="Agent name, ID, row number, or @alias"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List all versions for an agent.
 

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -496,6 +496,10 @@ def agent_list(
     total = int(headers.get("x-total-count", str(len(data))))
     total_pages = max(1, (total + limit - 1) // limit)
 
+    if data:
+        # Preserve numeric shorthand after both table and JSON listings.
+        config.save_last_results(data)
+
     if output == "json":
         output_json({"items": data, "total": total, "page": page, "page_size": limit})
         return
@@ -506,9 +510,6 @@ def agent_list(
         else:
             rprint(f"[yellow]Page {page} is empty. Total agents: {total} (last page: {total_pages})[/yellow]")
         return
-
-    # Cache IDs for numeric shorthand
-    config.save_last_results(data)
 
     include_id = show_id or full_id
     table = Table(

--- a/observal_cli/cmd_auth.py
+++ b/observal_cli/cmd_auth.py
@@ -30,7 +30,7 @@ from rich import print as rprint
 from observal_cli import client, config
 from observal_cli.branding import welcome_banner
 from observal_cli.prompts import password_input, quick_choice, text_input
-from observal_cli.render import console, kv_panel, spinner, status_badge
+from observal_cli.render import OutputMode, console, kv_panel, spinner, status_badge
 from observal_shared.namespace_rules import NAMESPACE_RULE_TEXT, is_valid_namespace
 
 # ── Auth subgroup ───────────────────────────────────────────
@@ -369,7 +369,7 @@ def logout():
 
 @auth_app.command()
 def whoami(
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table, json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table, json"),
 ):
     """Show current authenticated user.
 
@@ -811,7 +811,7 @@ def register_config(app: typer.Typer):
         """Set a CLI config value.
 
         Persists the given key/value pair to ~/.observal/config.json.
-        Common keys: output (table/json/plain), color (true/false),
+        Common keys: output (table/json), color (true/false),
         server_url.
 
         Examples:
@@ -820,6 +820,8 @@ def register_config(app: typer.Typer):
             observal config set server_url http://observal.internal:80
         """
         optic.trace("key={}, value={}", key, value)
+        if key == "output" and value not in ("table", "json"):
+            raise typer.BadParameter("output must be 'table' or 'json'", param_hint="value")
         if key == "server_url":
             from observal_cli.lockfile import migrate_lockfile_v1
 

--- a/observal_cli/cmd_component.py
+++ b/observal_cli/cmd_component.py
@@ -19,7 +19,7 @@ from rich.table import Table
 
 from observal_cli import client
 from observal_cli.prompts import text_input
-from observal_cli.render import console, output_json, relative_time, spinner, status_badge
+from observal_cli.render import OutputMode, console, output_json, relative_time, spinner, status_badge
 
 # ── Constants ──────────────────────────────────────────────────
 
@@ -154,7 +154,7 @@ def version_publish(
 def version_list(
     component_type: str = typer.Argument(..., help="Component type: hook, skill, prompt, mcp, sandbox"),
     listing: str = typer.Argument(..., help="Listing name or ID"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List version history for a registry component.
 

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -24,11 +24,11 @@ from observal_cli.constants import (
 )
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
+    OutputMode,
     console,
     display_name,
     handle,
     kv_panel,
-    name_inline,
     output_json,
     relative_time,
     spinner,
@@ -304,7 +304,7 @@ def hook_list(
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
     team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List approved hooks from the registry.
 
@@ -316,7 +316,7 @@ def hook_list(
       observal registry hook list
       observal registry hook list --event Stop
       observal registry hook list --search guard --output json
-      observal registry hook list -o plain
+      observal registry hook list -o json
     """
     params = {}
     if event:
@@ -335,10 +335,6 @@ def hook_list(
     config.save_last_results(data)
     if output == "json":
         output_json(data)
-        return
-    if output == "plain":
-        for item in data:
-            rprint(f"{item['id']}  {name_inline(item)}  {item.get('event', '?')}")
         return
     table = Table(title=f"Hooks ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -364,7 +360,7 @@ def hook_list(
 @hook_app.command(name="show")
 def hook_show(
     hook_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show detailed information for a single hook.
 

--- a/observal_cli/cmd_hook.py
+++ b/observal_cli/cmd_hook.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json as _json
 import os
+from contextlib import nullcontext
 from pathlib import Path
 
 import typer
@@ -327,10 +328,14 @@ def hook_list(
         params["namespace"] = namespace.lstrip("@").lower()
     if team:
         params["team_id"] = client.resolve_team_id(team)
-    with spinner("Fetching hooks..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching hooks...")
+    with fetch_ctx:
         data = client.get("/api/v1/hooks", params=params)
     if not data:
-        rprint("[dim]No hooks found.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]No hooks found.[/dim]")
         return
     config.save_last_results(data)
     if output == "json":
@@ -376,7 +381,8 @@ def hook_show(
       observal registry hook show abc123 -o json
     """
     resolved = client.resolve_registry_reference("hook", hook_id)
-    with spinner():
+    fetch_ctx = nullcontext() if output == "json" else spinner()
+    with fetch_ctx:
         item = client.get(f"/api/v1/hooks/{resolved}")
     if output == "json":
         output_json(item)

--- a/observal_cli/cmd_inbox.py
+++ b/observal_cli/cmd_inbox.py
@@ -20,7 +20,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.render import console, esc, output_json, spinner
+from observal_cli.render import OutputMode, console, esc, output_json, spinner
 
 inbox_app = typer.Typer(
     name="inbox",
@@ -159,7 +159,7 @@ def inbox(
     unread: bool = typer.Option(False, "--unread", help="Only unread items"),
     page: int = typer.Option(1, "--page", "-p", min=1, help="Page number"),
     page_size: int = typer.Option(25, "--page-size", min=1, max=100, help="Items per page"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """Show your inbox.
 
@@ -183,7 +183,7 @@ def inbox_list(
     unread: bool = typer.Option(False, "--unread", help="Only unread items"),
     page: int = typer.Option(1, "--page", "-p", min=1, help="Page number"),
     page_size: int = typer.Option(25, "--page-size", min=1, max=100, help="Items per page"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List your inbox items.
 
@@ -196,7 +196,7 @@ def inbox_list(
 
 @inbox_app.command(name="count")
 def inbox_count(
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """Show unread and needs-action counts.
 
@@ -219,7 +219,7 @@ def inbox_count(
 @inbox_app.command(name="show")
 def inbox_show(
     item_id: str = typer.Argument(..., help="Inbox item ID"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """Show one item with its full action history.
 

--- a/observal_cli/cmd_insights.py
+++ b/observal_cli/cmd_insights.py
@@ -11,7 +11,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.render import console, esc, output_json, relative_time, spinner, status_badge
+from observal_cli.render import OutputMode, console, esc, output_json, relative_time, spinner, status_badge
 
 insights_app = typer.Typer(help="Agent insight reports")
 
@@ -82,7 +82,7 @@ def _resolve_report_for_show(target: str, report_ref: str | None) -> dict:
 @insights_app.command(name="list")
 def insights_list(
     agent_id: str = typer.Argument(..., help="Agent ID, name, or @alias"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """List insight reports for an agent.
 
@@ -129,7 +129,7 @@ def insights_list(
 def insights_show(
     target: str = typer.Argument(..., help="Agent name, agent ID, or @alias"),
     report_ref: str | None = typer.Argument(None, help="Report row number, report ID prefix, or 'latest'"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
     section: str | None = typer.Option(None, "--section", "-s", help="Show only a specific section"),
 ):
     """Show an insight report with pretty-printed narrative.
@@ -578,7 +578,7 @@ def insights_generate(
     period_days: int = typer.Option(14, "--period", "-p", help="Analysis period in days"),
     agent_version: str | None = typer.Option(None, "--version", "-v", help="Agent version to analyze"),
     compare_version: str | None = typer.Option(None, "--compare", help="Baseline agent version for A/B comparison"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
     wait: bool = typer.Option(False, "--wait", help="Poll until the report completes"),
 ):
     """Trigger generation of a new insight report.

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 
 import typer
@@ -934,14 +935,18 @@ def _list_impl(category, search, limit, sort, output, interactive=False, namespa
     if team:
         params["team_id"] = client.resolve_team_id(team)
 
-    with spinner("Fetching MCP servers..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching MCP servers...")
+    with fetch_ctx:
         data = client.get("/api/v1/mcps", params=params)
 
     if not data:
-        rprint("[dim]No MCP servers found.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]No MCP servers found.[/dim]")
         return
 
-    if interactive:
+    if interactive and output != "json":
 
         def _display(item: dict) -> str:
             optic.trace("item={}", item)
@@ -988,7 +993,8 @@ def _list_impl(category, search, limit, sort, output, interactive=False, namespa
 def _show_impl(mcp_id, output):
     optic.trace("mcp_id={}, output={}", mcp_id, output)
     resolved = client.resolve_registry_reference("mcp", mcp_id)
-    with spinner():
+    fetch_ctx = nullcontext() if output == "json" else spinner()
+    with fetch_ctx:
         item = client.get(f"/api/v1/mcps/{resolved}")
 
     if output == "json":
@@ -1375,10 +1381,14 @@ def mcp_my(
         observal registry mcp my --output json
     """
     optic.trace("output={}", output)
-    with spinner("Fetching your MCPs..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching your MCPs...")
+    with fetch_ctx:
         data = client.get("/api/v1/mcps/my")
     if not data:
-        rprint("[dim]You have no MCP servers.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]You have no MCP servers.[/dim]")
         return
     config.save_last_results(data)
     if output == "json":

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -25,6 +25,7 @@ from observal_cli.analyzer import analyze_local
 from observal_cli.constants import VALID_HARNESSES, VALID_MCP_CATEGORIES
 from observal_cli.prompts import fuzzy_select, select_one, text_input
 from observal_cli.render import (
+    OutputMode,
     console,
     display_name,
     handle,
@@ -963,11 +964,6 @@ def _list_impl(category, search, limit, sort, output, interactive=False, namespa
         output_json(data)
         return
 
-    if output == "plain":
-        for item in data:
-            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}  [{item.get('category', '')}]")
-        return
-
     table = Table(title=f"MCP Servers ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
@@ -1330,7 +1326,7 @@ def list_mcps(
     interactive: bool = typer.Option(False, "--interactive", "-i", help="Interactive search mode"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
     sort: str = typer.Option("name", "--sort", help="Sort by: name, category, version"),
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List approved MCP servers in the registry.
 
@@ -1363,7 +1359,7 @@ def list_mcps(
 
 @mcp_app.command(name="my")
 def mcp_my(
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List your own MCP servers across all statuses.
 
@@ -1377,9 +1373,6 @@ def mcp_my(
 
         # JSON output for scripting
         observal registry mcp my --output json
-
-        # Plain output (one per line)
-        observal registry mcp my --output plain
     """
     optic.trace("output={}", output)
     with spinner("Fetching your MCPs..."):
@@ -1390,10 +1383,6 @@ def mcp_my(
     config.save_last_results(data)
     if output == "json":
         output_json(data)
-        return
-    if output == "plain":
-        for item in data:
-            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My MCPs ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -1417,7 +1406,7 @@ def mcp_my(
 @mcp_app.command()
 def show(
     mcp_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output: table, json"),
 ):
     """Show full details of an MCP server.
 

--- a/observal_cli/cmd_models.py
+++ b/observal_cli/cmd_models.py
@@ -7,28 +7,23 @@
 
 from __future__ import annotations
 
-import json
-
 import typer
 from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import model_catalog
+from observal_cli.render import OutputMode, output_json
 
 models_app = typer.Typer(name="models", help="Inspect registry-backed harness model data.", no_args_is_help=False)
 
 
-def _emit(harness: str | None, output: str) -> None:
+def _emit(harness: str | None, output: OutputMode) -> None:
     try:
         rows = model_catalog.fetch_catalog(harness=harness).get("models") or []
     except ValueError as exc:
         raise typer.BadParameter(str(exc), param_hint="harness") from exc
     if output == "json":
-        rprint(json.dumps(rows, indent=2))
-        return
-    if output == "plain":
-        for row in rows:
-            rprint(f"{row['harness']}\t{row['model_id']}\t{row.get('kind', 'exact')}\t{row.get('display_name', '')}")
+        output_json(rows)
         return
     table = Table(show_header=True, header_style="bold cyan")
     table.add_column("harness")
@@ -45,7 +40,7 @@ def _emit(harness: str | None, output: str) -> None:
 def models(
     ctx: typer.Context,
     harness: str | None = typer.Option(None, "--harness", help="Filter to one harness."),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table | json | plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     if ctx.invoked_subcommand is None:
         if harness == "--help":
@@ -57,6 +52,6 @@ def models(
 @models_app.command("list")
 def list_models(
     harness: str | None = typer.Option(None, "--harness", help="Filter to one harness."),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table | json | plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     _emit(harness, output)

--- a/observal_cli/cmd_ops.py
+++ b/observal_cli/cmd_ops.py
@@ -19,6 +19,7 @@ from rich.table import Table
 from observal_cli import client, config
 from observal_cli.prompts import password_input
 from observal_cli.render import (
+    OutputMode,
     console,
     kv_panel,
     output_json,
@@ -48,7 +49,7 @@ review_app = typer.Typer(help="Admin review commands")
 def review_list(
     type_filter: str = typer.Option(None, "--type", "-t", help="Filter by type (mcp, skill, hook, prompt, sandbox)"),
     tab: str = typer.Option(None, "--tab", help="Filter tab (agents, components)"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """List pending submissions awaiting admin review.
 
@@ -107,7 +108,7 @@ def review_list(
 @review_app.command(name="show")
 def review_show(
     review_id: str = typer.Argument(..., help="Name, row #, @alias, or UUID"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show review details for a component or agent.
 
@@ -305,7 +306,7 @@ def telemetry_test():
 def _metrics(
     item_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
     item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
     watch: bool = typer.Option(False, "--watch", "-w", help="Refresh every 5s"),
 ):
     """Show metrics for an MCP server or agent.
@@ -380,7 +381,7 @@ def _metrics_impl(item_id, item_type, output, watch):
 @ops_app.command(name="top")
 def _top(
     item_type: str = typer.Option("mcp", "--type", "-t", help="mcp or agent"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show top MCP servers or agents by usage.
 
@@ -544,7 +545,7 @@ def _resolve_listing_id(listing_id: str, listing_type: str) -> str:
 def _feedback(
     listing_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
     listing_type: str = typer.Option("mcp", "--type", "-t"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show feedback for an MCP server or agent.
 
@@ -592,7 +593,7 @@ admin_app = typer.Typer(help="Admin commands")
 
 
 @admin_app.command(name="settings")
-def admin_settings(output: str = typer.Option("table", "--output", "-o")):
+def admin_settings(output: OutputMode = typer.Option("table", "--output", "-o")):
     """List server settings.
 
     Displays all configured key-value server settings.
@@ -641,7 +642,7 @@ def admin_set(
 
 
 @admin_app.command(name="users")
-def admin_users(output: str = typer.Option("table", "--output", "-o")):
+def admin_users(output: OutputMode = typer.Option("table", "--output", "-o")):
     """List all users.
 
     Displays all registered users with their email, name, role, and ID.
@@ -679,7 +680,7 @@ def admin_create_user(
     username: str = typer.Option(None, "--username", "-u", help="Username (optional)"),
     role: str = typer.Option("reviewer", "--role", "-r", help="Role: admin, reviewer, or user"),
     password: str = typer.Option(None, "--password", "-p", help="Password (auto-generated if omitted)"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Create a new user account. Requires admin privileges.
 
@@ -797,7 +798,7 @@ def admin_delete_user(
 
 
 @admin_app.command(name="diagnostics")
-def admin_diagnostics(output: str = typer.Option("table", "--output", "-o")):
+def admin_diagnostics(output: OutputMode = typer.Option("table", "--output", "-o")):
     """Show system diagnostics and health status.
 
     Reports overall system health, database connectivity, JWT key status,
@@ -850,7 +851,7 @@ def admin_diagnostics(output: str = typer.Option("table", "--output", "-o")):
 
 
 @admin_app.command(name="saml-config")
-def admin_saml_config(output: str = typer.Option("table", "--output", "-o")):
+def admin_saml_config(output: OutputMode = typer.Option("table", "--output", "-o")):
     """View current SAML SSO configuration.
 
     Displays the IdP entity ID, SSO/SLO URLs, SP entity ID, and whether
@@ -948,7 +949,7 @@ def admin_saml_config_delete(
 
 
 @admin_app.command(name="scim-tokens")
-def admin_scim_tokens(output: str = typer.Option("table", "--output", "-o")):
+def admin_scim_tokens(output: OutputMode = typer.Option("table", "--output", "-o")):
     """List SCIM provisioning tokens.
 
     Shows all SCIM bearer tokens with their prefix, description,
@@ -1044,7 +1045,7 @@ def admin_security_events(
     severity: str = typer.Option(None, "--severity", "-s", help="Filter: info, warning, critical"),
     actor: str = typer.Option(None, "--actor", "-a", help="Filter by actor email"),
     limit: int = typer.Option(50, "--limit", "-n"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """View security events log.
 
@@ -1114,7 +1115,7 @@ def admin_audit_log(
     actor: str = typer.Option(None, "--actor", help="Filter by actor email"),
     resource_type: str = typer.Option(None, "--resource-type", "-r", help="Filter by resource type"),
     limit: int = typer.Option(50, "--limit", "-n"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Query the audit log.
 
@@ -1323,7 +1324,7 @@ def _traces(
     limit: int = typer.Option(20, "--limit", "-n"),
     turn: bool = typer.Option(False, "--turn", help="Unfold sessions to show turns (prompts)"),
     span: bool = typer.Option(False, "--span", help="Show full detail including tool calls"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """List recent traces (sessions).
 
@@ -1491,7 +1492,7 @@ def _format_tokens(input_tokens: int, output_tokens: int) -> str:
 @ops_app.command(name="spans")
 def _spans(
     trace_id: str = typer.Argument(..., help="Trace ID"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """List spans for a trace.
 

--- a/observal_cli/cmd_outdated.py
+++ b/observal_cli/cmd_outdated.py
@@ -10,7 +10,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.render import console, spinner
+from observal_cli.render import OutputMode, console, spinner
 
 outdated_app = typer.Typer(
     name="outdated",
@@ -24,7 +24,7 @@ def register_outdated(app: typer.Typer):
     @app.command("outdated")
     def outdated(
         harness: str | None = typer.Option(None, "--harness", "-i", help="Filter by harness"),
-        output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+        output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
         report: bool = typer.Option(
             True,
             "--report/--no-report",

--- a/observal_cli/cmd_outdated.py
+++ b/observal_cli/cmd_outdated.py
@@ -5,12 +5,14 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 import typer
 from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.render import OutputMode, console, spinner
+from observal_cli.render import OutputMode, console, output_json, spinner
 
 outdated_app = typer.Typer(
     name="outdated",
@@ -51,15 +53,20 @@ def register_outdated(app: typer.Typer):
 
         entries = get_all_entries(harness=harness)
         if not entries:
-            rprint("[dim]No installed agents or components found in lock file.[/dim]")
-            rprint("[dim]Run `observal agent pull` or `observal registry mcp install` first.[/dim]")
+            if output == "json":
+                output_json([])
+            else:
+                rprint("[dim]No installed agents or components found in lock file.[/dim]")
+                rprint("[dim]Run `observal agent pull` or `observal registry mcp install` first.[/dim]")
             raise typer.Exit(0)
 
-        rprint(f"\n[bold]Checking {len(entries)} installed item(s)...[/bold]\n")
+        if output != "json":
+            rprint(f"\n[bold]Checking {len(entries)} installed item(s)...[/bold]\n")
 
         results: list[dict] = []
 
-        with spinner("Fetching latest versions from registry..."):
+        fetch_ctx = nullcontext() if output == "json" else spinner("Fetching latest versions from registry...")
+        with fetch_ctx:
             for entry in entries:
                 entry_type = entry.get("entry_type", "")
                 component_type = entry.get("type", "")
@@ -121,9 +128,7 @@ def register_outdated(app: typer.Typer):
         reported = _report_to_inbox(outdated_items) if report else None
 
         if output == "json":
-            import json
-
-            print(json.dumps(results, indent=2))
+            output_json(results)
             return
 
         up_to_date = [r for r in results if not r["outdated"] and not r["error"]]

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import json as _json
+from contextlib import nullcontext
 
 import typer
 from rich import print as rprint
@@ -172,10 +173,14 @@ def prompt_list(
         params["namespace"] = namespace.lstrip("@").lower()
     if team:
         params["team_id"] = client.resolve_team_id(team)
-    with spinner("Fetching prompts..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching prompts...")
+    with fetch_ctx:
         data = client.get("/api/v1/prompts", params=params)
     if not data:
-        rprint("[dim]No prompts found.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]No prompts found.[/dim]")
         return
     config.save_last_results(data)
     if output == "json":
@@ -213,10 +218,14 @@ def prompt_my(
         observal registry prompt my
         observal registry prompt my --output json
     """
-    with spinner("Fetching your prompts..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching your prompts...")
+    with fetch_ctx:
         data = client.get("/api/v1/prompts/my")
     if not data:
-        rprint("[dim]You have no prompts.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]You have no prompts.[/dim]")
         return
     config.save_last_results(data)
     if output == "json":
@@ -258,7 +267,8 @@ def prompt_show(
         observal registry prompt show abc123 --output json
     """
     resolved = client.resolve_registry_reference("prompt", prompt_id)
-    with spinner():
+    fetch_ctx = nullcontext() if output == "json" else spinner()
+    with fetch_ctx:
         item = client.get(f"/api/v1/prompts/{resolved}")
     if output == "json":
         output_json(item)

--- a/observal_cli/cmd_prompt.py
+++ b/observal_cli/cmd_prompt.py
@@ -19,11 +19,11 @@ from observal_cli import client, config
 from observal_cli.constants import VALID_PROMPT_CATEGORIES
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
+    OutputMode,
     console,
     display_name,
     handle,
     kv_panel,
-    name_inline,
     output_json,
     relative_time,
     spinner,
@@ -150,7 +150,7 @@ def prompt_list(
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
     team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List approved prompts in the registry.
 
@@ -181,10 +181,6 @@ def prompt_list(
     if output == "json":
         output_json(data)
         return
-    if output == "plain":
-        for item in data:
-            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}")
-        return
     table = Table(title=f"Prompts ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
@@ -206,7 +202,7 @@ def prompt_list(
 
 @prompt_app.command(name="my")
 def prompt_my(
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List your own prompts across all statuses.
 
@@ -225,10 +221,6 @@ def prompt_my(
     config.save_last_results(data)
     if output == "json":
         output_json(data)
-        return
-    if output == "plain":
-        for item in data:
-            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My Prompts ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -252,7 +244,7 @@ def prompt_my(
 @prompt_app.command(name="show")
 def prompt_show(
     prompt_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show detailed information about a prompt.
 

--- a/observal_cli/cmd_recommend.py
+++ b/observal_cli/cmd_recommend.py
@@ -15,7 +15,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.render import console, esc, output_json, spinner
+from observal_cli.render import OutputMode, console, esc, output_json, spinner
 
 recommend_app = typer.Typer(
     name="recommend",
@@ -122,7 +122,7 @@ def recommend(
     limit: int = typer.Option(8, "--limit", "-n", min=1, max=24, help="How many to return"),
     type_: str | None = typer.Option(None, "--type", "-t", help="Restrict to one component type"),
     refresh: bool = typer.Option(False, "--refresh", help="Recompute your profile instead of using the cache"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """Show components recommended for you.
 
@@ -143,7 +143,7 @@ def recommend_list(
     limit: int = typer.Option(8, "--limit", "-n", min=1, max=24, help="How many to return"),
     type_: str | None = typer.Option(None, "--type", "-t", help="Restrict to one component type"),
     refresh: bool = typer.Option(False, "--refresh", help="Recompute your profile instead of using the cache"),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """Show components recommended for you.
 

--- a/observal_cli/cmd_recommend.py
+++ b/observal_cli/cmd_recommend.py
@@ -10,6 +10,8 @@ profile, matching the server, which exposes no such route either.
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 import typer
 from rich import print as rprint
 from rich.table import Table
@@ -47,14 +49,15 @@ def _normalize_type(raw: str) -> str:
     return normalized
 
 
-def _emit(limit: int, type_: str | None, refresh: bool, output: str) -> None:
+def _emit(limit: int, type_: str | None, refresh: bool, output: OutputMode) -> None:
     params: dict[str, object] = {"limit": limit}
     if type_:
         params["type"] = _normalize_type(type_)
     if refresh:
         params["refresh"] = True
 
-    with spinner("Fetching recommendations..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching recommendations...")
+    with fetch_ctx:
         data = client.get("/api/v1/recommendations/me", params=params)
 
     if output == "json":

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import json as _json
+from contextlib import nullcontext
 
 import typer
 from rich import print as rprint
@@ -264,10 +265,14 @@ def sandbox_list(
         params["namespace"] = namespace.lstrip("@").lower()
     if team:
         params["team_id"] = client.resolve_team_id(team)
-    with spinner("Fetching sandboxes..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching sandboxes...")
+    with fetch_ctx:
         data = client.get("/api/v1/sandboxes", params=params)
     if not data:
-        rprint("[dim]No sandboxes found.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]No sandboxes found.[/dim]")
         return
     config.save_last_results(data)
     if output == "json":
@@ -309,7 +314,8 @@ def sandbox_show(
         observal registry sandbox show @dev-env --output json
     """
     resolved = client.resolve_registry_reference("sandbox", sandbox_id)
-    with spinner():
+    fetch_ctx = nullcontext() if output == "json" else spinner()
+    with fetch_ctx:
         item = client.get(f"/api/v1/sandboxes/{resolved}")
     if output == "json":
         output_json(item)

--- a/observal_cli/cmd_sandbox.py
+++ b/observal_cli/cmd_sandbox.py
@@ -18,11 +18,11 @@ from observal_cli import client, config
 from observal_cli.constants import VALID_HARNESSES, VALID_SANDBOX_NETWORK_POLICIES, VALID_SANDBOX_RUNTIME_TYPES
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
+    OutputMode,
     console,
     display_name,
     handle,
     kv_panel,
-    name_inline,
     output_json,
     relative_time,
     spinner,
@@ -242,7 +242,7 @@ def sandbox_list(
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
     team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List approved sandboxes in the registry.
 
@@ -273,10 +273,6 @@ def sandbox_list(
     if output == "json":
         output_json(data)
         return
-    if output == "plain":
-        for item in data:
-            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}")
-        return
     table = Table(title=f"Sandboxes ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
@@ -299,7 +295,7 @@ def sandbox_list(
 @sandbox_app.command(name="show")
 def sandbox_show(
     sandbox_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show detailed information about a sandbox.
 

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -30,7 +30,7 @@ from observal_cli.harness import (
     get_adapter,
     get_all_adapters,
 )
-from observal_cli.render import console, spinner
+from observal_cli.render import OutputMode, console, spinner
 
 # ── harness home directory paths (for status display) ────────────────
 
@@ -54,7 +54,7 @@ def register_scan(app: typer.Typer):
     @app.command(name="scan")
     def scan(
         harness: str | None = typer.Option(None, "--harness", "-i", help="Filter to a specific harness"),
-        output: str = typer.Option("table", "--output", "-o", help="Output format: table or json"),
+        output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
     ):
         """Show a read-only inventory of your local harness setup.
 

--- a/observal_cli/cmd_scan.py
+++ b/observal_cli/cmd_scan.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import json
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -30,7 +29,7 @@ from observal_cli.harness import (
     get_adapter,
     get_all_adapters,
 )
-from observal_cli.render import OutputMode, console, spinner
+from observal_cli.render import OutputMode, console, output_json, spinner
 
 # ── harness home directory paths (for status display) ────────────────
 
@@ -81,8 +80,12 @@ def register_scan(app: typer.Typer):
                 get_adapter(harness)
             except KeyError:
                 valid = sorted(get_all_adapters().keys())
-                rprint(f"[red]Unknown harness: {harness}[/red]")
-                rprint(f"Valid harnesses: {', '.join(valid)}")
+                if output == "json":
+                    typer.echo(f"Unknown harness: {harness}", err=True)
+                    typer.echo(f"Valid harnesses: {', '.join(valid)}", err=True)
+                else:
+                    rprint(f"[red]Unknown harness: {harness}[/red]")
+                    rprint(f"Valid harnesses: {', '.join(valid)}")
                 raise typer.Exit(1)
 
         adapters = {harness: get_adapter(harness)} if harness else get_all_adapters()
@@ -159,7 +162,7 @@ def register_scan(app: typer.Typer):
 
         if total == 0 and not ide_status:
             if output == "json":
-                print(json.dumps({"harnesses": [], "mcps": [], "skills": [], "hooks": [], "agents": []}, indent=2))
+                output_json({"harnesses": [], "mcps": [], "skills": [], "hooks": [], "agents": []})
                 return
             rprint("[yellow]No harness configurations found.[/yellow]")
             raise typer.Exit(1)
@@ -173,7 +176,7 @@ def register_scan(app: typer.Typer):
                 "hooks": [vars(h) for h in all_hooks],
                 "agents": [vars(a) for a in all_agents],
             }
-            print(json.dumps(out_data, indent=2))
+            output_json(out_data)
             return
 
         rprint(f"\n[bold]Observal Scan[/bold] - {total} components discovered\n")

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -23,11 +23,11 @@ from observal_cli import client, config
 from observal_cli.constants import VALID_SKILL_TASK_TYPES
 from observal_cli.prompts import select_one, text_input
 from observal_cli.render import (
+    OutputMode,
     console,
     display_name,
     handle,
     kv_panel,
-    name_inline,
     output_json,
     relative_time,
     spinner,
@@ -294,7 +294,7 @@ def skill_list(
     search: str | None = typer.Option(None, "--search", "-s"),
     namespace: str | None = typer.Option(None, "--namespace", help="Filter by user or team namespace"),
     team: str | None = typer.Option(None, "--team", help="Only items owned by this teamspace"),
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List approved skills in the registry.
 
@@ -330,10 +330,6 @@ def skill_list(
     if output == "json":
         output_json(data)
         return
-    if output == "plain":
-        for item in data:
-            rprint(f"{item['id']}  {name_inline(item)}  v{item.get('version', '?')}")
-        return
     table = Table(title=f"Skills ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
     table.add_column("Name", style="bold cyan", no_wrap=True)
@@ -355,7 +351,7 @@ def skill_list(
 
 @skill_app.command(name="my")
 def skill_my(
-    output: str = typer.Option("table", "--output", "-o", help="Output: table, json, plain"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json"),
 ):
     """List your own skills across all statuses.
 
@@ -374,10 +370,6 @@ def skill_my(
     config.save_last_results(data)
     if output == "json":
         output_json(data)
-        return
-    if output == "plain":
-        for item in data:
-            rprint(f"{name_inline(item)}  v{item.get('version', '?')}  {item.get('status', '')}")
         return
     table = Table(title=f"My Skills ({len(data)})", show_lines=False, padding=(0, 1))
     table.add_column("#", style="dim", width=3)
@@ -404,7 +396,7 @@ def skill_my(
 @skill_app.command(name="show")
 def skill_show(
     skill_id: str = typer.Argument(..., help="ID, name, row number, or @alias"),
-    output: str = typer.Option("table", "--output", "-o"),
+    output: OutputMode = typer.Option("table", "--output", "-o"),
 ):
     """Show detailed information about a skill.
 

--- a/observal_cli/cmd_skill.py
+++ b/observal_cli/cmd_skill.py
@@ -13,6 +13,7 @@ import json as _json
 import re
 import subprocess
 import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 
 import typer
@@ -321,10 +322,14 @@ def skill_list(
         params["namespace"] = namespace.lstrip("@").lower()
     if team:
         params["team_id"] = client.resolve_team_id(team)
-    with spinner("Fetching skills..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching skills...")
+    with fetch_ctx:
         data = client.get("/api/v1/skills", params=params)
     if not data:
-        rprint("[dim]No skills found.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]No skills found.[/dim]")
         return
     config.save_last_results(data)
     if output == "json":
@@ -362,10 +367,14 @@ def skill_my(
         observal registry skill my
         observal registry skill my --output json
     """
-    with spinner("Fetching your skills..."):
+    fetch_ctx = nullcontext() if output == "json" else spinner("Fetching your skills...")
+    with fetch_ctx:
         data = client.get("/api/v1/skills/my")
     if not data:
-        rprint("[dim]You have no skills.[/dim]")
+        if output == "json":
+            output_json([])
+        else:
+            rprint("[dim]You have no skills.[/dim]")
         return
     config.save_last_results(data)
     if output == "json":
@@ -410,7 +419,8 @@ def skill_show(
         observal registry skill show @refactor-skill --output json
     """
     resolved = client.resolve_registry_reference("skill", skill_id)
-    with spinner():
+    fetch_ctx = nullcontext() if output == "json" else spinner()
+    with fetch_ctx:
         item = client.get(f"/api/v1/skills/{resolved}")
     if output == "json":
         output_json(item)

--- a/observal_cli/cmd_team.py
+++ b/observal_cli/cmd_team.py
@@ -10,7 +10,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.render import output_json
+from observal_cli.render import OutputMode, output_json
 
 team_app = typer.Typer(name="team", help="Manage teamspaces: creation, membership, and listing.", no_args_is_help=True)
 members_app = typer.Typer(name="members", help="Manage team membership.", no_args_is_help=True)
@@ -26,7 +26,7 @@ def _resolve_team_id(team: str) -> str:
 
 @team_app.command("list")
 def list_teams(
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table | json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table | json"),
     all_teams: bool = typer.Option(False, "--all", help="List all teamspaces, not only yours."),
 ):
     """List teamspaces you belong to (or all with --all).
@@ -65,7 +65,7 @@ def list_teams(
 @team_app.command("show")
 def show_team(
     team: str = typer.Argument(help="Team UUID or handle."),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table | json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table | json"),
 ):
     """Show teamspace detail and members.
 
@@ -192,7 +192,7 @@ def leave_team(
 @members_app.command("list")
 def list_members(
     team: str = typer.Argument(help="Team UUID or handle."),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table | json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table | json"),
 ):
     """List members of a teamspace.
 
@@ -237,7 +237,7 @@ def create_invite(
 @invite_app.command("list")
 def list_invites(
     team: str = typer.Argument(help="Private team UUID or handle."),
-    output: str = typer.Option("table", help="Output format: table | json"),
+    output: OutputMode = typer.Option("table", help="Output format: table | json"),
 ):
     """List invitation links for a private teamspace."""
     team_id = _resolve_team_id(team)
@@ -307,7 +307,7 @@ def request_join(
 def list_join_requests(
     team: str = typer.Argument(help="Team UUID or handle."),
     status: str = typer.Option(None, "--status", "-s", help="Filter: pending | approved | rejected | cancelled."),
-    output: str = typer.Option("table", "--output", "-o", help="Output format: table | json"),
+    output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table | json"),
 ):
     """List a teamspace's join requests and decisions. Owner or admin only.
 

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import json as _json
 from datetime import UTC, date, datetime
-from typing import Any, Literal
+from enum import Enum
+from typing import Any
 
 from rich import print as rprint
 from rich.console import Console
@@ -19,7 +20,12 @@ from rich.table import Table  # noqa: TC002 - used at runtime
 
 console = Console()
 
-OutputMode = Literal["table", "json"]
+
+class OutputMode(str, Enum):
+    """Supported CLI output formats."""
+
+    table = "table"
+    json = "json"
 
 
 def esc(value: Any) -> str:

--- a/observal_cli/render.py
+++ b/observal_cli/render.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json as _json
 from datetime import UTC, date, datetime
-from typing import Any
+from typing import Any, Literal
 
 from rich import print as rprint
 from rich.console import Console
@@ -18,6 +18,8 @@ from rich.panel import Panel
 from rich.table import Table  # noqa: TC002 - used at runtime
 
 console = Console()
+
+OutputMode = Literal["table", "json"]
 
 
 def esc(value: Any) -> str:
@@ -112,7 +114,7 @@ def handle(item: dict) -> str:
 
 
 def name_inline(item: dict) -> str:
-    """``name @namespace`` for plain output, which has no columns to separate them."""
+    """Render ``name @namespace`` when columns are unavailable."""
     name, namespace = registry_identity(item)
     return f"{name} [dim]@{namespace}[/dim]" if namespace else name
 
@@ -127,17 +129,12 @@ def star_rating(n: int, max_stars: int = 5) -> str:
 # ── Output format dispatch ───────────────────────────────
 
 
-def output_json(data: Any):
-    console.print_json(_json.dumps(data, default=str))
+def output_json(data: Any) -> None:
+    print(_json.dumps(data, default=str, ensure_ascii=False, indent=2))
 
 
-def output_table(table: Table):
+def output_table(table: Table) -> None:
     console.print(table)
-
-
-def output_plain(lines: list[str]):
-    for line in lines:
-        rprint(line)
 
 
 # ── Detail panels ────────────────────────────────────────

--- a/observal_cli/skills/observal-agents/SKILL.md
+++ b/observal_cli/skills/observal-agents/SKILL.md
@@ -28,8 +28,8 @@ Required: `--name`, `--description`, `--prompt`. Optional: `--model`, `--harness
 Before choosing a model, query the registry for every selected harness and pick an available exact model:
 
 ```bash
-observal registry models --harness kiro --output plain
-observal registry models --harness claude-code --output plain
+observal registry models --harness kiro --output json
+observal registry models --harness claude-code --output json
 ```
 
 > **WARNING:** Without `--name` and `--prompt`, the command launches an interactive wizard. Always pass at least `--name`, `--description`, and `--prompt`.

--- a/observal_cli/tests/test_cmd_agent_versions.py
+++ b/observal_cli/tests/test_cmd_agent_versions.py
@@ -143,6 +143,32 @@ def test_agent_release_shows_pending_warning(agent_yaml_dir: Path) -> None:
     assert "This agent already has 2 pending version(s)" in result.output
 
 
+# ── agent list ─────────────────────────────────────────────────
+
+
+def test_agent_list_json_includes_pagination_metadata() -> None:
+    rows = [
+        {
+            "id": "agent-uuid-list",
+            "name": "Reviewer",
+            "slug": "reviewer",
+            "namespace": "observal",
+            "version": "1.2.0",
+            "model_name": "claude-sonnet-4",
+        }
+    ]
+    with patch("observal_cli.cmd_agent.client.get_with_headers", return_value=(rows, {"x-total-count": "3"})):
+        result = runner.invoke(app, ["agent", "list", "--page", "2", "--limit", "2", "--output", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "items": rows,
+        "total": 3,
+        "page": 2,
+        "page_size": 2,
+    }
+
+
 # ── agent versions ─────────────────────────────────────────────
 
 

--- a/observal_cli/tests/test_cmd_auth.py
+++ b/observal_cli/tests/test_cmd_auth.py
@@ -281,6 +281,12 @@ class TestAuthWhoami:
         assert "alice@example.com" in result.output
         assert "admin" in result.output
 
+    def test_whoami_rejects_removed_plain_output(self) -> None:
+        result = runner.invoke(app, ["auth", "whoami", "--output", "plain"])
+
+        assert result.exit_code == 2
+        assert "is not one of 'table', 'json'" in result.output
+
     def test_whoami_unset_username_is_handled(self) -> None:
         """A user without a username should still render cleanly."""
         user_data = {

--- a/observal_cli/tests/test_registry_namespace_cli.py
+++ b/observal_cli/tests/test_registry_namespace_cli.py
@@ -18,7 +18,7 @@ def test_listings_render_the_bare_name_over_an_at_handle():
     # Tables put the name and its namespace in separate columns.
     assert render.display_name(item) == "task-creator"
     assert render.handle(item) == "@alice"
-    # Plain output has no columns, so it keeps them on one line.
+    # Inline displays have no columns, so they keep both values on one line.
     assert render.name_inline(item) == "task-creator [dim]@alice[/dim]"
     # Commands still need the slash form.
     assert client.canonical_name(item) == "alice/task-creator"

--- a/tests/test_cmd_agent_coverage.py
+++ b/tests/test_cmd_agent_coverage.py
@@ -461,19 +461,18 @@ def test_agent_list_table_filters_ids_and_pagination(monkeypatch, _isolated_boun
     assert "End of results" not in no_id.output
 
 
-def test_agent_list_json_plain_and_empty_pages(monkeypatch):
+def test_agent_list_json_rejects_plain_and_handles_empty_pages(monkeypatch):
     data = [_item()]
     get_with_headers = Mock(return_value=(data, {}))
     monkeypatch.setattr(agent.client, "get_with_headers", get_with_headers)
 
     as_json = _invoke("list", "--output", "json")
     assert as_json.exit_code == 0, as_json.output
-    assert json.loads(as_json.output)[0]["qualified_name"] == "alice/reviewer"
+    assert json.loads(as_json.output)["items"][0]["qualified_name"] == "alice/reviewer"
 
     plain = _invoke("list", "--output", "plain")
-    assert plain.exit_code == 0, plain.output
-    assert "reviewer" in plain.output
-    assert "@alice" in plain.output
+    assert plain.exit_code == 2
+    assert "is not one of 'table', 'json'" in plain.output
 
     get_with_headers.return_value = ([], {"x-total-count": "0"})
     empty = _invoke("list")
@@ -511,7 +510,7 @@ def test_agent_list_interactive_selection_and_cancellation(monkeypatch):
     show.assert_not_called()
 
 
-def test_agent_my_empty_json_plain_and_table(monkeypatch, _isolated_boundaries):
+def test_agent_my_empty_json_rejects_plain_and_renders_table(monkeypatch, _isolated_boundaries):
     get = Mock(return_value=[])
     monkeypatch.setattr(agent.client, "get", get)
 
@@ -526,14 +525,14 @@ def test_agent_my_empty_json_plain_and_table(monkeypatch, _isolated_boundaries):
     assert json.loads(as_json.output)[0]["status"] == "pending"
 
     plain = _invoke("my", "--output", "plain")
-    assert plain.exit_code == 0
-    assert "pending" in plain.output
+    assert plain.exit_code == 2
+    assert "is not one of 'table', 'json'" in plain.output
 
     table = _invoke("my")
     assert table.exit_code == 0, table.output
     assert "My Agents (1)" in table.output
     assert "pending" in table.output
-    assert _isolated_boundaries.save_last_results.call_count == 3
+    assert _isolated_boundaries.save_last_results.call_count == 2
 
 
 def test_agent_show_json_and_full_rendering(monkeypatch):

--- a/tests/test_cmd_hook_coverage.py
+++ b/tests/test_cmd_hook_coverage.py
@@ -449,9 +449,9 @@ def test_submit_interactive_handler_paths(tmp_path, handler_type, script_name, e
         assert "Command auto-set" in result.output
 
 
-def test_list_filters_json_empty_plain_and_table(monkeypatch):
+def test_list_filters_json_empty_rejects_plain_and_renders_table(monkeypatch):
     item = _hook_item()
-    get = Mock(side_effect=[[item], [], [item], [item]])
+    get = Mock(side_effect=[[item], [], [item]])
     save = Mock()
     resolve_team = Mock(return_value="team-1")
     monkeypatch.setattr(hook.client, "get", get)
@@ -480,11 +480,11 @@ def test_list_filters_json_empty_plain_and_table(monkeypatch):
     plain = runner.invoke(app, ["registry", "hook", "list", "--output", "plain"])
     table = runner.invoke(app, ["registry", "hook", "list"])
 
-    assert all(result.exit_code == 0 for result in (as_json, empty, plain, table))
+    assert all(result.exit_code == 0 for result in (as_json, empty, table))
+    assert plain.exit_code == 2
+    assert "is not one of 'table', 'json'" in plain.output
     assert json.loads(as_json.output) == [item]
     assert "No hooks found" in empty.output
-    assert "hook-123456789  guard" in plain.output
-    assert "PreToolUse" in plain.output
     assert "Hooks (1)" in table.output
     assert "@alice" in table.output
     assert get.call_args_list[0] == call(
@@ -497,7 +497,7 @@ def test_list_filters_json_empty_plain_and_table(monkeypatch):
         },
     )
     resolve_team.assert_called_once_with("platform")
-    assert save.call_count == 3
+    assert save.call_count == 2
 
 
 def test_list_surfaces_http_failure(monkeypatch):

--- a/tests/test_cmd_mcp_coverage.py
+++ b/tests/test_cmd_mcp_coverage.py
@@ -638,7 +638,7 @@ def test_list_json_filters_sorts_limits_and_caches(monkeypatch):
     save.assert_called_once_with([data[1]])
 
 
-def test_list_plain_table_empty_and_interactive(monkeypatch, capsys):
+def test_list_table_empty_and_interactive(monkeypatch, capsys):
     save = Mock()
     monkeypatch.setattr(mcp.config, "save_last_results", save)
     item = _registry_item()
@@ -648,7 +648,7 @@ def test_list_plain_table_empty_and_interactive(monkeypatch, capsys):
     assert "No MCP servers found" in capsys.readouterr().out
 
     monkeypatch.setattr(mcp.client, "get", Mock(return_value=[item]))
-    mcp._list_impl(None, None, 50, "version", "plain")
+    mcp._list_impl(None, None, 50, "version", "table")
     assert "mcp-1" in capsys.readouterr().out
 
     mcp._list_impl(None, None, 50, "unknown", "table")
@@ -673,9 +673,9 @@ def test_list_plain_table_empty_and_interactive(monkeypatch, capsys):
     show.assert_not_called()
 
 
-def test_my_mcp_outputs_and_empty_state(monkeypatch):
+def test_my_mcp_outputs_reject_plain_and_empty_state(monkeypatch):
     item = _registry_item()
-    get = Mock(side_effect=[[], [item], [item], [item]])
+    get = Mock(side_effect=[[], [item], [item]])
     monkeypatch.setattr(mcp.client, "get", get)
     save = Mock()
     monkeypatch.setattr(mcp.config, "save_last_results", save)
@@ -685,12 +685,13 @@ def test_my_mcp_outputs_and_empty_state(monkeypatch):
     as_json = runner.invoke(app, ["registry", "mcp", "my", "--output", "json"])
     table = runner.invoke(app, ["registry", "mcp", "my"])
 
-    assert empty.exit_code == plain.exit_code == as_json.exit_code == table.exit_code == 0
+    assert empty.exit_code == as_json.exit_code == table.exit_code == 0
+    assert plain.exit_code == 2
+    assert "is not one of 'table', 'json'" in plain.output
     assert "You have no MCP servers" in empty.output
-    assert "search-mcp" in plain.output
     assert json.loads(as_json.output)[0]["id"] == "mcp-1"
     assert "My MCPs" in table.output
-    assert save.call_count == 3
+    assert save.call_count == 2
 
 
 def test_show_renders_validation_and_json(monkeypatch):

--- a/tests/test_cmd_scan.py
+++ b/tests/test_cmd_scan.py
@@ -226,14 +226,14 @@ def test_unknown_harness_filter_lists_sorted_choices(scan_env) -> None:
     ]
 
 
-def test_short_filter_alias_scans_only_selected_static_home_and_plain_falls_back_to_tables(scan_env) -> None:
+def test_short_filter_alias_scans_only_selected_static_home(scan_env) -> None:
     (scan_env.home / ".cursor").mkdir()
     cursor = _adapter()
     skipped = _adapter()
     scan_env.get_one.return_value = cursor
     scan_env.get_all.return_value = {"cursor": cursor, "kiro": skipped}
 
-    result = _invoke("-i", "cursor", "-o", "plain")
+    result = _invoke("-i", "cursor", "-o", "table")
 
     assert result.exit_code == 0, result.exception
     assert scan_env.get_one.call_args_list == [call("cursor"), call("cursor")]

--- a/tests/test_cmd_skill_coverage.py
+++ b/tests/test_cmd_skill_coverage.py
@@ -458,9 +458,9 @@ def test_list_filters_json_and_caches_results(monkeypatch):
     save.assert_called_once_with(data)
 
 
-def test_list_empty_plain_and_table_rendering(monkeypatch):
+def test_list_empty_rejects_plain_and_renders_table(monkeypatch):
     item = _skill_item()
-    monkeypatch.setattr(skill.client, "get", Mock(side_effect=[[], [item], [item]]))
+    monkeypatch.setattr(skill.client, "get", Mock(side_effect=[[], [item]]))
     save = Mock()
     monkeypatch.setattr(skill.config, "save_last_results", save)
 
@@ -468,17 +468,18 @@ def test_list_empty_plain_and_table_rendering(monkeypatch):
     plain = runner.invoke(app, ["registry", "skill", "list", "--output", "plain"])
     table = runner.invoke(app, ["registry", "skill", "list"])
 
-    assert empty.exit_code == plain.exit_code == table.exit_code == 0
+    assert empty.exit_code == table.exit_code == 0
+    assert plain.exit_code == 2
+    assert "is not one of 'table', 'json'" in plain.output
     assert "No skills found" in empty.output
-    assert "skill-123456789  review-skill" in plain.output
     assert "Skills (1)" in table.output
     assert "@alice" in table.output
-    assert save.call_count == 2
+    assert save.call_count == 1
 
 
-def test_my_empty_plain_json_and_table_outputs(monkeypatch):
+def test_my_empty_json_rejects_plain_and_renders_table(monkeypatch):
     item = _skill_item(status="pending")
-    monkeypatch.setattr(skill.client, "get", Mock(side_effect=[[], [item], [item], [item]]))
+    monkeypatch.setattr(skill.client, "get", Mock(side_effect=[[], [item], [item]]))
     save = Mock()
     monkeypatch.setattr(skill.config, "save_last_results", save)
 
@@ -487,13 +488,13 @@ def test_my_empty_plain_json_and_table_outputs(monkeypatch):
     as_json = runner.invoke(app, ["registry", "skill", "my", "--output", "json"])
     table = runner.invoke(app, ["registry", "skill", "my"])
 
-    assert empty.exit_code == plain.exit_code == as_json.exit_code == table.exit_code == 0
+    assert empty.exit_code == as_json.exit_code == table.exit_code == 0
+    assert plain.exit_code == 2
+    assert "is not one of 'table', 'json'" in plain.output
     assert "You have no skills" in empty.output
-    assert "review-skill" in plain.output
-    assert "pending" in plain.output
     assert json.loads(as_json.output) == [item]
     assert "My Skills (1)" in table.output
-    assert save.call_count == 3
+    assert save.call_count == 2
 
 
 def test_show_renders_metadata_and_json(monkeypatch):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
<!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## Purpose / Description

Establish the first slice of the agent-ready CLI output contract. Table output remains the human-friendly default, JSON becomes the single machine-readable mode, and paginated agent-list JSON becomes self-describing.

This is **PR 1 of 3** in a stack. PR #1686 (help examples) is based on this branch, and PR #1688 (stable error contract) is stacked above #1686. Review in that order.

This PR is the output-contract foundation for the Agent-ready CLI initiative; it does not attempt to complete the full initiative.

## Fixes

* N/A — no linked issue was provided.

## Approach

* Added a shared `OutputMode` type containing only `table` and `json`.
* Kept `table` as the default for existing output options.
* Removed the redundant plain mode from implementation code, help text, documentation, bundled skills, and tests.
* Changed JSON rendering to use standard output without Rich formatting.
* Changed paginated agent-list JSON to return `{items, total, page, page_size}`.
* Added validation for persisted output configuration values.
* Updated the roadmap and CLI documentation to describe the two-mode contract.
* Added and updated regression coverage for rejected plain output and pagination metadata.

## How Has This Been Tested?

The following checks were run locally on macOS with Python 3.14.6:

* Output-related test selection — 225 passed.
* `uv run ruff check observal_cli tests` — passed.
* `uv run ruff format --check observal_cli tests` — passed.
* `git diff --check` — passed.
* `make test` — 8,297 passed and 21 skipped; two unrelated server-package setup tests failed because macOS Bash 3.2 treats an empty `profile_args` array as unbound.

Reproduce the focused test run with:

```bash
uv run pytest -q \
  observal_cli/tests/test_cmd_agent_versions.py \
  observal_cli/tests/test_cmd_auth.py \
  observal_cli/tests/test_registry_namespace_cli.py \
  tests/test_cmd_agent_coverage.py \
  tests/test_cmd_hook_coverage.py \
  tests/test_cmd_mcp_coverage.py \
  tests/test_cmd_scan.py \
  tests/test_cmd_skill_coverage.py
```

## Learning (optional, can help others)

Using a shared Typer `Literal` output type makes invalid output modes fail consistently during command parsing. JSON is emitted through the standard JSON encoder rather than Rich so machine-readable output cannot inherit terminal formatting.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (not applicable — no UI changes)

## AI Assistance

_Was generative AI tooling used to co-author this PR?_

- [x] Yes (pi coding agent using `gpt-5.6-sol`; used to apply, adapt, test, stack, and prepare the supplied patch)
- [ ] Was the generated code manually reviewed and tested? (Automated tests were run; human review is still required.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation to support only `table` and `json` output formats.
  * Removed examples and references to the unsupported `plain` format.

* **New Features**
  * Standardized output selection across CLI commands.
  * JSON listings now include structured items and pagination metadata where applicable.

* **Bug Fixes**
  * Invalid `--output plain` values are rejected with clear validation errors.
  * JSON output is consistently formatted, preserves Unicode, suppresses progress indicators, and returns empty results consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
