### PR TITLE
fix(fuzz): repair the OSS-Fuzz build before submitting upstream to google

### DIFF
--- a/docs/testing/Testing_Guide.md
+++ b/docs/testing/Testing_Guide.md
@@ -397,7 +397,7 @@ Keep property-based tests deterministic and focused. If a failing example reveal
 
 ## Fuzzing
 
-Property tests cover invariants you can name. Fuzzing covers the ones you cannot: Observal is fuzzed continuously by [Google OSS-Fuzz](https://google.github.io/oss-fuzz/), and the Atheris targets live in `fuzz/`.
+Property tests cover invariants you can name. Fuzzing covers the ones you cannot: the Atheris targets live in `fuzz/`, and the project is being submitted to [Google OSS-Fuzz](https://google.github.io/oss-fuzz/) for continuous fuzzing.
 
 Reach for a fuzz target instead of a property test when the boundary takes untrusted bytes and the interesting failures are crashes rather than wrong answers. Session transcripts, the ingest classifiers, and both redaction layers are covered today.
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -79,15 +79,20 @@ inside the container the report came from.
    other exception is a finding.
 4. Bound the input size. Slow inputs are reported as timeouts rather than as
    bugs.
-5. Add a seed corpus under `corpus/<name>_fuzzer/` and a dictionary at
+5. Declare any third-party import in the `fuzz` dependency group in
+   `pyproject.toml` and commit the refreshed `uv.lock`. OSS-Fuzz installs that
+   group into the base image's system interpreter, which is the only
+   environment PyInstaller resolves imports against; a package that is merely
+   importable in a local virtualenv is silently omitted from the built target.
+6. Add a seed corpus under `corpus/<name>_fuzzer/` and a dictionary at
    `dictionaries/<name>_fuzzer.dict`. Both are optional and both are picked up
    automatically.
-6. Corpus files are raw fuzzer input, not source. Nothing may rewrite them.
+7. Corpus files are raw fuzzer input, not source. Nothing may rewrite them.
    `scripts/update_spdx_copyright.py` skips `fuzz/corpus/**`, and `REUSE.toml`
    carries their licensing instead. `session_jsonl_fuzzer` reads
    its first byte, so a stray header would repoint the whole corpus at one
    parser; `tests/test_fuzz_targets.py` asserts every parser still has a seed.
-7. Keep seed corpora free of anything that looks like a credential. The
+8. Keep seed corpora free of anything that looks like a credential. The
    repository runs Gitleaks and a pre-commit secret scan; put distinctive vendor
    prefixes in the dictionary, where they are too short to match a scanner rule,
    and use zero-entropy placeholders in corpus files.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -3,7 +3,9 @@
 
 # Fuzzing
 
-Observal is fuzzed continuously by [Google OSS-Fuzz](https://google.github.io/oss-fuzz/).
+Observal is fuzzed with [Atheris](https://github.com/google/atheris) and is being
+submitted to [Google OSS-Fuzz](https://google.github.io/oss-fuzz/) for continuous
+fuzzing; the upstream project is not live yet.
 The fuzz targets live here so they are versioned alongside the code they
 exercise; OSS-Fuzz only stores the three-file project configuration, which is
 mirrored under `fuzz/oss-fuzz/`.

--- a/fuzz/oss-fuzz/Dockerfile
+++ b/fuzz/oss-fuzz/Dockerfile
@@ -16,9 +16,6 @@
 # limitations under the License.
 #
 ################################################################################
-#
-# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
 
 FROM gcr.io/oss-fuzz-base/base-builder-python:latest@sha256:6b2b3a7e4a2da50de47f94925cffbe34747e1aae4f33d7f07ba6c681dd648b23
 

--- a/fuzz/oss-fuzz/Dockerfile
+++ b/fuzz/oss-fuzz/Dockerfile
@@ -20,7 +20,7 @@
 # SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:6b2b3a7e4a2da50de47f94925cffbe34747e1aae4f33d7f07ba6c681dd648b23
+FROM gcr.io/oss-fuzz-base/base-builder-python:latest@sha256:6b2b3a7e4a2da50de47f94925cffbe34747e1aae4f33d7f07ba6c681dd648b23
 
 # uv 0.11.25 (multi-arch: linux/amd64, linux/arm64)
 COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac16ff35925780cf5c459858b2d693f01a9 /uv /uvx /bin/
@@ -28,7 +28,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.25@sha256:1e3808aa9023d0980e7c15b1fa7c1ac1
 RUN git clone --depth 1 https://github.com/Observal/Observal.git observal
 WORKDIR $SRC/observal
 
-RUN uv venv --system-site-packages && uv sync --frozen --only-group fuzz --no-install-project
-ENV PATH="$SRC/observal/.venv/bin:$PATH"
+# Must install into the system interpreter: compile_python_fuzzer runs the
+# system PyInstaller, which resolves imports against /usr/local site-packages
+# only, so anything in a virtualenv is silently omitted from the bundle.
+RUN uv export --frozen --only-group fuzz --no-emit-project --no-editable -o /tmp/fuzz-requirements.txt \
+    && uv pip install --system --no-cache --require-hashes -r /tmp/fuzz-requirements.txt
 
 COPY build.sh $SRC/

--- a/fuzz/oss-fuzz/build.sh
+++ b/fuzz/oss-fuzz/build.sh
@@ -17,9 +17,6 @@
 # limitations under the License.
 #
 ################################################################################
-#
-# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
 
 # The fuzz targets import directly from the checkout. PyInstaller needs each
 # source root and the model catalogue used by observal_shared.

--- a/fuzz/oss-fuzz/project.yaml
+++ b/fuzz/oss-fuzz/project.yaml
@@ -16,9 +16,6 @@
 # limitations under the License.
 #
 ################################################################################
-#
-# SPDX-FileCopyrightText: 2026 RAWx18 <rawx18.dev@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
 
 homepage: "https://github.com/Observal/Observal"
 main_repo: "https://github.com/Observal/Observal.git"


### PR DESCRIPTION
## Purpose / Description

Our OSS-Fuzz configuration does not work: three of the four fuzz targets are built
into bundles that crash on startup, so submitting the project to `google/oss-fuzz`
as-is would have produced a permanently broken project on Google's infrastructure.

This PR fixes the build and cleans up the surrounding documentation so the upstream
submission can go ahead.

## Fixes

No tracked issue.

## Approach

**The bug.** `compile_python_fuzzer` invokes the base image's PyInstaller, whose
shebang hard-pins `/usr/local/bin/python3`. PyInstaller therefore resolves imports
against the *system* site-packages and never sees a virtualenv. Our Dockerfile
installed the fuzz dependency group with `uv venv --system-site-packages && uv sync`
and put `.venv/bin` on `PATH`, which does not help: `PATH` affects which
`pyinstaller` script is found, not which interpreter that script runs under.

The dependencies were silently omitted from every frozen bundle. PyInstaller only
warns on unresolved imports, so the build "succeeded" while producing fuzzers that
died immediately:

```
ERROR: 75.0% of fuzz targets seem to be broken.
ModuleNotFoundError: No module named 'loguru'      # secrets_redactor_fuzzer
ModuleNotFoundError: No module named 'orjson'      # session_jsonl_fuzzer
ModuleNotFoundError: No module named 'hypothesis'  # session_structure_fuzzer
ERROR:__main__:Check build failed.
```

Only `support_redaction_fuzzer` survived, because it happens to import nothing
outside the standard library.

**The fix.** Export the locked fuzz group and install it into the system
interpreter, which is the only environment PyInstaller resolves against:

```dockerfile
RUN uv export --frozen --only-group fuzz --no-emit-project --no-editable -o /tmp/fuzz-requirements.txt \
    && uv pip install --system --no-cache --require-hashes -r /tmp/fuzz-requirements.txt
```

This keeps `uv.lock` as the single source of truth for the pinned versions (no
duplicated pins to drift) and additionally enforces hashes, so it is a net
improvement on the previous supply-chain posture rather than a relaxation. No
upstream OSS-Fuzz project uses a virtualenv — I checked all 1336 project
Dockerfiles, and ours was the only one.

**Also in this PR:**

- Tagged the base image as `base-builder-python:latest@sha256:...`. The pin is
  unchanged and still matches the current `latest`, but the reference was
  previously tagless, which Renovate cannot track reliably.
- Removed the premature claim that Observal "is fuzzed continuously by Google
  OSS-Fuzz" from `fuzz/README.md` and `docs/testing/Testing_Guide.md`. That only
  becomes true once the upstream project exists and has built at least once.
- Added a step to the "Adding a target" list in `fuzz/README.md` recording the
  system-interpreter constraint, so the same bug cannot be reintroduced by the
  next person who adds a target with a new dependency.
- Dropped the duplicated SPDX block from the three mirrored files.
  `scripts/update_spdx_copyright.py` inserts after the *last* existing
  `SPDX-FileCopyrightText` line rather than deduplicating, so each file carried the
  header twice. These three files are copied verbatim into `google/oss-fuzz`, so
  they should be clean. Still REUSE compliant (1338/1338).

`CHANGELOG.md` still claims "Scorecard Fuzzing 0/10 → 10/10" under the released
v1.12.0 entry. That is not yet true, but I left it alone rather than rewrite
released history.

## How Has This Been Tested?

Against the real OSS-Fuzz toolchain and base images, not a simulation:

```bash
git clone --depth 1 https://github.com/google/oss-fuzz.git && cd oss-fuzz
cp -r /path/to/Observal/fuzz/oss-fuzz projects/observal

docker build --no-cache --pull -t gcr.io/oss-fuzz/observal projects/observal
python3 infra/helper.py build_fuzzers observal
python3 infra/helper.py check_build observal
python3 infra/helper.py build_fuzzers --sanitizer undefined observal
python3 infra/helper.py check_build --sanitizer undefined observal
python3 infra/helper.py build_fuzzers --sanitizer coverage observal
python3 infra/helper.py run_fuzzer observal session_jsonl_fuzzer -- -runs=3000
```

| Check | Before | After |
| --- | --- | --- |
| `build_image` / cold `--no-cache` build | pass | pass |
| `build_fuzzers` (address / undefined / coverage) | pass | pass |
| `check_build` (address) | **FAIL, 3 of 4 targets broken** | **pass, 4 of 4** |
| `check_build` (undefined) | fail | pass |
| `run_fuzzer`, 3000 runs × 4 targets | crash on startup | pass, no findings |
| `build_fuzzers` from a local checkout | fail | pass, leaves the tree clean |
| `infra/presubmit.py` | Success | Success |
| `reuse lint` | 1338/1338 | 1338/1338 |
| `pytest tests/test_fuzz_targets.py` | 13 passed | 13 passed |

Note that `tests/test_fuzz_targets.py` passed both before and after: it
`importorskip`s Atheris and exercises the targets as source, so it cannot catch a
defect that only exists in the PyInstaller bundle. Worth knowing when relying on
it as a regression guard.

## Learning (optional, can help others)

- OSS-Fuzz Python integration guide: https://google.github.io/oss-fuzz/getting-started/new-project-guide/python-lang/
- The canonical Python + Hypothesis reference project is `projects/ujson` upstream.
- Scorecard's Fuzzing check does **not** detect Atheris targets in a Python repo.
  It reads `main_repo` out of `https://oss-fuzz-build-logs.storage.googleapis.com/status.json`,
  so the score only moves after the upstream project exists *and* has built at
  least once. Merging the Google PR is necessary but not sufficient.

## Checklist

- [x] You have a descriptive commit message with a short title
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots — n/a

## AI Assistance

- [x] Yes (Please Specify the tool): GitHub Copilot
- [x] Was the generated code manually reviewed and tested? Yes — the root cause was
      identified by inspecting PyInstaller's resolved `sys.path` inside the
      container, and every change was verified end-to-end against the real
      OSS-Fuzz builder as tabulated above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fuzzing documentation to clarify that the project is being submitted to Google OSS-Fuzz.
  * Expanded guidance for creating fuzzing targets, including dependency and lockfile requirements.
  * Retained instructions for locating fuzzing targets and protecting credential information.

* **Chores**
  * Updated the fuzzing build environment for more consistent dependency installation.
  * Removed duplicate licensing headers from OSS-Fuzz support files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->