### PR TITLE
docs: update README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
  ╚═════╝ ╚═════╝ ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚═╝  ╚═╝╚══════╝
 </pre>
 
-**Observal is the control plane and system of record for internal AI components**
+**Observal is self-hosted registry for your coding agent extensions with a built in insight engine.** Setup Observal, define the scope and share your Skills, MCPs and Agents with your peers.
 
 <p>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square" alt="License"></a>


### PR DESCRIPTION
## Summary
Updates the README hero tagline (the line under the ASCII banner) to describe Observal as a self-hosted registry for coding-agent extensions.

**Before**
> Observal is the control plane and system of record for internal AI components

**After**
> Observal is self-hosted registry for your coding agent extensions with a built in insight engine. Setup Observal, define the scope and share your Skills, MCPs and Agents with your peers.

## Changes
- README.md: replaced the single tagline line only. No other content touched.

## Testing
- Docs-only change; renders as a bold tagline + subtitle, consistent with existing hero styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the project tagline to highlight its self-hosted registry for coding agent extensions and built-in insights.
  - Clarified that users can configure scope and share Skills, MCPs, and Agents with peers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->