### PR TITLE
feat(skills): add observal-sdlc SDLC skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- add the `observal-sdlc` skill documenting the contribution lifecycle (fork workflow, branch naming, conventional commits, SPDX, tests, issue and PR templates, AI policy, CLA, and review gates)
+
 ## [1.12.1] - 2026-08-09
 
 ### Fixes

--- a/observal_cli/skill_installer.py
+++ b/observal_cli/skill_installer.py
@@ -32,6 +32,7 @@ _SKILL_DIRS = (
     "observal-ops",
     "observal-admin",
     "observal-advanced",
+    "observal-sdlc",
 )
 _SKILLS_BASE = Path(__file__).parent / "skills"
 

--- a/observal_cli/skills/observal-sdlc/SKILL.md
+++ b/observal_cli/skills/observal-sdlc/SKILL.md
@@ -1,0 +1,75 @@
+---
+# SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+name: observal-sdlc
+command: observal
+description: "Guides a contributor or coding agent through Observal's software development lifecycle: forking, branch naming, running the stack, conventional commits, SPDX headers, tests, filling the issue and pull request templates, the AI policy, the CLA, and code-review merge gates. Use when preparing, committing, or submitting any change (code, docs, or a registry component) to the Observal repository."
+version: 1.0.0
+owner: observal
+---
+
+# Contributing to Observal (SDLC)
+
+You are shepherding a change into the Observal repository. Follow the process
+exactly: reviewers close pull requests that skip these steps.
+
+## Execution contract
+
+1. **Fork is mandatory.** Contribute from a fork; there is no direct push access to `Observal/Observal`. Open pull requests from `your-fork:branch` against `Observal:main`.
+2. **Never commit to `main`.** Always work on a topic branch. Rebase on `upstream/main` before opening the pull request.
+3. **One concern per pull request.** Keep it small and focused. Split unrelated changes.
+4. **Fill the pull request template completely.** Pull requests with unfilled or placeholder sections are closed without review.
+5. **Every source file needs SPDX headers**, and every user-facing change follows Conventional Commits. CI blocks merges that miss either.
+6. **Tests and linters must pass locally** (`make format`, `make lint`, `make test`) before you push.
+7. **Disclose AI assistance and keep a human accountable.** Interactive, human-directed AI tooling is welcome; fully autonomous, unreviewed submissions are prohibited and closed on sight (see the AI Policy).
+8. **Sign the CLA** when the bot prompts you on your first pull request.
+9. Do not fabricate an issue number, a test result, or a passing check. Report real status only.
+
+## Choose the workflow
+
+| User intent | Read |
+| --- | --- |
+| Set up the fork, run the stack, branch, rebase, push, open the PR, claim an issue | [Contribution workflow](references/contribution-workflow.md) |
+| File a bug or feature issue, or fill each field of the PR template | [Issue and PR templates](references/issue-and-pr-templates.md) |
+| Get commits, SPDX headers, changelog, tests, code style, review gates, AI policy, and CLA right | [Conventions and standards](references/conventions-and-standards.md) |
+
+Read only the reference you need, and read it completely before acting.
+
+## Golden path
+
+```bash
+# 1. Fork on GitHub, then clone your fork and wire the upstream remote
+git clone https://github.com/YOUR-USERNAME/Observal.git
+cd Observal
+git remote add upstream https://github.com/Observal/Observal.git
+
+# 2. Branch from an up-to-date main (never work on main itself)
+git fetch upstream
+git switch -c feature/short-topic upstream/main
+
+# 3. Make the change, install hooks, format, lint, and test
+make hooks
+make format
+make lint
+make test
+
+# 4. Commit with a Conventional Commit subject (<= 50 chars, imperative, no period)
+git add -A
+git commit -m "feat(cli): add skill submit command"
+
+# 5. Rebase on latest upstream, then push to YOUR fork
+git fetch upstream && git rebase upstream/main
+git push -u origin feature/short-topic
+```
+
+Then open a pull request on GitHub from `your-fork:feature/short-topic` into
+`Observal:main`, fill every section of the template, add a `[Unreleased]`
+changelog entry if the change is user-facing, sign the CLA, and respond to
+review promptly.
+
+## Completion
+
+Report: the branch name, that the PR targets `Observal:main` from a fork, that
+the template is fully filled, the local `make lint`/`make test` result, whether
+a changelog entry was needed, the CLA status, and any reviewer or CI gate still
+outstanding.

--- a/observal_cli/skills/observal-sdlc/references/contribution-workflow.md
+++ b/observal_cli/skills/observal-sdlc/references/contribution-workflow.md
@@ -1,0 +1,100 @@
+<!-- SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Contribution workflow
+
+The end-to-end path for landing a change in Observal. Discord is the primary
+channel for discussion (`discord.observal.io`); GitHub issues and pull requests
+are for concrete, actionable items.
+
+## 1. Fork and clone
+
+There is no direct push access. Fork `Observal/Observal` on GitHub, then:
+
+```bash
+git clone https://github.com/YOUR-USERNAME/Observal.git
+cd Observal
+git remote add upstream https://github.com/Observal/Observal.git
+```
+
+Push topic branches to your fork (`origin`); never to `upstream`.
+
+## 2. Run the stack locally
+
+Prerequisites: Docker + Docker Compose, uv (Python 3.11+), Node.js 20+ and
+pnpm, Git. No configuration is needed for local development; defaults work.
+
+```bash
+cp .env.example .env
+make rebuild-fast    # build shared API image, reuse for api/init/worker, build web
+```
+
+Use `make rebuild` only when the Compose topology changes (new services, build
+contexts, image names, volumes, or networks). Use `make rebuild-fast` for
+normal backend, frontend, schema, migration, init, or worker changes. The stack
+serves at `http://localhost` (nginx on port 80); `.env.example` seeds demo
+accounts on first startup.
+
+Frontend only:
+
+```bash
+cd web && pnpm install && pnpm dev
+```
+
+## 3. Find and claim work
+
+- Check open issues first; `good first issue` is the place to start.
+- For larger changes, open an issue or discuss in `#contributing` on Discord before writing code.
+- Comment `/take` on a `good first issue` or `help wanted` issue to self-assign; `/drop` to release it.
+- Maximum 2 open assigned issues at a time. Issues idle for 30 days are auto-unassigned.
+- Issues labeled `keep open` cannot be claimed; anyone may submit a PR for them without assignment.
+
+## 4. Branch
+
+Never commit directly to `main`. Name the branch after the change, using a
+Conventional-Commit-aligned prefix. Documented and observed prefixes:
+
+```
+feature/skill-registry      # or feat/...
+fix/clickhouse-insert-timeout
+docs/update-setup-guide
+refactor/cli-output-modes
+ci/codecov-canonical-upload
+chore/release-v1.12.1
+```
+
+```bash
+git fetch upstream
+git switch -c feature/short-topic upstream/main
+```
+
+## 5. Make the change, then verify
+
+Install hooks first, then format, lint, and test. All must pass before pushing.
+
+```bash
+make hooks     # install pre-commit hooks (do this first)
+make format    # auto-format Python (ruff) and TypeScript
+make lint      # run all linters (ruff, hadolint, ...)
+make test      # quick; use `make test-v` for verbose
+```
+
+Include tests for any feature or bug fix. Tests mock external services, so
+Docker is not required to run them. See details in
+[conventions-and-standards.md](conventions-and-standards.md).
+
+## 6. Rebase, push, open the PR
+
+```bash
+git fetch upstream && git rebase upstream/main
+git push -u origin feature/short-topic
+```
+
+Open the pull request from `your-fork:feature/short-topic` into `Observal:main`.
+Then:
+
+1. Fill in the pull request template completely; placeholder or empty sections get the PR closed. See [issue-and-pr-templates.md](issue-and-pr-templates.md).
+2. Add a `[Unreleased]` entry in `CHANGELOG.md` if the change is user-facing.
+3. Ensure CI passes: linters, tests, and the docker build.
+4. Sign the CLA when the CLA-assistant bot prompts you (once per contributor).
+5. Respond to review feedback promptly; every PR is evaluated under the Code Review Standard (`docs/code-review.md`).

--- a/observal_cli/skills/observal-sdlc/references/conventions-and-standards.md
+++ b/observal_cli/skills/observal-sdlc/references/conventions-and-standards.md
@@ -1,0 +1,99 @@
+<!-- SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Conventions and standards
+
+The rules CI and reviewers enforce. Getting these right is what separates a
+mergeable PR from a closed one.
+
+## Commit messages (Conventional Commits)
+
+Format: `type(scope): summary`. Subject in imperative mood, no trailing period.
+The PR template asks for a title `<= 50` chars; CONTRIBUTING allows `<= 72`.
+Keep it as short as the 50-char target when you can.
+
+Types seen in the history: `feat`, `fix`, `docs`, `refactor`, `chore`, `ci`.
+Append `!` to mark a breaking change. Real examples from merged PRs:
+
+```
+feat(web): revamp registry home
+feat(cli)!: add help and error contracts
+fix(security): harden diagnostics and CodeQL
+refactor(cli): standardize table and JSON output modes
+ci: target canonical Codecov project
+chore(release): v1.12.1
+docs: update contributing guide
+```
+
+## SPDX headers
+
+Every source file needs an SPDX copyright line and license identifier. The
+pre-commit hook adds them automatically; CI blocks merge if any file is missing
+them. Comment syntax by file type:
+
+```python
+# SPDX-FileCopyrightText: 2026 Your Name <your@email.com>
+# SPDX-License-Identifier: Apache-2.0
+```
+
+- TypeScript / JS: `// SPDX-...`
+- Markdown / HTML: `<!-- SPDX-... -->`
+- In a `SKILL.md`, place the SPDX lines as `#` comments inside the YAML frontmatter (between the `---` fences), matching the other bundled skills.
+
+## Changelog
+
+Add an entry under the `[Unreleased]` heading in `CHANGELOG.md` for any
+user-facing change, grouped under `### Features`, `### Fixes`, etc., linking the
+PR number. Release commits (`chore(release): vX.Y.Z`) roll these into a version.
+
+## Code style
+
+```bash
+make hooks     # install pre-commit hooks first
+make format    # ruff (Python) + TypeScript formatting
+make lint      # ruff, hadolint (Dockerfiles), and other linters
+```
+
+## Testing
+
+```bash
+make test      # quick
+make test-v    # verbose
+```
+
+All tests must pass before submitting, and every feature or bug fix ships with
+tests. Tests mock external services (no Docker needed). New Python tests follow
+the Testing Guide (`docs/testing/Testing_Guide.md`): keep them hermetic, assert
+behavior over implementation details, use small local setup helpers, and never
+touch real user configuration.
+
+## Code review and merge gates
+
+Every PR is evaluated under the Code Review Standard (`docs/code-review.md`),
+which defines reviewer responsibilities, required approvals, review freshness,
+merge gates, and the conditions that require changes or rejection. Keep PRs
+small and single-purpose to move through review quickly. Rebase on
+`upstream/main` before opening and when asked.
+
+## AI policy (read before submitting)
+
+Observal welcomes interactive, human-directed AI coding tools (Claude Code, Pi,
+Cursor, Copilot, and similar). The accountable human must direct the work,
+review the complete change, be able to explain it, and authorize publication.
+
+Prohibited: fully autonomous agents that make material implementation choices
+and submit code without meaningful human authorship (the concern is CLA
+support, license-chain certainty, and training-data provenance, not tool
+capability). PRs showing obvious signs of unreviewed AI output are closed
+without review. Always disclose AI usage in the PR template's AI Assistance
+section.
+
+## CLA
+
+The CLA-assistant bot prompts you to sign the Observal CLA on your first PR. You
+sign once. For corporate contributions, contact the maintainer listed in
+`CONTRIBUTING.md`.
+
+## License
+
+All code is licensed under Apache-2.0.

--- a/observal_cli/skills/observal-sdlc/references/issue-and-pr-templates.md
+++ b/observal_cli/skills/observal-sdlc/references/issue-and-pr-templates.md
@@ -1,0 +1,76 @@
+<!-- SPDX-FileCopyrightText: 2026 Subramania Raja <dhanpraja231@gmail.com> -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Issue and PR templates
+
+How to file issues and how to fill every field of the pull request template.
+Fields marked required must be non-empty; the PR is closed if template sections
+are left as placeholders.
+
+## Issue templates
+
+Blank issues are enabled, and there is a contact link to GitHub Discussions for
+questions, support, and early feature ideas. Two structured forms exist:
+
+### Bug (`🐞 Bug`, label `Needs Triage`, type `Bug`)
+
+- **Checked for duplicates?** (required) confirm the issue is not a duplicate.
+- **Steps to reproduce** (required) what you did that triggered the bug.
+- **Expected behaviour** (required) what happened vs. what should have happened.
+- **Support bundle** attach the `.tar.gz` produced by the `observal support bundle` command; you can review it first with `observal support inspect`.
+- **Anything else?** optional extra context.
+
+### Feature Request (`💡 Feature Request`, title prefix `[FEATURE] `, label `accepted`)
+
+- **Problem** (required) the problem you are solving; describe the problem, not just the solution.
+- **Solution** (required) what you want to happen.
+- **Alternatives** other approaches you considered.
+- **Additional context** screenshots or extra detail.
+
+Consider starting in GitHub Discussions or `#feature-requests` on Discord before
+filing a formal request for larger features.
+
+## Pull request template
+
+Fill each section. Reproduce the structure below and replace the guidance text.
+
+- **Purpose / Description** describe the problem or feature and the motivation.
+- **Fixes** link the issue, e.g. `Fixes #123`. If there is genuinely no tracking issue, say so explicitly rather than leaving the placeholder.
+- **Approach** how the change addresses the problem.
+- **How Has This Been Tested?** the tests you ran and how to reproduce them, plus relevant test configuration.
+- **Learning (optional)** research notes, links to posts, patterns, or libraries used.
+- **Checklist** tick each item honestly:
+  - Descriptive commit message with a short title (first line, max 50 chars).
+  - Code commented, particularly in hard-to-understand areas.
+  - You performed a self-review.
+  - UI changes include screenshots of all affected screens (especially new or changed strings).
+- **Licenses** uncomment and fill the table only if the PR introduces new external resources (libraries, icons): one row per resource with Library, Description, and License.
+- **AI Assistance** state whether generative AI tooling co-authored the PR, name the tool, and confirm the generated code was manually reviewed and tested. This is required, not optional, and it must be truthful (see the AI policy in [conventions-and-standards.md](conventions-and-standards.md)).
+
+### Filled example
+
+```text
+## Purpose / Description
+Adds a `skill submit` command so contributors can publish skills from the CLI.
+
+## Fixes
+* Fixes #142
+
+## Approach
+New Typer command wraps the registry submit API and validates SKILL.md
+frontmatter before the network call.
+
+## How Has This Been Tested?
+`make test` (unit) plus a manual submit against a local stack via
+`make rebuild-fast`. Steps to reproduce in the PR discussion.
+
+## Checklist
+- [x] Descriptive commit message with a short title (max 50 chars)
+- [x] Commented hard-to-understand areas
+- [x] Performed a self-review
+- [ ] UI changes: screenshots (n/a, CLI only)
+
+## AI Assistance
+- [x] Yes (tool): Kiro CLI, used interactively under maintainer direction
+- [x] The generated code was manually reviewed and tested
+```

--- a/tests/test_observal_skill.py
+++ b/tests/test_observal_skill.py
@@ -46,6 +46,7 @@ ALL_SKILL_PATHS = [
     SKILLS_DIR / "observal-ops" / "SKILL.md",
     SKILLS_DIR / "observal-admin" / "SKILL.md",
     SKILLS_DIR / "observal-advanced" / "SKILL.md",
+    SKILLS_DIR / "observal-sdlc" / "SKILL.md",
 ]
 ALL_SKILL_MARKDOWN_PATHS = sorted(path for skill_path in ALL_SKILL_PATHS for path in skill_path.parent.rglob("*.md"))
 


### PR DESCRIPTION
## Purpose / Description
Adds a bundled `observal-sdlc` skill so contributors and interactive coding agents follow Observal's actual software development lifecycle. It codifies the process into a skill in the same format as the existing bundled skills (`observal-registry`, `observal-ops`, etc.).

## Fixes
N/A - no tracking issue; documentation/skill addition.

## Approach
New skill at `observal_cli/skills/observal-sdlc/` with a `SKILL.md` (execution contract + workflow selector) and three progressive-disclosure references:
- `contribution-workflow.md` - fork/clone/upstream, running the stack, claiming issues, branching, rebase, push-to-fork, open PR.
- `issue-and-pr-templates.md` - the Bug/Feature issue forms and how to fill every field of the PR template.
- `conventions-and-standards.md` - Conventional Commits, SPDX, changelog, code style, testing, code-review gates, AI policy, CLA.

Content is grounded in `CONTRIBUTING.md`, `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/*`, `AI_POLICY.md`, and the conventions visible in recent merged PRs.

Also registered the skill so it is bundled and tested like the others:
- `observal_cli/skill_installer.py`: added to `_SKILL_DIRS`.
- `tests/test_observal_skill.py`: added to `ALL_SKILL_PATHS`.
- `CHANGELOG.md`: `[Unreleased]` entry.

## How Has This Been Tested?
The repo test env (uv) was not available locally, so I replicated the checks that `tests/test_observal_skill.py` applies to a skill, using PyYAML:
- Frontmatter parses and contains required fields `name`, `description`, `version`; `command` is `observal`.
- Every progressive-disclosure link in `SKILL.md` resolves to a bundled reference file.
- No fenced `bash`/`sh` block contains a line starting with `observal` (so the command-resolution test cannot fail on this skill; only git/make/gh commands are shown).
- SPDX headers present in every new file.

All checks passed. Please run `make test` / `tests/test_observal_skill.py` in CI to confirm against the live Typer app.

## Learning (optional)
Skill format mirrors `observal_cli/skills/observal-registry/SKILL.md` and the validation contract in `observal-server/services/skill_validator.py`.

## Checklist
- [x] Descriptive commit message with a short title (first line, max 50 chars)
- [x] Commented code in hard-to-understand areas (n/a, docs/skill content)
- [x] Performed a self-review
- [ ] UI changes: screenshots (n/a, no UI change)

## AI Assistance
- [x] Yes (tool): Kiro CLI, used interactively under the maintainer's direction; the maintainer directed the task, and the content was assembled from and cross-checked against the repo's own contributing docs and templates
- [x] The change was manually reviewed and statically validated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `observal-sdlc` skill with contribution workflow guidance, coding standards, testing practices, review requirements, licensing, AI disclosure, and pull request expectations.
  * Included supporting documentation for contribution workflows, conventions, issue templates, and pull request templates.
  * Bundled the new skill for installation.

* **Documentation**
  * Added an Unreleased changelog entry describing the new skill.

* **Tests**
  * Added the skill to automated validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->