### PR TITLE
fix(cli): harden machine-readable workflows

### DIFF
--- a/docs/adding-a-cli-command.md
+++ b/docs/adding-a-cli-command.md
@@ -149,8 +149,9 @@ Never include tokens, passwords, API keys, authorization headers, secret payload
 | 8 | Rate limit reached |
 | 9 | Network, service, or dependency unavailable |
 | 10 | CLI and server version mismatch |
+| 11 | Batch completed with one or more item errors |
 
-When JSON formatting is selected, errors go to stderr as one JSON object and stdout stays clean. File-destination options named `output` do not activate JSON error rendering.
+When JSON formatting is selected, errors go to stderr as one JSON object and stdout stays clean. Safe repair data belongs in `error.result`; internal diagnostics remain debug-only. Finite partial batches keep one result document on stdout, set `partial: true`, and exit 11. File-destination options named `output` do not activate JSON error rendering.
 
 ## 5. Preserve non-interactive and side-effect safety
 
@@ -189,6 +190,7 @@ At minimum, cover:
 - Invalid output modes are rejected as usage errors.
 - API failures produce the expected category, exit code, operation, resource, remediation, and request ID.
 - JSON failures produce zero stdout bytes and one JSON object on stderr.
+- Partial batches preserve per-item JSON, set `partial: true`, and exit 11.
 - Debug-only detail is absent by default.
 - Confirmation, dry-run, idempotence, file writes, and secret handling when applicable.
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -82,10 +82,11 @@ Consistent across all commands:
 | 8    | Rate limit reached                           |
 | 9    | Network, service, or dependency unavailable  |
 | 10   | CLI and server version mismatch              |
+| 11   | Batch completed with one or more item errors |
 
-Errors identify the failed operation, resource, remediation, and server request ID when available. Internal details appear only with `--debug`.
+Errors identify the failed operation, resource, remediation, and server request ID when available. Repairable failures may include a safe structured `result`; internal details appear only with `--debug`.
 
-When JSON output is selected, errors are written to stderr as one JSON object and stdout remains clean:
+When JSON output is selected, errors are written to stderr as one JSON object and stdout remains clean. Startup migrations and update notices never write to JSON stdout. A nonfatal startup migration warning is a structured `warning` object on stderr.
 
 ```json
 {

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -85,7 +85,7 @@ observal agent bulk-create --from-file agents.json --dry-run --output json
 observal agent bulk-create --from-file agents.json --yes --output json
 ```
 
-JSON mode requires either `--dry-run` or `--yes`. It returns the direct bulk result, including per-agent statuses and summary counts.
+Input contains 1-50 agents. The CLI rejects malformed fields and duplicate canonical names before HTTP, and the server applies the same duplicate rules. JSON mode requires either `--dry-run` or `--yes`. Results include per-agent statuses, summary counts, and `partial`. Item errors set `partial: true` and exit with code 11; skips alone remain successful.
 
 ## List, my, and show
 
@@ -185,7 +185,7 @@ observal agent build --dir ./reviewer --output json
 observal agent build --dir ./reviewer --team platform --visibility team --output json
 ```
 
-Build verifies every component and validates whether private components are visible to the target owner. A successful JSON result contains `valid`, `agent`, `components`, and `issues`. Invalid composition exits with code 7 and leaves JSON stdout empty.
+Build verifies every component and validates whether private components are visible to the target owner. A successful JSON result contains `valid`, `agent`, `components`, and `issues`. Invalid composition exits with code 7 and leaves JSON stdout empty; the stderr error includes the same repairable data under `error.result`.
 
 ### Publish
 
@@ -254,6 +254,7 @@ Common Agent failures use:
 | 8 | Server rate limit |
 | 9 | Server, filesystem, lockfile, generated config, or setup dependency unavailable |
 | 10 | CLI and server version mismatch |
+| 11 | Bulk operation returned one or more item errors |
 
 ## Related
 

--- a/docs/cli/api.md
+++ b/docs/cli/api.md
@@ -9,18 +9,18 @@ Call an authenticated JSON endpoint when no dedicated high-level command exists.
 
 ```bash
 observal api GET /api/v1/teams --output json
-observal api GET /api/v1/agents --param limit=10 --param page=2 --output json
+observal api GET /api/v1/agents --param tag=review --param tag=security --output json
 observal api POST /api/v1/teams --from-file team.json --output json
 cat team.json | observal api POST /api/v1/teams --output json
 ```
 
-Methods are `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. Paths must be canonical relative `/api/v1/` paths. Full URLs, traversal segments, fragments, and inline query strings are rejected. Use repeatable `--param KEY=VALUE` options for query parameters.
+Methods are `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. Paths must be canonical relative `/api/v1/` paths. Full URLs, encoded or plain traversal segments, fragments, and inline query strings are rejected. Use repeatable `--param KEY=VALUE` options for query parameters; repeated keys preserve their original order.
 
 The command uses the configured bearer token. It does not accept arbitrary authorization headers, so it cannot forward credentials to another host.
 
 ## Request bodies
 
-`POST`, `PUT`, `PATCH`, and `DELETE` accept one JSON object from `--from-file` or standard input. A file takes precedence when both are present. `GET` rejects request bodies.
+`POST`, `PUT`, `PATCH`, and `DELETE` accept any single JSON value from `--from-file` or standard input: objects, arrays, strings, numbers, booleans, and explicit `null`. A file takes precedence when both are present. `GET` rejects every request body, including `null`.
 
 ## Output
 

--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -42,11 +42,11 @@ observal agent pull alice/reviewer --harness pi --version 1.2.3 --no-prompt --ou
 
 Unknown harnesses, unsupported scopes, malformed assignments, unused harness model overrides, unsupported model or tool options, and invalid versions fail locally with validation exit code 7.
 
-JSON mode cannot prompt and requires `--no-prompt`.
+JSON mode cannot prompt and requires `--no-prompt`. Missing required component values fail before config generation with `error.result.needs_input: true` and a list of names and component labels.
 
 ## Secrets
 
-Pull discovers required MCP environment variables and headers from the Agent's components. Interactive mode prompts for missing values. Non-interactive mode uses matching `--env` and `--header` assignments and leaves unprovided values for the generated config's placeholder behavior.
+Pull discovers required MCP environment variables and headers from the Agent's components. Interactive mode prompts for missing values. Non-interactive mode uses matching `--env` and `--header` assignments and stops before installation when any required value is missing. Optional values may remain unset.
 
 Values are sent only in the installation request and generated config. They are not included in JSON results, success messages, traces, or error details.
 
@@ -80,7 +80,7 @@ Pull performs these steps:
 8. Record Agent and component versions in the Registry-scoped lockfile.
 9. Refresh the local layer snapshot and active-Agent state.
 
-Failed skill installation or MCP setup prevents installation metadata from being recorded. A lockfile write failure is reported as exit code 9 instead of claiming success. A layer-snapshot failure is returned as a visible warning because the generated harness installation remains usable.
+Failed skill installation or MCP setup prevents installation metadata from being recorded. A lockfile write failure is reported as exit code 9 instead of claiming success. Failures after filesystem changes include safe partial state under `error.result`, including the stage, written file statuses, setup executable status, and tracking state. Setup arguments and secret values are omitted. A layer-snapshot failure is returned as a visible warning because the generated harness installation remains usable.
 
 ## JSON result
 

--- a/docs/cli/pull.md
+++ b/docs/cli/pull.md
@@ -80,7 +80,7 @@ Pull performs these steps:
 8. Record Agent and component versions in the Registry-scoped lockfile.
 9. Refresh the local layer snapshot and active-Agent state.
 
-Failed skill installation or MCP setup prevents installation metadata from being recorded. A lockfile write failure is reported as exit code 9 instead of claiming success. Failures after filesystem changes include safe partial state under `error.result`, including the stage, written file statuses, setup executable status, and tracking state. Setup arguments and secret values are omitted. A layer-snapshot failure is returned as a visible warning because the generated harness installation remains usable.
+Failed skill installation or MCP setup prevents installation metadata from being recorded. Setup commands have a 60-second timeout; a timeout is reported as a setup failure with exit code 9. A lockfile write failure is also reported as exit code 9 instead of claiming success. Failures after filesystem changes include safe partial state under `error.result`, including the stage, written file statuses, setup executable status, and tracking state. Setup arguments and secret values are omitted. A layer-snapshot failure is returned as a visible warning because the generated harness installation remains usable.
 
 ## JSON result
 

--- a/docs/cli/registry.md
+++ b/docs/cli/registry.md
@@ -91,7 +91,7 @@ The file is a bare array or an object with a `components` array. Each entry cont
 }
 ```
 
-Dry run validates file structure without contacting submission endpoints. Execution structurally validates every entry before the first mutation, submits entries in order, reports conflicts as skipped, and returns per-entry IDs, canonical names, review status, and safe errors. Authentication, permission, rate-limit, version, and service failures stop the batch. JSON execution requires `--yes`.
+Dry run validates file structure without contacting submission endpoints. Execution structurally validates every entry before the first mutation, submits entries in order, reports conflicts as skipped, and returns per-entry IDs, canonical names, review status, and safe errors. Results include `partial`; item errors set it to `true` and exit with code 11, while conflicts counted as skips remain successful. Authentication, permission, rate-limit, version, and service failures stop the batch. JSON execution requires `--yes`.
 
 Re-running a partially completed file is safe only after inspecting results. Existing identities are skipped for component types that reject duplicates. Verify created items by returned UUID or `qualified_name`.
 
@@ -240,7 +240,7 @@ observal registry mcp show @fav --output json
 
 ### `observal registry mcp install`
 
-Generate a harness config snippet for an MCP server. This command does not write harness configuration or record an installation. Prompts for required environment variables and headers unless non-interactive or machine output is selected.
+Generate a harness config snippet for an MCP server. This command does not write harness configuration or record an installation. Interactive mode prompts for required environment variables and headers. JSON mode requires `--no-prompt` and rejects missing required values before config generation with `error.result.needs_input: true`.
 
 ```bash
 observal registry mcp install <id-or-name> --harness <harness> [options]
@@ -253,8 +253,8 @@ observal registry mcp install <id-or-name> --harness <harness> [options]
 | `--env` | `-e` | Environment value as `KEY=VALUE`; repeatable |
 | `--header` | | Header value as `KEY=VALUE`; repeatable |
 | `--env-file` | | Read environment values from a file |
-| `--no-prompt` | `-y` | Use supplied values and placeholders without prompting |
-| `--raw` | | Output only the bare config snippet for piping |
+| `--no-prompt` | `-y` | Use supplied values without prompting; JSON fails if required values are missing |
+| `--raw` | | Output only a bare config template; missing values remain explicit placeholders |
 | `--output` | `-o` | Output the complete operation result as table or JSON |
 
 ```bash

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -46,7 +46,7 @@ observal server restart --background --output json
 observal server stop --output json
 ```
 
-`start` accepts `--port/-p` and `--host`. When the default API port is occupied, it tries the documented local fallback ports and reports the selected port. An explicitly selected occupied port is a conflict.
+`start` accepts `--port/-p` and `--host`. When the default API port is occupied, it tries the documented local fallback ports and reports the selected port. An explicitly selected occupied port is a conflict. Background start and restart verify all four final service states before returning success; stop verifies that none remains running. Their JSON results include the verified `services` list, and an unverified transition exits with code 9 plus observed state in `error.result`.
 
 Startup performs these steps in order:
 

--- a/observal-server/api/routes/bulk.py
+++ b/observal-server/api/routes/bulk.py
@@ -118,8 +118,24 @@ async def bulk_create_agents(
     created = 0
     skipped = 0
     errors = 0
+    seen_identities: set[tuple[str, str]] = set()
 
     for item in request.agents:
+        try:
+            identity = registry_identity(current_user, item.name)
+        except ValueError:
+            results.append(BulkResultItem(name=item.name, status="error", error="Agent name is invalid"))
+            errors += 1
+            continue
+
+        if identity in seen_identities:
+            results.append(
+                BulkResultItem(name=item.name, status="skipped", error="Agent name is duplicated in this batch")
+            )
+            skipped += 1
+            continue
+        seen_identities.add(identity)
+
         # Check for duplicate name
         if await _agent_name_exists(item.name, current_user, db):
             results.append(
@@ -129,6 +145,24 @@ async def bulk_create_agents(
             continue
 
         if request.dry_run:
+            try:
+                from services.agent_resolver import validate_component_ids
+
+                component_errors = await validate_component_ids(
+                    item.components,
+                    db,
+                    require_approved=False,
+                    current_user=current_user,
+                )
+                if component_errors:
+                    raise ValueError("component validation failed")
+            except Exception as exc:
+                optic.warning(
+                    "bulk dry-run validation failed for agent '{}': error_type={}", item.name, type(exc).__name__
+                )
+                results.append(BulkResultItem(name=item.name, status="error", error="Agent definition is invalid"))
+                errors += 1
+                continue
             results.append(BulkResultItem(name=item.name, status="created"))
             created += 1
             continue
@@ -155,8 +189,8 @@ async def bulk_create_agents(
             results.append(BulkResultItem(name=item.name, status="created", agent_id=agent.id))
             created += 1
         except Exception as exc:
-            optic.warning("bulk create failed for agent '{}': {}", item.name, exc)
-            results.append(BulkResultItem(name=item.name, status="error", error=str(exc)))
+            optic.warning("bulk create failed for agent '{}': error_type={}", item.name, type(exc).__name__)
+            results.append(BulkResultItem(name=item.name, status="error", error="Agent could not be created"))
             errors += 1
 
     if not request.dry_run and created > 0:
@@ -175,6 +209,7 @@ async def bulk_create_agents(
         created=created,
         skipped=skipped,
         errors=errors,
+        partial=errors > 0,
         dry_run=request.dry_run,
         results=results,
     )

--- a/observal-server/schemas/bulk.py
+++ b/observal-server/schemas/bulk.py
@@ -5,22 +5,29 @@ from __future__ import annotations
 
 import uuid  # noqa: TC003 - needed at runtime by Pydantic
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class BulkAgentItem(BaseModel):
     """Single agent in a bulk create request. Extends AgentCreateRequest fields with relaxed defaults."""
 
-    name: str
+    name: str = Field(min_length=1, max_length=255)
     version: str = "1.0.0"
     description: str = ""
     owner: str = ""
     prompt: str = ""
     model_name: str = "claude-sonnet-4"
-    model_config_json: dict = {}
-    supported_harnesses: list[str] = []
-    components: list[dict] = []  # [{component_type, component_id}]
-    external_mcps: list[dict] = []
+    model_config_json: dict = Field(default_factory=dict)
+    supported_harnesses: list[str] = Field(default_factory=list)
+    components: list[dict] = Field(default_factory=list)  # [{component_type, component_id}]
+    external_mcps: list[dict] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Agent name must not be empty")
+        return value
 
 
 class BulkAgentRequest(BaseModel):
@@ -40,5 +47,6 @@ class BulkResult(BaseModel):
     created: int
     skipped: int
     errors: int
+    partial: bool
     dry_run: bool
     results: list[BulkResultItem]

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -27,6 +27,7 @@ _version_enforced: bool = False
 
 # Subcommands exempt from version enforcement (user needs these to fix mismatches)
 _EXEMPT_SUBCOMMANDS = frozenset({"self", "server"})
+_QueryParams = dict | list[tuple[str, str]]
 
 
 def _get_cli_version() -> str:
@@ -263,7 +264,7 @@ def _request_with_retry(
     url: str,
     headers: dict,
     *,
-    params: dict | None = None,
+    params: _QueryParams | None = None,
     json: object | None = None,
 ) -> httpx.Response:
     """Execute HTTP with transient retries for GET requests only.
@@ -395,14 +396,15 @@ def _request(
     *,
     operation: str,
     resource: str,
-    params: dict | None = None,
+    params: _QueryParams | None = None,
     json_data: object | None = None,
+    send_json: bool = False,
 ) -> httpx.Response:
     base, headers = _client()
     request_kwargs: dict = {}
     if params is not None:
         request_kwargs["params"] = params
-    if json_data is not None:
+    if json_data is not None or send_json:
         request_kwargs["json"] = json_data
     try:
         return _request_with_retry(method, f"{base}{path}", headers, **request_kwargs)
@@ -447,8 +449,9 @@ def request_json(
     method: str,
     path: str,
     *,
-    params: dict | None = None,
+    params: _QueryParams | None = None,
     json_data: object | None = None,
+    send_json: bool = False,
     operation: str | None = None,
     resource: str | None = None,
 ) -> object:
@@ -460,7 +463,15 @@ def request_json(
         default_operation=f"Call {method.upper()} {path}",
         default_resource=path,
     )
-    response = _request(method, path, operation=operation, resource=resource, params=params, json_data=json_data)
+    response = _request(
+        method,
+        path,
+        operation=operation,
+        resource=resource,
+        params=params,
+        json_data=json_data,
+        send_json=send_json,
+    )
     return _json_response(
         response,
         operation=operation,
@@ -471,7 +482,7 @@ def request_json(
 
 def get(
     path: str,
-    params: dict | None = None,
+    params: _QueryParams | None = None,
     *,
     operation: str | None = None,
     resource: str | None = None,
@@ -489,7 +500,7 @@ def get(
 
 def get_text(
     path: str,
-    params: dict | None = None,
+    params: _QueryParams | None = None,
     *,
     content_type: str | None = None,
     operation: str | None = None,
@@ -520,7 +531,7 @@ def get_text(
 
 def get_with_headers(
     path: str,
-    params: dict | None = None,
+    params: _QueryParams | None = None,
     *,
     operation: str | None = None,
     resource: str | None = None,

--- a/observal_cli/client.py
+++ b/observal_cli/client.py
@@ -266,6 +266,7 @@ def _request_with_retry(
     *,
     params: _QueryParams | None = None,
     json: object | None = None,
+    send_json: bool = False,
 ) -> httpx.Response:
     """Execute HTTP with transient retries for GET requests only.
 
@@ -277,10 +278,15 @@ def _request_with_retry(
     timeout = config.get_timeout()
     func = getattr(httpx, method)
 
-    kwargs: dict = {"headers": headers, "timeout": timeout}
+    request_headers = headers
+    kwargs: dict = {"headers": request_headers, "timeout": timeout}
     if params is not None:
         kwargs["params"] = params
-    if json is not None:
+    if send_json and json is None:
+        request_headers = {**headers, "Content-Type": "application/json"}
+        kwargs["headers"] = request_headers
+        kwargs["content"] = b"null"
+    elif json is not None:
         kwargs["json"] = json
 
     safe_url = urlunparse(urlparse(url)._replace(netloc=urlparse(url).hostname or ""))
@@ -295,7 +301,8 @@ def _request_with_retry(
             # Update headers with new token and retry
             cfg = config.load()
             headers["Authorization"] = f"Bearer {cfg['access_token']}"
-            kwargs["headers"] = headers
+            request_headers["Authorization"] = headers["Authorization"]
+            kwargs["headers"] = request_headers
             optic.debug("token refreshed, retrying")
             continue
 
@@ -406,6 +413,8 @@ def _request(
         request_kwargs["params"] = params
     if json_data is not None or send_json:
         request_kwargs["json"] = json_data
+    if send_json:
+        request_kwargs["send_json"] = True
     try:
         return _request_with_retry(method, f"{base}{path}", headers, **request_kwargs)
     except httpx.HTTPStatusError as error:

--- a/observal_cli/cmd_agent.py
+++ b/observal_cli/cmd_agent.py
@@ -28,7 +28,7 @@ from rich.table import Table
 
 from observal_cli import client, config
 from observal_cli.constants import AGENT_NAME_REGEX, VALID_HARNESSES
-from observal_cli.errors import CliError, ErrorCategory, fail
+from observal_cli.errors import CliError, ErrorCategory, exit_partial, fail
 from observal_cli.prompts import fuzzy_select, select_many, select_one, text_input
 from observal_cli.render import (
     OutputMode,
@@ -48,6 +48,7 @@ from observal_cli.render import (
 # ── Agent authoring constants ──────────────────────────────
 YAML_FILE = "observal-agent.yaml"
 VALID_COMPONENT_TYPES = {"mcp", "skill", "hook", "prompt", "sandbox"}
+_RESERVED_AGENT_SLUGS = {"archive", "draft", "install", "resolve", "restore", "submit", "unarchive", "versions"}
 
 # Common model choices for the interactive wizard
 _MODEL_CHOICES = [
@@ -66,6 +67,12 @@ def _slugify(raw: str) -> str:
     s = re.sub(r"[^a-z0-9_-]+", "-", s)
     s = re.sub(r"-{2,}", "-", s)
     return s.strip("-")
+
+
+def _bulk_agent_slug(raw: str) -> str:
+    """Mirror the server's canonical registry slug for duplicate preflight."""
+    slug = re.sub(r"[^a-z0-9_-]+", "-", raw.strip().lower()).strip("-_")
+    return slug[:64].rstrip("-_")
 
 
 def _validate_name(name: str) -> str | None:
@@ -620,6 +627,131 @@ def agent_bulk_create(
             resource=file_path,
             remediation="Replace scalar or array entries with agent definition objects.",
         )
+    if len(agents) > 50:
+        fail(
+            ErrorCategory.VALIDATION,
+            "Bulk agent files may contain at most 50 entries.",
+            operation="Bulk create agents",
+            resource=file_path,
+            remediation="Split the input into files of 50 entries or fewer.",
+        )
+
+    identities: dict[str, int] = {}
+    for index, item in enumerate(agents, 1):
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} requires a non-empty string name.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Add a name to every agent definition.",
+            )
+        if len(name) > 255:
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} has a name longer than 255 characters.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Shorten the agent name and retry.",
+            )
+        identity = _bulk_agent_slug(name)
+        if not identity:
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} has a name without letters or numbers.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Use a name containing at least one letter or number.",
+            )
+        if identity in _RESERVED_AGENT_SLUGS:
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} resolves to reserved name: {identity}.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Choose a non-reserved agent name.",
+            )
+        if identity in identities:
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entries {identities[identity]} and {index} resolve to the same name: {identity}.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Keep one entry for each canonical agent name.",
+            )
+        identities[identity] = index
+
+        components = item.get("components", [])
+        if not isinstance(components, list):
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} components must be a list.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Use a list of component reference objects.",
+            )
+        for component_index, component in enumerate(components, 1):
+            if not isinstance(component, dict):
+                fail(
+                    ErrorCategory.VALIDATION,
+                    f"Bulk agent entry {index} component {component_index} must be an object.",
+                    operation="Bulk create agents",
+                    resource=file_path,
+                    remediation="Replace scalar component references with objects.",
+                )
+            component_type = component.get("component_type", "mcp")
+            if component_type not in VALID_COMPONENT_TYPES or not str(component.get("component_id") or "").strip():
+                fail(
+                    ErrorCategory.VALIDATION,
+                    f"Bulk agent entry {index} component {component_index} is incomplete.",
+                    operation="Bulk create agents",
+                    resource=file_path,
+                    remediation="Provide a valid component_type and component_id.",
+                )
+        for field in ("version", "description", "owner", "prompt", "model_name"):
+            if field in item and not isinstance(item[field], str):
+                fail(
+                    ErrorCategory.VALIDATION,
+                    f"Bulk agent entry {index} field {field} has the wrong type.",
+                    operation="Bulk create agents",
+                    resource=file_path,
+                    remediation=f"Use a JSON string for {field}.",
+                )
+        if "model_config_json" in item and not isinstance(item["model_config_json"], dict):
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} field model_config_json has the wrong type.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Use a JSON object for model_config_json.",
+            )
+        for field in ("supported_harnesses", "external_mcps"):
+            if field in item and not isinstance(item[field], list):
+                fail(
+                    ErrorCategory.VALIDATION,
+                    f"Bulk agent entry {index} field {field} has the wrong type.",
+                    operation="Bulk create agents",
+                    resource=file_path,
+                    remediation=f"Use a JSON list for {field}.",
+                )
+        if "supported_harnesses" in item and not all(isinstance(value, str) for value in item["supported_harnesses"]):
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} supported_harnesses must contain strings.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Replace non-string harness values.",
+            )
+        if "external_mcps" in item and not all(isinstance(value, dict) for value in item["external_mcps"]):
+            fail(
+                ErrorCategory.VALIDATION,
+                f"Bulk agent entry {index} external_mcps must contain objects.",
+                operation="Bulk create agents",
+                resource=file_path,
+                remediation="Replace non-object external MCP values.",
+            )
+
     if output == "json" and not (dry_run or yes):
         fail(
             ErrorCategory.VALIDATION,
@@ -652,8 +784,12 @@ def agent_bulk_create(
     if dry_run:
         with _progress(output, "Running dry-run..."):
             result = client.post("/api/v1/bulk/agents", {"agents": agents, "dry_run": True})
+        result = dict(result)
+        result["partial"] = result.get("errors", 0) > 0
         if output == "json":
             output_json(result)
+            if result["partial"]:
+                exit_partial()
             return
 
         results_table = Table(title="Dry-run results", show_lines=False, padding=(0, 1))
@@ -675,6 +811,8 @@ def agent_bulk_create(
             f"\n[bold]Summary:[/bold] {result.get('created', 0)} would be created, "
             f"{result.get('skipped', 0)} skipped, {result.get('errors', 0)} errors"
         )
+        if result["partial"]:
+            exit_partial()
         return
 
     # ── Confirmation ─────────────────────────────────────────
@@ -685,8 +823,12 @@ def agent_bulk_create(
     # ── Create ───────────────────────────────────────────────
     with _progress(output, "Creating agents..."):
         result = client.post("/api/v1/bulk/agents", {"agents": agents, "dry_run": False})
+    result = dict(result)
+    result["partial"] = result.get("errors", 0) > 0
     if output == "json":
         output_json(result)
+        if result["partial"]:
+            exit_partial()
         return
 
     results_table = Table(title="Bulk create results", show_lines=False, padding=(0, 1))
@@ -711,6 +853,8 @@ def agent_bulk_create(
         f"{result.get('created', 0)} created, {result.get('skipped', 0)} skipped, "
         f"{result.get('errors', 0)} errors"
     )
+    if result["partial"]:
+        exit_partial()
 
 
 @agent_app.command(name="list")
@@ -1413,7 +1557,7 @@ def agent_build(
             operation="Validate agent",
             resource=str(dir_path / YAML_FILE),
             remediation="Fix the reported component references or target scope and retry.",
-            detail=_json.dumps(result, default=str),
+            result=result,
         )
     if output == "json":
         output_json(result)

--- a/observal_cli/cmd_api.py
+++ b/observal_cli/cmd_api.py
@@ -15,16 +15,28 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.errors import ErrorCategory, fail, load_json_object
+from observal_cli.errors import ErrorCategory, fail, load_json_value
 from observal_cli.render import OutputMode, esc, output_json
 
 _METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+_NO_BODY = object()
 
 
 def _api_path(value: str) -> str:
     path = "/" + value.strip().lstrip("/")
-    decoded = unquote(path)
-    if not path.startswith("/api/v1/") or "?" in path or "#" in path or ".." in decoded.split("/"):
+    decoded = path
+    while True:
+        expanded = unquote(decoded)
+        if expanded == decoded:
+            break
+        decoded = expanded
+    if (
+        not path.startswith("/api/v1/")
+        or not decoded.startswith("/api/v1/")
+        or "?" in decoded
+        or "#" in decoded
+        or ".." in decoded.split("/")
+    ):
         fail(
             ErrorCategory.VALIDATION,
             "API path must be a canonical /api/v1 endpoint without a query string.",
@@ -35,10 +47,10 @@ def _api_path(value: str) -> str:
     return path
 
 
-def _params(values: list[str] | None) -> dict[str, str] | None:
+def _params(values: list[str] | None) -> list[tuple[str, str]] | None:
     if not values:
         return None
-    result: dict[str, str] = {}
+    result: list[tuple[str, str]] = []
     for value in values:
         key, separator, item = value.partition("=")
         if not separator or not key:
@@ -49,16 +61,16 @@ def _params(values: list[str] | None) -> dict[str, str] | None:
                 resource="API query parameters",
                 remediation="Use --param KEY=VALUE for every query parameter.",
             )
-        result[key] = item
+        result.append((key, item))
     return result
 
 
-def _stdin_body() -> dict[str, Any] | None:
+def _stdin_body() -> Any:
     if sys.stdin.isatty():
-        return None
+        return _NO_BODY
     content = sys.stdin.read().strip()
     if not content:
-        return None
+        return _NO_BODY
     try:
         payload = json.loads(content)
     except json.JSONDecodeError as error:
@@ -67,16 +79,8 @@ def _stdin_body() -> dict[str, Any] | None:
             "API standard input is not valid JSON.",
             operation="Call Observal API",
             resource="API request body",
-            remediation="Pipe one JSON object or use --from-file.",
+            remediation="Pipe one valid JSON value or use --from-file.",
             detail=repr(error),
-        )
-    if not isinstance(payload, dict):
-        fail(
-            ErrorCategory.VALIDATION,
-            "API request body must be a JSON object.",
-            operation="Call Observal API",
-            resource="API request body",
-            remediation="Wrap request fields in a JSON object.",
         )
     return payload
 
@@ -105,7 +109,7 @@ def _render_response(response: Any) -> None:
 def api_request(
     method: str = typer.Argument(help="HTTP method: GET, POST, PUT, PATCH, or DELETE."),
     path: str = typer.Argument(help="Relative /api/v1 endpoint path."),
-    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Read a JSON object request body."),
+    from_file: str | None = typer.Option(None, "--from-file", "-f", help="Read a JSON request body."),
     param: list[str] | None = typer.Option(None, "--param", help="Query parameter as KEY=VALUE; repeatable."),
     output: OutputMode = typer.Option("table", "--output", "-o", help="Output format: table or json."),
 ):
@@ -131,11 +135,11 @@ def api_request(
     endpoint = _api_path(path)
     query = _params(param)
     body = (
-        load_json_object(from_file, operation="Call Observal API", noun="API request file")
+        load_json_value(from_file, operation="Call Observal API", noun="API request file")
         if from_file
         else _stdin_body()
     )
-    if method == "GET" and body is not None:
+    if method == "GET" and body is not _NO_BODY:
         fail(
             ErrorCategory.VALIDATION,
             "GET does not accept a request body in this command.",
@@ -144,14 +148,15 @@ def api_request(
             remediation="Remove the body or choose POST, PUT, PATCH, or DELETE.",
         )
 
-    response = client.request_json(
-        method,
-        endpoint,
-        params=query,
-        json_data=body,
-        operation="Call Observal API",
-        resource="Observal API endpoint",
-    )
+    request_options: dict[str, Any] = {
+        "params": query,
+        "json_data": None if body is _NO_BODY else body,
+        "operation": "Call Observal API",
+        "resource": "Observal API endpoint",
+    }
+    if body is None:
+        request_options["send_json"] = True
+    response = client.request_json(method, endpoint, **request_options)
 
     if output == "json":
         output_json(response, raw=True)

--- a/observal_cli/cmd_bulk.py
+++ b/observal_cli/cmd_bulk.py
@@ -13,7 +13,7 @@ from rich import print as rprint
 from rich.table import Table
 
 from observal_cli import client
-from observal_cli.errors import CliError, ErrorCategory, fail
+from observal_cli.errors import CliError, ErrorCategory, exit_partial, fail
 from observal_cli.render import OutputMode, esc, output_json
 
 bulk_app = typer.Typer(
@@ -209,6 +209,7 @@ def bulk_submit_components(
             "submitted": 0,
             "skipped": 0,
             "errors": 0,
+            "partial": False,
             "dry_run": True,
             "results": results,
         }
@@ -271,11 +272,14 @@ def bulk_submit_components(
         "submitted": submitted,
         "skipped": skipped,
         "errors": errors,
+        "partial": errors > 0,
         "dry_run": False,
         "results": results,
     }
     if output == "json":
         output_json(response)
-        return
-    rprint(_results_table(results, title="Bulk submission results"))
-    rprint(f"[green]{submitted} submitted[/green], [yellow]{skipped} skipped[/yellow], [red]{errors} errors[/red]")
+    else:
+        rprint(_results_table(results, title="Bulk submission results"))
+        rprint(f"[green]{submitted} submitted[/green], [yellow]{skipped} skipped[/yellow], [red]{errors} errors[/red]")
+    if errors:
+        exit_partial()

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1075,7 +1075,9 @@ def _show_impl(mcp_id, output):
 
 def _install_input_definitions(listing: dict, field: str, kind: str) -> list[dict]:
     """Validate server-provided input metadata before using it in machine workflows."""
-    definitions = listing.get(field) or []
+    definitions = listing.get(field, [])
+    if definitions is None:
+        definitions = []
     if not isinstance(definitions, list) or any(
         not isinstance(item, dict) or not isinstance(item.get("name"), str) or not item["name"].strip()
         for item in definitions

--- a/observal_cli/cmd_mcp.py
+++ b/observal_cli/cmd_mcp.py
@@ -1073,6 +1073,24 @@ def _show_impl(mcp_id, output):
             rprint(f"  {icon} {esc(v['stage'])}: {esc(v.get('details', '') or 'passed')}")
 
 
+def _install_input_definitions(listing: dict, field: str, kind: str) -> list[dict]:
+    """Validate server-provided input metadata before using it in machine workflows."""
+    definitions = listing.get(field) or []
+    if not isinstance(definitions, list) or any(
+        not isinstance(item, dict) or not isinstance(item.get("name"), str) or not item["name"].strip()
+        for item in definitions
+    ):
+        fail(
+            ErrorCategory.UNAVAILABLE,
+            "The server returned invalid MCP installation requirements.",
+            operation="Install MCP server",
+            resource=listing.get("qualified_name") or listing.get("name") or "MCP server",
+            remediation="Check server compatibility and retry.",
+            result={"invalid_input_kind": kind},
+        )
+    return definitions
+
+
 def _install_impl(
     mcp_id,
     harness,
@@ -1094,6 +1112,8 @@ def _install_impl(
     fetch_context = nullcontext() if machine_output else spinner("Fetching server details...")
     with fetch_context:
         listing = client.get(f"/api/v1/mcps/{resolved}")
+    env_var_list = _install_input_definitions(listing, "environment_variables", "environment_variable")
+    header_list = _install_input_definitions(listing, "headers", "header")
 
     # Build env overrides from --env flags and --env-file
     _env_from_flags: dict[str, str] = dict(env_overrides) if env_overrides else {}
@@ -1119,7 +1139,26 @@ def _install_impl(
     skip_prompts = machine_output or no_prompt
 
     env_values: dict[str, str] = {}
-    env_var_list = listing.get("environment_variables") or []
+    if output == "json":
+        missing_inputs = [
+            {"kind": "environment_variable", "name": ev["name"]}
+            for ev in env_var_list
+            if ev.get("required", True) and not _env_from_flags.get(ev["name"])
+        ]
+        missing_inputs.extend(
+            {"kind": "header", "name": header["name"]}
+            for header in header_list
+            if header.get("required", True) and not _header_from_flags.get(header["name"])
+        )
+        if missing_inputs:
+            fail(
+                ErrorCategory.VALIDATION,
+                "MCP installation requires values that are unavailable in non-interactive mode.",
+                operation="Install MCP server",
+                resource=listing.get("qualified_name") or listing.get("name") or resolved,
+                remediation="Provide non-secret values explicitly; for credentials, use interactive table mode.",
+                result={"needs_input": True, "inputs": missing_inputs},
+            )
     if env_var_list and not skip_prompts:
         required = [ev for ev in env_var_list if ev.get("required", True)]
         optional = [ev for ev in env_var_list if not ev.get("required", True)]
@@ -1156,7 +1195,6 @@ def _install_impl(
 
     # Prompt for headers (SSE/HTTP servers with auth)
     header_values: dict[str, str] = {}
-    header_list = listing.get("headers") or []
     if header_list and not skip_prompts:
         required_headers = [h for h in header_list if h.get("required", True)]
         optional_headers = [h for h in header_list if not h.get("required", True)]
@@ -1519,6 +1557,14 @@ def install(
             )
     env_overrides = _parse_assignments(env, "environment variable")
     header_overrides = _parse_assignments(header, "header")
+    if output == "json" and not no_prompt:
+        fail(
+            ErrorCategory.VALIDATION,
+            "JSON mode cannot prompt for MCP installation values.",
+            operation="Install MCP server",
+            resource="MCP installation",
+            remediation="Add --no-prompt and provide every required value, or use interactive table mode.",
+        )
     _install_impl(
         mcp_id,
         harness,

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -115,7 +115,9 @@ def _resolve_hook_paths(content: str) -> str:
 
 
 def _component_input_definitions(listing: dict, field: str, kind: str, component: str) -> list[dict]:
-    definitions = listing.get(field) or []
+    definitions = listing.get(field, [])
+    if definitions is None:
+        definitions = []
     if not isinstance(definitions, list) or any(
         not isinstance(item, dict) or not isinstance(item.get("name"), str) or not item["name"].strip()
         for item in definitions
@@ -186,7 +188,7 @@ def _collect_mcp_env_vars(
             for ev in required + optional:
                 if ev["name"] in _overrides:
                     mcp_env[ev["name"]] = _overrides[ev["name"]]
-                elif ev in required and missing_inputs is not None:
+                elif ev.get("required", True) and missing_inputs is not None:
                     missing_inputs.append({"kind": "environment_variable", "name": ev["name"], "component": mcp_name})
         else:
             if required:
@@ -265,7 +267,7 @@ def _collect_mcp_headers(
             for h in required + optional:
                 if h["name"] in _overrides:
                     mcp_hdrs[h["name"]] = _overrides[h["name"]]
-                elif h in required and missing_inputs is not None:
+                elif h.get("required", True) and missing_inputs is not None:
                     missing_inputs.append({"kind": "header", "name": h["name"], "component": mcp_name})
         else:
             if required:
@@ -594,6 +596,10 @@ def _pull_failure_result(
         ]
     result.update(state)
     return result
+
+
+def _valid_setup_command(command: object) -> bool:
+    return isinstance(command, list) and bool(command) and all(isinstance(argument, str) for argument in command)
 
 
 def _parse_assignments(values: list[str] | None, label: str) -> dict[str, str]:
@@ -1127,7 +1133,6 @@ def register_pull(app: typer.Typer):
             if dry_run:
                 written.append((str(p), "would write"))
             else:
-                existed = p.exists()
                 status = tracked_write(p, hf["content"])
                 written.append((str(p), status))
                 if hf.get("executable"):
@@ -1145,7 +1150,6 @@ def register_pull(app: typer.Typer):
                             detail=repr(error),
                             result=_pull_failure_result(written, "mark_hook_executable", failed_path=str(p)),
                         )
-                written[-1] = (str(p), "updated" if existed else "created")
 
         # ── prompt_files (native Copilot .github/prompts/*.prompt.md) ─
         for pf in snippet.get("prompt_files") or []:
@@ -1264,7 +1268,7 @@ def register_pull(app: typer.Typer):
         setup_cmds = snippet.get("mcp_setup_commands") or []
         if setup_cmds and not dry_run:
             for command in setup_cmds:
-                if not isinstance(command, list) or not command or not all(isinstance(arg, str) for arg in command):
+                if not _valid_setup_command(command):
                     setup_results.append({"command": [], "status": "failed", "return_code": None})
                     setup_failures.append("invalid setup command")
                     continue
@@ -1288,7 +1292,7 @@ def register_pull(app: typer.Typer):
                     setup_failures.append(f"{command[0]} exited with code {process.returncode}")
         elif setup_cmds:
             for command in setup_cmds:
-                if not isinstance(command, list) or not command or not all(isinstance(arg, str) for arg in command):
+                if not _valid_setup_command(command):
                     setup_results.append({"command": [], "status": "failed", "return_code": None})
                     setup_failures.append("invalid setup command")
                 else:

--- a/observal_cli/cmd_pull.py
+++ b/observal_cli/cmd_pull.py
@@ -30,7 +30,7 @@ from rich import print as rprint
 
 from observal_cli import client, config
 from observal_cli.constants import VALID_HARNESSES
-from observal_cli.errors import ErrorCategory, fail
+from observal_cli.errors import CliError, ErrorCategory, fail
 from observal_cli.harness import ensure_loaded, get_adapter
 from observal_cli.prompts import password_input, select_one
 from observal_cli.render import OutputMode, esc, output_json, spinner
@@ -114,8 +114,29 @@ def _resolve_hook_paths(content: str) -> str:
     return content
 
 
+def _component_input_definitions(listing: dict, field: str, kind: str, component: str) -> list[dict]:
+    definitions = listing.get(field) or []
+    if not isinstance(definitions, list) or any(
+        not isinstance(item, dict) or not isinstance(item.get("name"), str) or not item["name"].strip()
+        for item in definitions
+    ):
+        fail(
+            ErrorCategory.UNAVAILABLE,
+            "The server returned invalid agent installation requirements.",
+            operation="Pull agent",
+            resource=component,
+            remediation="Check server compatibility and retry.",
+            result={"invalid_input_kind": kind, "component": component},
+        )
+    return definitions
+
+
 def _collect_mcp_env_vars(
-    agent_detail: dict, *, no_prompt: bool = False, env_overrides: dict[str, str] | None = None
+    agent_detail: dict,
+    *,
+    no_prompt: bool = False,
+    env_overrides: dict[str, str] | None = None,
+    missing_inputs: list[dict[str, str]] | None = None,
 ) -> dict[str, dict[str, str]]:
     """Discover MCP env vars from agent components and prompt the user for values.
 
@@ -146,13 +167,18 @@ def _collect_mcp_env_vars(
     for listing_id, display_name in mcp_ids:
         listing = client.get(f"/api/v1/mcps/{listing_id}")
 
-        ev_list = listing.get("environment_variables") or []
+        mcp_name = display_name or listing.get("name", listing_id[:8])
+        ev_list = _component_input_definitions(
+            listing,
+            "environment_variables",
+            "environment_variable",
+            mcp_name,
+        )
         if not ev_list:
             continue
 
         required = [ev for ev in ev_list if ev.get("required", True)]
         optional = [ev for ev in ev_list if not ev.get("required", True)]
-        mcp_name = display_name or listing.get("name", listing_id[:8])
         mcp_env: dict[str, str] = {}
 
         if no_prompt:
@@ -160,6 +186,8 @@ def _collect_mcp_env_vars(
             for ev in required + optional:
                 if ev["name"] in _overrides:
                     mcp_env[ev["name"]] = _overrides[ev["name"]]
+                elif ev in required and missing_inputs is not None:
+                    missing_inputs.append({"kind": "environment_variable", "name": ev["name"], "component": mcp_name})
         else:
             if required:
                 rprint(f"\n[bold]{esc(mcp_name)}[/bold] requires {len(required)} environment variable(s):")
@@ -192,7 +220,11 @@ def _collect_mcp_env_vars(
 
 
 def _collect_mcp_headers(
-    agent_detail: dict, *, no_prompt: bool = False, header_overrides: dict[str, str] | None = None
+    agent_detail: dict,
+    *,
+    no_prompt: bool = False,
+    header_overrides: dict[str, str] | None = None,
+    missing_inputs: list[dict[str, str]] | None = None,
 ) -> dict[str, dict[str, str]]:
     """Discover MCP headers from agent components and prompt the user for values.
 
@@ -220,19 +252,21 @@ def _collect_mcp_headers(
     for listing_id, display_name in mcp_ids:
         listing = client.get(f"/api/v1/mcps/{listing_id}")
 
-        header_list = listing.get("headers") or []
+        mcp_name = display_name or listing.get("name", listing_id[:8])
+        header_list = _component_input_definitions(listing, "headers", "header", mcp_name)
         if not header_list:
             continue
 
         required = [h for h in header_list if h.get("required", True)]
         optional = [h for h in header_list if not h.get("required", True)]
-        mcp_name = display_name or listing.get("name", listing_id[:8])
         mcp_hdrs: dict[str, str] = {}
 
         if no_prompt:
             for h in required + optional:
                 if h["name"] in _overrides:
                     mcp_hdrs[h["name"]] = _overrides[h["name"]]
+                elif h in required and missing_inputs is not None:
+                    missing_inputs.append({"kind": "header", "name": h["name"], "component": mcp_name})
         else:
             if required:
                 rprint(f"\n[bold]{esc(mcp_name)}[/bold] requires {len(required)} header(s):")
@@ -536,6 +570,32 @@ def _progress(output: OutputMode | str, message: str | None = None):
     return nullcontext() if output == "json" else spinner(message)
 
 
+def _pull_failure_result(
+    written: list[tuple[str, str]],
+    stage: str,
+    *,
+    setup_results: list[dict] | None = None,
+    **state: object,
+) -> dict:
+    """Build a secret-free description of pull side effects completed before failure."""
+    result: dict[str, object] = {
+        "partial": bool(written) and not bool(state.get("dry_run")),
+        "stage": stage,
+        "files": [{"path": path, "status": status} for path, status in written],
+    }
+    if setup_results is not None:
+        result["setup_commands"] = [
+            {
+                "executable": str(item.get("command", [""])[0]) if item.get("command") else "",
+                "status": item.get("status"),
+                "return_code": item.get("return_code"),
+            }
+            for item in setup_results
+        ]
+    result.update(state)
+    return result
+
+
 def _parse_assignments(values: list[str] | None, label: str) -> dict[str, str]:
     parsed: dict[str, str] = {}
     for item in values or []:
@@ -787,6 +847,7 @@ def register_pull(app: typer.Typer):
           observal agent pull my-agent --harness claude-code --version 1.2.0
           observal agent pull my-agent --harness cursor --no-prompt --dry-run
         """
+        harness, scope, version = _validate_pull_inputs(harness, scope, version)
         if output == "json" and not no_prompt:
             fail(
                 ErrorCategory.VALIDATION,
@@ -795,7 +856,6 @@ def register_pull(app: typer.Typer):
                 resource="agent installation",
                 remediation="Add --no-prompt only when no secret values are required; otherwise use interactive table mode.",
             )
-        harness, scope, version = _validate_pull_inputs(harness, scope, version)
         env_overrides = _parse_assignments(env, "environment variable")
         header_overrides = _parse_assignments(header, "header")
         model_default, model_overrides = _parse_model_overrides(model or [])
@@ -844,10 +904,28 @@ def register_pull(app: typer.Typer):
         with _progress(output, "Fetching agent details..."):
             agent_detail = client.get(f"/api/v1/agents/{resolved}")
 
-        env_values = _collect_mcp_env_vars(agent_detail, no_prompt=no_prompt, env_overrides=env_overrides or None)
-        header_values = _collect_mcp_headers(
-            agent_detail, no_prompt=no_prompt, header_overrides=header_overrides or None
+        missing_inputs: list[dict[str, str]] = []
+        env_values = _collect_mcp_env_vars(
+            agent_detail,
+            no_prompt=no_prompt,
+            env_overrides=env_overrides or None,
+            missing_inputs=missing_inputs,
         )
+        header_values = _collect_mcp_headers(
+            agent_detail,
+            no_prompt=no_prompt,
+            header_overrides=header_overrides or None,
+            missing_inputs=missing_inputs,
+        )
+        if missing_inputs:
+            fail(
+                ErrorCategory.VALIDATION,
+                "Agent installation requires values that are unavailable in non-interactive mode.",
+                operation="Pull agent",
+                resource=agent_detail.get("qualified_name") or agent_detail.get("name") or resolved,
+                remediation="Use interactive table mode to enter credentials securely.",
+                result={"needs_input": True, "inputs": missing_inputs},
+            )
 
         if output != "json":
             rprint(f"\n[bold]Install options for [cyan]{esc(harness)}[/cyan]:[/bold]")
@@ -936,6 +1014,47 @@ def register_pull(app: typer.Typer):
 
         written: list[tuple[str, str]] = []  # (path, status)
 
+        def tracked_write(path: Path, content: str | dict, *, merge_mcp: bool = False) -> str:
+            try:
+                return _write_file_checked(path, content, merge_mcp=merge_mcp)
+            except CliError as error:
+                if error.result is None:
+                    error.result = _pull_failure_result(
+                        written,
+                        "write_files",
+                        failed_path=str(path),
+                    )
+                raise
+
+        def tracked_skill_install(skill_name: str, installer, **kwargs):
+            try:
+                with redirect_stdout(StringIO()) if output == "json" else nullcontext():
+                    return installer(**kwargs)
+            except CliError as error:
+                if error.result is None:
+                    error.result = _pull_failure_result(
+                        written,
+                        "install_skills",
+                        failed_skills=[skill_name],
+                        installation_tracked=False,
+                    )
+                raise
+            except (OSError, RuntimeError, ValueError, subprocess.SubprocessError) as error:
+                fail(
+                    ErrorCategory.UNAVAILABLE,
+                    f"Failed to install agent skill: {skill_name}.",
+                    operation="Pull agent",
+                    resource="agent skills",
+                    remediation="Check skill source access and local filesystem permissions, then retry.",
+                    detail=repr(error),
+                    result=_pull_failure_result(
+                        written,
+                        "install_skills",
+                        failed_skills=[skill_name],
+                        installation_tracked=False,
+                    ),
+                )
+
         # ── mcp_config with path key (Cursor/VSCode/Gemini) ─
         mcp_cfg = snippet.get("mcp_config")
         if mcp_cfg and isinstance(mcp_cfg, dict) and "path" in mcp_cfg:
@@ -943,7 +1062,7 @@ def register_pull(app: typer.Typer):
             if dry_run:
                 written.append((str(p), "would write"))
             else:
-                status = _write_file_checked(p, mcp_cfg["content"], merge_mcp=True)
+                status = tracked_write(p, mcp_cfg["content"], merge_mcp=True)
                 written.append((str(p), status))
 
         # ── hooks_config (Cursor/VSCode/Copilot/OpenCode/Gemini) ─
@@ -969,7 +1088,7 @@ def register_pull(app: typer.Typer):
             if dry_run:
                 written.append((str(p), "would write"))
             else:
-                status = _write_file_checked(p, content, merge_mcp=hooks_cfg.get("merge", False))
+                status = tracked_write(p, content, merge_mcp=hooks_cfg.get("merge", False))
                 written.append((str(p), status))
 
         # ── agent_profile (Kiro, Cursor) ────────────────────────
@@ -988,7 +1107,7 @@ def register_pull(app: typer.Typer):
             if dry_run:
                 written.append((str(p), "would write"))
             else:
-                status = _write_file_checked(p, agent_profile["content"])
+                status = tracked_write(p, agent_profile["content"])
                 written.append((str(p), status))
 
         # ── steering_file (Kiro) ───────────────────────────
@@ -998,7 +1117,7 @@ def register_pull(app: typer.Typer):
             if dry_run:
                 written.append((str(p), "would write"))
             else:
-                status = _write_file_checked(p, steering_file["content"])
+                status = tracked_write(p, steering_file["content"])
                 written.append((str(p), status))
 
         # ── hook_files (script files from hook components) ─────
@@ -1009,7 +1128,8 @@ def register_pull(app: typer.Typer):
                 written.append((str(p), "would write"))
             else:
                 existed = p.exists()
-                _write_file_checked(p, hf["content"])
+                status = tracked_write(p, hf["content"])
+                written.append((str(p), status))
                 if hf.get("executable"):
                     import os
 
@@ -1023,8 +1143,9 @@ def register_pull(app: typer.Typer):
                             resource=str(p),
                             remediation="Check file ownership and permissions.",
                             detail=repr(error),
+                            result=_pull_failure_result(written, "mark_hook_executable", failed_path=str(p)),
                         )
-                written.append((str(p), "updated" if existed else "created"))
+                written[-1] = (str(p), "updated" if existed else "created")
 
         # ── prompt_files (native Copilot .github/prompts/*.prompt.md) ─
         for pf in snippet.get("prompt_files") or []:
@@ -1033,7 +1154,7 @@ def register_pull(app: typer.Typer):
                 written.append((str(p), "would write"))
             else:
                 existed = p.exists()
-                _write_file_checked(p, pf["content"])
+                tracked_write(p, pf["content"])
                 written.append((str(p), "updated" if existed else "created"))
 
         # ── Direct skill files ─────────────────────────
@@ -1042,7 +1163,7 @@ def register_pull(app: typer.Typer):
             if dry_run:
                 written.append((str(p), "would write"))
             else:
-                status = _write_file_checked(p, sf["content"])
+                status = tracked_write(p, sf["content"])
                 written.append((str(p), status))
 
         # ── Skills ────────────────────────────────────
@@ -1067,18 +1188,19 @@ def register_pull(app: typer.Typer):
                 continue
 
             if git_url:
-                with redirect_stdout(StringIO()) if output == "json" else nullcontext():
-                    result_path = install_skill_from_git(
-                        name=sc.get("name", "skill"),
-                        git_url=git_url,
-                        skill_path=sc.get("skill_path", "/"),
-                        git_ref=sc.get("git_ref", "main"),
-                        harness=harness,
-                        scope=scope_str,
-                        skill_md_content=sc.get("skill_md_content"),
-                        cwd=target_dir,
-                        dest=skill_dest,
-                    )
+                result_path = tracked_skill_install(
+                    sc_name,
+                    install_skill_from_git,
+                    name=sc.get("name", "skill"),
+                    git_url=git_url,
+                    skill_path=sc.get("skill_path", "/"),
+                    git_ref=sc.get("git_ref", "main"),
+                    harness=harness,
+                    scope=scope_str,
+                    skill_md_content=sc.get("skill_md_content"),
+                    cwd=target_dir,
+                    dest=skill_dest,
+                )
                 if result_path:
                     written.append((str(result_path), "cloned"))
                 else:
@@ -1090,17 +1212,18 @@ def register_pull(app: typer.Typer):
                         )
             else:
                 # Registry direct: SKILL.md content + optional script
-                with redirect_stdout(StringIO()) if output == "json" else nullcontext():
-                    result_path = install_skill_registry_direct(
-                        name=sc.get("name", "skill"),
-                        skill_md_content=sc.get("skill_md_content"),
-                        script_content=sc.get("script_content"),
-                        script_filename=sc.get("script_filename"),
-                        harness=harness,
-                        scope=scope_str,
-                        cwd=target_dir,
-                        dest=skill_dest,
-                    )
+                result_path = tracked_skill_install(
+                    sc_name,
+                    install_skill_registry_direct,
+                    name=sc.get("name", "skill"),
+                    skill_md_content=sc.get("skill_md_content"),
+                    script_content=sc.get("script_content"),
+                    script_filename=sc.get("script_filename"),
+                    harness=harness,
+                    scope=scope_str,
+                    cwd=target_dir,
+                    dest=skill_dest,
+                )
                 if result_path:
                     written.append((str(result_path), "installed"))
                 else:
@@ -1116,6 +1239,12 @@ def register_pull(app: typer.Typer):
                 resource="agent skills",
                 remediation="Check skill source access and content, then retry.",
                 detail=", ".join(failed_skills),
+                result=_pull_failure_result(
+                    written,
+                    "install_skills",
+                    failed_skills=failed_skills,
+                    installation_tracked=False,
+                ),
             )
 
         if not written:
@@ -1135,18 +1264,35 @@ def register_pull(app: typer.Typer):
         setup_cmds = snippet.get("mcp_setup_commands") or []
         if setup_cmds and not dry_run:
             for command in setup_cmds:
+                if not isinstance(command, list) or not command or not all(isinstance(arg, str) for arg in command):
+                    setup_results.append({"command": [], "status": "failed", "return_code": None})
+                    setup_failures.append("invalid setup command")
+                    continue
                 try:
-                    process = subprocess.run(command, capture_output=True, text=True)
+                    process = subprocess.run(command, capture_output=True, text=True, timeout=60)
                 except FileNotFoundError:
                     setup_results.append({"command": command, "status": "failed", "return_code": None})
                     setup_failures.append(f"{command[0]} not found")
+                    continue
+                except subprocess.TimeoutExpired:
+                    setup_results.append({"command": command, "status": "failed", "return_code": None})
+                    setup_failures.append(f"{command[0]} timed out")
+                    continue
+                except OSError:
+                    setup_results.append({"command": command, "status": "failed", "return_code": None})
+                    setup_failures.append(f"{command[0]} could not start")
                     continue
                 status = "completed" if process.returncode == 0 else "failed"
                 setup_results.append({"command": command, "status": status, "return_code": process.returncode})
                 if process.returncode != 0:
                     setup_failures.append(f"{command[0]} exited with code {process.returncode}")
         elif setup_cmds:
-            setup_results = [{"command": command, "status": "would_run", "return_code": None} for command in setup_cmds]
+            for command in setup_cmds:
+                if not isinstance(command, list) or not command or not all(isinstance(arg, str) for arg in command):
+                    setup_results.append({"command": [], "status": "failed", "return_code": None})
+                    setup_failures.append("invalid setup command")
+                else:
+                    setup_results.append({"command": command, "status": "would_run", "return_code": None})
 
         if setup_failures:
             fail(
@@ -1156,6 +1302,13 @@ def register_pull(app: typer.Typer):
                 resource="harness MCP registration",
                 remediation="Fix the reported command and pull the agent again.",
                 detail="; ".join(setup_failures),
+                result=_pull_failure_result(
+                    written,
+                    "run_setup_commands",
+                    setup_results=setup_results,
+                    dry_run=dry_run,
+                    installation_tracked=False,
+                ),
             )
 
         # Record installation state only after files and setup commands succeed.
@@ -1186,6 +1339,13 @@ def register_pull(app: typer.Typer):
                     resource="Observal lockfile",
                     remediation="Repair the local lockfile and pull the agent again.",
                     detail=repr(error),
+                    result=_pull_failure_result(
+                        written,
+                        "update_lockfile",
+                        setup_results=setup_results,
+                        installation_tracked=False,
+                        active_agent_persisted=False,
+                    ),
                 )
 
             try:
@@ -1205,6 +1365,13 @@ def register_pull(app: typer.Typer):
                     resource=f"{harness} active-agent state",
                     remediation="Fix harness configuration permissions and pull the agent again.",
                     detail=repr(error),
+                    result=_pull_failure_result(
+                        written,
+                        "persist_active_agent",
+                        setup_results=setup_results,
+                        installation_tracked=True,
+                        active_agent_persisted=False,
+                    ),
                 )
 
             from observal_cli.audit import emit_cli_audit

--- a/observal_cli/cmd_server.py
+++ b/observal_cli/cmd_server.py
@@ -61,7 +61,13 @@ def _verified_service_states(orchestrator, *, running: bool, operation: str) -> 
             remediation="Run `observal server status --output json` and inspect the server logs.",
             detail=repr(error),
         )
+    expected = "running" if running else "stopped"
     expected_services = {"postgres", "clickhouse", "redis", "api"}
+    states = (
+        [{"service": service, "status": status} for service, status in statuses.items()]
+        if isinstance(statuses, dict)
+        else []
+    )
     if not isinstance(statuses, dict) or not expected_services.issubset(statuses):
         fail(
             ErrorCategory.UNAVAILABLE,
@@ -69,15 +75,14 @@ def _verified_service_states(orchestrator, *, running: bool, operation: str) -> 
             operation=operation,
             resource="embedded services",
             remediation="Run `observal server status --output json` and inspect the server logs.",
+            result={"expected": expected, "services": states},
         )
-    states = [{"service": service, "status": status} for service, status in statuses.items()]
     verified = bool(statuses) and (
         all(status == "running" for status in statuses.values())
         if running
         else not any(status == "running" for status in statuses.values())
     )
     if not verified:
-        expected = "running" if running else "stopped"
         fail(
             ErrorCategory.UNAVAILABLE,
             f"Embedded services did not reach the expected {expected} state.",

--- a/observal_cli/cmd_server.py
+++ b/observal_cli/cmd_server.py
@@ -48,6 +48,47 @@ def _is_json(output: OutputMode) -> bool:
     return output == "json"
 
 
+def _verified_service_states(orchestrator, *, running: bool, operation: str) -> list[dict[str, str]]:
+    """Read final embedded-service state and fail when it contradicts the requested lifecycle action."""
+    try:
+        statuses = orchestrator.status()
+    except Exception as error:
+        fail(
+            ErrorCategory.UNAVAILABLE,
+            "The final embedded service state could not be verified.",
+            operation=operation,
+            resource="embedded services",
+            remediation="Run `observal server status --output json` and inspect the server logs.",
+            detail=repr(error),
+        )
+    expected_services = {"postgres", "clickhouse", "redis", "api"}
+    if not isinstance(statuses, dict) or not expected_services.issubset(statuses):
+        fail(
+            ErrorCategory.UNAVAILABLE,
+            "The embedded service status response was incomplete.",
+            operation=operation,
+            resource="embedded services",
+            remediation="Run `observal server status --output json` and inspect the server logs.",
+        )
+    states = [{"service": service, "status": status} for service, status in statuses.items()]
+    verified = bool(statuses) and (
+        all(status == "running" for status in statuses.values())
+        if running
+        else not any(status == "running" for status in statuses.values())
+    )
+    if not verified:
+        expected = "running" if running else "stopped"
+        fail(
+            ErrorCategory.UNAVAILABLE,
+            f"Embedded services did not reach the expected {expected} state.",
+            operation=operation,
+            resource="embedded services",
+            remediation="Inspect the returned service states and server logs, then retry.",
+            result={"expected": expected, "services": states},
+        )
+    return states
+
+
 @contextmanager
 def _quiet_output(output: OutputMode):
     """Suppress nested human progress while a command builds its JSON result."""
@@ -146,6 +187,9 @@ def start(
             detail=repr(error),
         )
 
+    services = (
+        _verified_service_states(orchestrator, running=True, operation="Start embedded server") if background else []
+    )
     if _is_json(output):
         output_json(
             {
@@ -155,6 +199,7 @@ def start(
                 "port": port,
                 "background": True,
                 "used_fallback_port": port != requested_port,
+                "services": services,
             }
         )
 
@@ -171,12 +216,24 @@ def stop(
         observal server stop
         observal server stop --output json
     """
-    from observal_cli.server.orchestrator import Orchestrator
+    from observal_cli.server.orchestrator import Orchestrator, ServiceError
 
-    with _quiet_output(output):
-        Orchestrator().stop_all()
+    orchestrator = Orchestrator()
+    try:
+        with _quiet_output(output):
+            orchestrator.stop_all()
+    except (ServiceError, RuntimeError, OSError) as error:
+        fail(
+            ErrorCategory.UNAVAILABLE,
+            "The embedded server could not stop cleanly.",
+            operation="Stop embedded server",
+            resource="embedded services",
+            remediation="Inspect server status and logs, then retry.",
+            detail=repr(error),
+        )
+    services = _verified_service_states(orchestrator, running=False, operation="Stop embedded server")
     if _is_json(output):
-        output_json({"status": "stopped", "mode": "embedded"})
+        output_json({"status": "stopped", "mode": "embedded", "services": services})
 
 
 @server_app.command()
@@ -221,8 +278,20 @@ def restart(
             remediation="Check local dependencies and server logs, then retry.",
             detail=repr(error),
         )
+    services = (
+        _verified_service_states(orchestrator, running=True, operation="Restart embedded server") if background else []
+    )
     if _is_json(output):
-        output_json({"status": "restarted", "mode": "embedded", "host": host, "port": port, "background": True})
+        output_json(
+            {
+                "status": "restarted",
+                "mode": "embedded",
+                "host": host,
+                "port": port,
+                "background": True,
+                "services": services,
+            }
+        )
 
 
 @server_app.command()

--- a/observal_cli/errors.py
+++ b/observal_cli/errors.py
@@ -35,6 +35,7 @@ class ExitCode(IntEnum):
     RATE_LIMIT = 8
     UNAVAILABLE = 9
     VERSION = 10
+    PARTIAL = 11
 
 
 class ErrorCategory(StrEnum):
@@ -81,6 +82,7 @@ class CliError(click.exceptions.Exit):
     request_id: str | None = None
     http_status: int | None = None
     detail: str | None = None
+    result: object | None = None
 
     def __post_init__(self) -> None:
         super().__init__(int(_EXIT_CODES[self.category]))
@@ -100,6 +102,7 @@ def fail(
     request_id: str | None = None,
     http_status: int | None = None,
     detail: str | None = None,
+    result: object | None = None,
 ) -> NoReturn:
     error = CliError(
         category=category,
@@ -110,6 +113,7 @@ def fail(
         request_id=request_id,
         http_status=http_status,
         detail=detail,
+        result=result,
     )
     if not _boundary_active.get():
         frame = inspect.currentframe()
@@ -136,11 +140,17 @@ def json_errors_requested(args: tuple[str, ...] | list[str] | None = None) -> bo
     return False
 
 
-def load_json_object(path: str, *, operation: str, noun: str) -> dict:
-    """Load a CLI-supplied JSON object with categorized failures."""
+def machine_output_requested(args: tuple[str, ...] | list[str] | None = None) -> bool:
+    """Return whether an invocation selected finite JSON or raw JSON output."""
+    values = tuple(args) if args is not None else _invocation_args.get()
+    return json_errors_requested(values) or "--raw" in values
+
+
+def load_json_value(path: str, *, operation: str, noun: str) -> object:
+    """Load any CLI-supplied JSON value with categorized failures."""
     try:
         with open(path) as file:
-            payload = json.load(file)
+            return json.load(file)
     except json.JSONDecodeError as error:
         fail(
             ErrorCategory.VALIDATION,
@@ -159,6 +169,11 @@ def load_json_object(path: str, *, operation: str, noun: str) -> dict:
             remediation="Provide an existing JSON file and retry.",
             detail=repr(error),
         )
+
+
+def load_json_object(path: str, *, operation: str, noun: str) -> dict:
+    """Load a CLI-supplied JSON object with categorized failures."""
+    payload = load_json_value(path, operation=operation, noun=noun)
     if not isinstance(payload, dict):
         fail(
             ErrorCategory.VALIDATION,
@@ -207,9 +222,11 @@ def emit_error(error: CliError, *, json_mode: bool | None = None, debug: bool | 
             body["request_id"] = error.request_id
         if error.http_status is not None:
             body["http_status"] = error.http_status
+        if error.result is not None:
+            body["result"] = error.result
         if use_debug and error.detail:
             body["detail"] = error.detail
-        print(json.dumps(payload, ensure_ascii=False), file=sys.stderr)
+        print(json.dumps(payload, ensure_ascii=False, default=str), file=sys.stderr)
         return
 
     _console.print(f"[bold red]Error ({escape(error.category.value)}):[/bold red] {escape(error.message)}")
@@ -222,6 +239,33 @@ def emit_error(error: CliError, *, json_mode: bool | None = None, debug: bool | 
         _console.print(f"[dim]Request ID:[/dim] {escape(error.request_id)}")
     if use_debug and error.detail:
         _console.print(f"[dim]Detail:[/dim] {escape(error.detail)}")
+
+
+def emit_warning(
+    category: str,
+    message: str,
+    *,
+    operation: str,
+    remediation: str | None = None,
+    detail: str | None = None,
+) -> None:
+    """Emit a nonfatal startup warning without contaminating command stdout."""
+    if _json_error_mode.get():
+        body: dict[str, object] = {
+            "category": category,
+            "message": message,
+            "operation": operation,
+        }
+        if remediation:
+            body["remediation"] = remediation
+        if debug_requested() and detail:
+            body["detail"] = detail
+        print(json.dumps({"warning": body}, ensure_ascii=False), file=sys.stderr)
+        return
+
+    _console.print(f"[bold yellow]Warning ({escape(category)}):[/bold yellow] {escape(message)}")
+    if remediation:
+        _console.print(f"[dim]Remediation:[/dim] {escape(remediation)}")
 
 
 def _resolve_command(command: click.Command, args: tuple[str, ...]) -> tuple[click.Command, str]:
@@ -249,6 +293,24 @@ def _uses_json_output(command: click.Command, args: tuple[str, ...]) -> bool:
     return has_format_option and json_errors_requested(args)
 
 
+def _uses_machine_output(command: click.Command, args: tuple[str, ...]) -> bool:
+    resolved, _path = _resolve_command(command, args)
+    has_raw_option = any(param.name == "raw" for param in resolved.params)
+    return _uses_json_output(command, args) or (has_raw_option and "--raw" in args)
+
+
+class PartialResultExit(click.exceptions.Exit):
+    """A nonzero batch outcome whose structured result must remain on stdout."""
+
+    def __init__(self) -> None:
+        super().__init__(int(ExitCode.PARTIAL))
+
+
+def exit_partial() -> NoReturn:
+    """Exit with the stable partial-result code after rendering the batch result."""
+    raise PartialResultExit()
+
+
 class _BoundaryError(Exception):
     def __init__(self, error: CliError) -> None:
         self.error = error
@@ -256,6 +318,11 @@ class _BoundaryError(Exception):
 
 class _BoundaryExitError(Exception):
     def __init__(self, error: click.exceptions.Exit) -> None:
+        self.error = error
+
+
+class _BoundaryPartialExitError(Exception):
+    def __init__(self, error: PartialResultExit) -> None:
         self.error = error
 
 
@@ -267,6 +334,8 @@ class ErrorHandlingGroup(TyperGroup):
             return super().invoke(ctx)
         except CliError as error:
             raise _BoundaryError(error) from error
+        except PartialResultExit as error:
+            raise _BoundaryPartialExitError(error) from error
         except click.UsageError:
             raise
         except click.exceptions.Exit as error:
@@ -278,7 +347,7 @@ class ErrorHandlingGroup(TyperGroup):
         invocation = tuple(args if args is not None else sys.argv[1:])
         token = _invocation_args.set(invocation)
         boundary_token = _boundary_active.set(True)
-        json_token = _json_error_mode.set(_uses_json_output(self, invocation))
+        json_token = _json_error_mode.set(_uses_machine_output(self, invocation))
         operation = f"Run {_command_path(self, invocation)}"
         captured = StringIO() if _json_error_mode.get() and not _json_stream_requested(self, invocation) else None
         output_context = redirect_stdout(captured) if captured is not None else nullcontext()
@@ -297,6 +366,10 @@ class ErrorHandlingGroup(TyperGroup):
         except _BoundaryError as wrapped:
             emit_error(wrapped.error)
             code = wrapped.error.contract_exit_code
+        except _BoundaryPartialExitError as wrapped:
+            if captured is not None:
+                sys.stdout.write(captured.getvalue())
+            code = int(wrapped.error.exit_code)
         except _BoundaryExitError as wrapped:
             code = int(wrapped.error.exit_code)
             emit_error(

--- a/observal_cli/main.py
+++ b/observal_cli/main.py
@@ -30,7 +30,7 @@ from observal_cli.errors import ErrorHandlingGroup
 
 
 def _check_package_conflict() -> None:
-    """Warn if the legacy 'observal' package is installed alongside 'observal-cli'."""
+    """Reject the legacy 'observal' package through the shared error contract."""
     from importlib.metadata import PackageNotFoundError, metadata
 
     try:
@@ -38,25 +38,19 @@ def _check_package_conflict() -> None:
     except PackageNotFoundError:
         return
 
-    # If we get here, a package literally named "observal" exists.
-    # Check it's not just our own package under a different dist name.
-    pkg_name = meta.get("Name", "")
-    if pkg_name.lower() == "observal-cli":
+    if meta.get("Name", "").lower() == "observal-cli":
         return
 
-    from rich import print as rprint
+    from observal_cli.errors import ErrorCategory, fail
 
-    rprint(
-        "[bold yellow]⚠ Package conflict detected:[/bold yellow] "
-        "Both [bold]observal[/bold] and [bold]observal-cli[/bold] are installed.\n"
-        "  The legacy [dim]observal[/dim] package is no longer maintained and conflicts with the CLI.\n"
-        "  Please uninstall it:\n\n"
-        "    [cyan]uv pip uninstall observal[/cyan]    [dim]# or: pip uninstall observal[/dim]\n"
+    fail(
+        ErrorCategory.CONFLICT,
+        "The legacy observal package conflicts with observal-cli.",
+        operation="Start Observal CLI",
+        resource="installed Python packages",
+        remediation="Run `uv pip uninstall observal` or `pip uninstall observal`, then retry.",
     )
-    sys.exit(1)
 
-
-_check_package_conflict()
 
 # ── Version callback for --version flag ───────────────────
 
@@ -100,6 +94,7 @@ def main(
     from observal_cli.optic import setup_optic
 
     setup_optic(debug=debug, verbose=verbose)
+    _check_package_conflict()
 
     if debug:
         logging.basicConfig(level=logging.DEBUG, format="%(levelname)s %(name)s: %(message)s")
@@ -117,17 +112,27 @@ def _migrate_legacy_mcp_configs() -> None:
     from rich import print as rprint
 
     from observal_cli.config import migrate_shimmed_mcp_configs
+    from observal_cli.errors import ErrorCategory, fail, machine_output_requested
 
     try:
         migrated = migrate_shimmed_mcp_configs()
-    except RuntimeError as exc:
-        rprint(f"[red]MCP config migration failed:[/red] {exc}")
-        raise typer.Exit(1) from exc
+    except RuntimeError as error:
+        fail(
+            ErrorCategory.UNAVAILABLE,
+            "Legacy MCP configuration migration failed.",
+            operation="Migrate legacy MCP configuration",
+            resource="local harness configuration",
+            remediation="Run with --debug, repair the reported configuration, and retry.",
+            detail=repr(error),
+        )
 
-    if migrated:
-        rprint(f"[green]Migrated {len(migrated)} legacy MCP config file(s) to direct commands.[/green]")
+    if migrated and not machine_output_requested():
+        rprint(
+            f"[green]Migrated {len(migrated)} legacy MCP config file(s) to direct commands.[/green]",
+            file=sys.stderr,
+        )
         for path in migrated:
-            rprint(f"  [dim]{path}[/dim]")
+            rprint(f"  [dim]{path}[/dim]", file=sys.stderr)
 
 
 def _sync_bundled_skills() -> None:
@@ -160,8 +165,19 @@ def _try_lockfile_migration() -> None:
             return
         if not LOCKFILE_PATH.exists():
             migrate_agent_markers()
-    except Exception:
-        pass  # Never crash the CLI for migration
+    except Exception as error:
+        from loguru import logger as optic
+
+        from observal_cli.errors import emit_warning
+
+        optic.warning("legacy agent-marker migration failed: error_type={}", type(error).__name__)
+        emit_warning(
+            "local_state_migration",
+            "Legacy installation state could not be migrated.",
+            operation="Migrate legacy installation state",
+            remediation="Run `observal doctor` before relying on installed-state data.",
+            detail=repr(error),
+        )
 
 
 # ── Register command groups ──────────────────────────────
@@ -298,6 +314,10 @@ def _show_update_banner() -> None:
 
     if not (_sys.stdout.isatty() and _sys.stderr.isatty()):
         return
+    from observal_cli.errors import machine_output_requested
+
+    if machine_output_requested(_sys.argv[1:]):
+        return
     if len(_sys.argv) > 1 and _sys.argv[1] in ("self", "server"):
         return
     if os.environ.get("CI") or os.environ.get("OBSERVAL_NO_UPDATE_CHECK"):
@@ -317,15 +337,19 @@ def _show_update_banner() -> None:
         if update.direction == "downgrade":
             _rprint(
                 f"\n[yellow]CLI v{update.current} is ahead of server v{update.latest}.[/yellow]\n"
-                f"  Downgrade to match: [bold cyan]{downgrade_command(update.latest)}[/bold cyan]"
+                f"  Downgrade to match: [bold cyan]{downgrade_command(update.latest)}[/bold cyan]",
+                file=_sys.stderr,
             )
         else:
             _rprint(
                 f"\n[green]Update available: v{update.current} \u2192 v{update.latest}[/green]\n"
-                f"  Run: [bold cyan]{upgrade_command(update.latest)}[/bold cyan]"
+                f"  Run: [bold cyan]{upgrade_command(update.latest)}[/bold cyan]",
+                file=_sys.stderr,
             )
-    except Exception:
-        pass  # Never crash the CLI for a version check
+    except Exception as error:
+        from loguru import logger as optic
+
+        optic.debug("CLI update check failed: error_type={}", type(error).__name__)
 
 
 # Register update banner as atexit handler so it runs via any entry point

--- a/observal_cli/skills/observal-advanced/SKILL.md
+++ b/observal_cli/skills/observal-advanced/SKILL.md
@@ -29,7 +29,7 @@ Read [Recovery workflows](references/recovery-workflows.md) completely before ex
 - Healthy telemetry does not need routine reconciliation.
 - Reconcile repairs missed local session delivery. It does not replace hook or extension installation.
 - Upgrade, downgrade, and rollback are distinct requests. Do not substitute one for another.
-- Local fallback is allowed only after the CLI explicitly reports `Connection failed` or `Not configured`, and only when the user still wants local files written.
+- Local fallback is allowed only after JSON reports `error.category: unavailable` with exit code `9`, or `error.category: authentication` with operation `Load authenticated CLI configuration` and exit code `3`. The user must still request local files.
 - Local fallback creates harness-native Agent files. It does not publish Registry state and must be reported as local-only.
 - Never invent telemetry environment variables or wrappers.
 

--- a/observal_cli/skills/observal-advanced/references/recovery-workflows.md
+++ b/observal_cli/skills/observal-advanced/references/recovery-workflows.md
@@ -50,7 +50,7 @@ Standalone binary changes require a published checksum because JSON mode does no
 
 ## Explicit local fallback
 
-Use only after the requested CLI operation returns `Connection failed` or `Not configured`, and only after the user confirms they want a local-only Agent file.
+Use only after JSON returns either `error.category: unavailable` with exit code `9`, or `error.category: authentication` with operation `Load authenticated CLI configuration` and exit code `3`. The user confirms they still want a local-only Agent file before anything is written.
 
 | Harness | User scope | Project scope |
 | --- | --- | --- |

--- a/observal_cli/skills/observal-agents/references/agent-workflows.md
+++ b/observal_cli/skills/observal-agents/references/agent-workflows.md
@@ -44,7 +44,7 @@ observal agent pull NAMESPACE/AGENT_SLUG --harness kiro --no-prompt --dir . --ou
 observal agent pull NAMESPACE/AGENT_SLUG --harness claude-code --scope project --dry-run --no-prompt --output json
 ```
 
-JSON pull requires `--no-prompt` and is appropriate only when no secret values are required. The `--env` and `--header` options expose values in shell history and process arguments, so use them only for non-secret configuration.
+JSON pull requires `--no-prompt` and is appropriate only when no secret values are required. If required values are missing, it exits nonzero with `error.result.needs_input: true` before installing anything. The `--env` and `--header` options expose values in shell history and process arguments, so use them only for non-secret configuration.
 
 For credentials or tokens, omit `--no-prompt` and JSON output, then enter values through the interactive prompts. This keeps values out of process arguments. Treat generated harness configuration as sensitive because the harness may store those values.
 
@@ -138,7 +138,7 @@ observal agent bulk-create --from-file agents.json --dry-run --output json
 observal agent bulk-create --from-file agents.json --yes --output json
 ```
 
-Verify each returned item. Do not treat a partial batch as complete.
+A file contains 1-50 agents and duplicate canonical names are rejected before the request. Verify each returned item. `errors > 0` sets `partial: true` and exits with code `11`; skips alone remain successful.
 
 ## Lifecycle and collaboration
 
@@ -157,5 +157,5 @@ Use user UUIDs returned by co-author list for removal. Verify ownership and life
 
 - 409 ambiguous name: re-list and use `qualified_name` or UUID.
 - 409 existing Agent: choose update only for in-place change, release for a new version.
-- Validation names a required YAML field: correct the source file, rebuild, and retry once.
+- Validation names a required YAML field: inspect `error.result.components` and `error.result.issues`, correct the source file, rebuild, and retry once.
 - Unavailable or not configured: stop. Load `observal-advanced` only for an explicit fallback request.

--- a/observal_cli/skills/observal-registry/references/component-submission.md
+++ b/observal_cli/skills/observal-registry/references/component-submission.md
@@ -33,7 +33,7 @@ observal registry bulk submit --from-file components.json --dry-run --output jso
 observal registry bulk submit --from-file components.json --yes --output json
 ```
 
-Each entry contains `type` plus the normal API submission fields. Supported types are `mcp`, `skill`, `hook`, `prompt`, and `sandbox`. Inspect `submitted`, `skipped`, `errors`, and every result. Authentication and service failures stop the batch. After an uncertain failure, verify by UUID or `qualified_name` before rerunning.
+Each entry contains `type` plus the normal API submission fields. Supported types are `mcp`, `skill`, `hook`, `prompt`, and `sandbox`. Inspect `submitted`, `skipped`, `errors`, `partial`, and every result. Actual item errors set `partial: true` and exit with code `11`; conflicts counted as skips remain successful. Authentication and service failures stop the batch. After an uncertain failure, verify by UUID or `qualified_name` before rerunning.
 
 ## MCP server
 

--- a/observal_cli/skills/observal-registry/references/discovery-and-installation.md
+++ b/observal_cli/skills/observal-registry/references/discovery-and-installation.md
@@ -79,7 +79,7 @@ Use raw output only when the user explicitly asks for a config snippet or raw re
 observal registry mcp install NAMESPACE/SLUG --harness claude-code --raw
 ```
 
-Never combine raw and JSON modes. Never print supplied environment or header values.
+Never combine raw and JSON modes. JSON MCP installation requires `--no-prompt`; missing required values return a nonzero `error.result.needs_input` response before install generation. Raw mode is the only template workflow that may intentionally contain placeholders. Never print supplied environment or header values.
 
 ## Verification
 

--- a/observal_cli/skills/observal/references/core-workflows.md
+++ b/observal_cli/skills/observal/references/core-workflows.md
@@ -108,11 +108,11 @@ Use only when no dedicated command exists. It preserves raw endpoint JSON and us
 
 ```bash
 observal api GET /api/v1/teams --output json
-observal api GET /api/v1/agents --param limit=10 --output json
+observal api GET /api/v1/agents --param limit=10 --param tag=review --param tag=security --output json
 observal api POST /api/v1/teams --from-file team.json --output json
 ```
 
-Mutation bodies come from one JSON object in a file or standard input. Full URLs and arbitrary authorization headers are rejected. Prefer dedicated commands for validation and confirmations.
+Mutation bodies accept any valid JSON value from a file or standard input, including arrays, scalars, and `null`. Repeated `--param` keys are preserved in order. Full URLs and arbitrary authorization headers are rejected. Prefer dedicated commands for validation and confirmations.
 
 ## Error handling
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -122,6 +122,7 @@ class TestBulkCreate:
         assert data["created"] == 3
         assert data["skipped"] == 0
         assert data["errors"] == 0
+        assert data["partial"] is False
         assert data["dry_run"] is False
         assert len(data["results"]) == 3
         db.commit.assert_awaited_once()
@@ -166,10 +167,13 @@ class TestBulkCreate:
         data = r.json()
         assert data["created"] == 2
         assert data["errors"] == 1
+        assert data["partial"] is True
 
         by_name = {item["name"]: item for item in data["results"]}
         assert by_name["agent-one"]["status"] == "created"
         assert by_name["agent-two"]["status"] == "error"
+        assert by_name["agent-two"]["error"] == "Agent could not be created"
+        assert "simulated database failure" not in str(data)
         # The item after the failure still ran, which is the part a poisoned
         # transaction would have taken away.
         assert by_name["agent-three"]["status"] == "created"
@@ -227,6 +231,34 @@ class TestBulkDryRun:
         db.commit.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_dry_run_reports_invalid_components_as_partial(self):
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/bulk/agents",
+                json={
+                    "agents": [
+                        _agent_item(
+                            "invalid-agent",
+                            components=[{"component_type": "skill"}],
+                        )
+                    ],
+                    "dry_run": True,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["created"] == 0
+        assert data["errors"] == 1
+        assert data["partial"] is True
+        assert data["results"][0]["status"] == "error"
+        assert data["results"][0]["error"] == "Agent definition is invalid"
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_dry_run_no_agent_ids(self):
         """Dry-run results should not include agent_id values."""
         app, db, _ = _app_with()
@@ -281,6 +313,29 @@ class TestBulkDedup:
         assert data["skipped"] == 1
         assert data["results"][0]["status"] == "skipped"
         assert data["results"][1]["status"] == "created"
+
+    @pytest.mark.asyncio
+    async def test_same_request_duplicates_are_skipped_in_dry_run(self):
+        app, db, _ = _app_with()
+        db.execute = AsyncMock(return_value=_empty_result())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            response = await ac.post(
+                "/api/v1/bulk/agents",
+                json={
+                    "agents": [_agent_item("Review Agent"), _agent_item("review-agent")],
+                    "dry_run": True,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["created"] == 1
+        assert data["skipped"] == 1
+        assert data["errors"] == 0
+        assert data["partial"] is False
+        assert data["results"][1]["status"] == "skipped"
+        assert "batch" in data["results"][1]["error"]
 
     @pytest.mark.asyncio
     async def test_skipped_result_includes_error_message(self):

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -10,6 +10,7 @@ import importlib.metadata
 import json
 import os
 import sys
+from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
@@ -22,7 +23,15 @@ from typer.testing import CliRunner
 
 from observal_cli import client
 from observal_cli.error_context import OPERATION_LABELS, RESOURCE_LABELS
-from observal_cli.errors import CliError, ErrorCategory, ErrorHandlingGroup, ExitCode, _uses_json_output, emit_error
+from observal_cli.errors import (
+    CliError,
+    ErrorCategory,
+    ErrorHandlingGroup,
+    ExitCode,
+    _uses_json_output,
+    _uses_machine_output,
+    emit_error,
+)
 from observal_cli.main import app
 
 _MISSING = object()
@@ -421,6 +430,44 @@ def test_error_renderer_exposes_detail_only_in_debug(capsys):
     assert payload["error"]["detail"] == "internal detail"
 
 
+def test_error_renderer_always_exposes_safe_structured_result(capsys):
+    error = CliError(
+        ErrorCategory.VALIDATION,
+        "Input is incomplete.",
+        operation="Install item",
+        detail="secret internal detail",
+        result={"needs_input": True, "inputs": [{"kind": "header", "name": "Authorization"}]},
+    )
+
+    emit_error(error, json_mode=True, debug=False)
+
+    payload = json.loads(capsys.readouterr().err)["error"]
+    assert payload["result"]["needs_input"] is True
+    assert "secret internal detail" not in json.dumps(payload)
+
+
+def test_every_leaf_command_exposes_json_machine_output():
+    from typer.main import get_command
+
+    root = get_command(app)
+    leaves = []
+
+    def walk(command):
+        if isinstance(command, Group):
+            for child in command.commands.values():
+                walk(child)
+        else:
+            leaves.append(command)
+
+    walk(root)
+    assert len(leaves) == 192
+    for command in leaves:
+        output = next((parameter for parameter in command.params if parameter.name == "output"), None)
+        assert output is not None, command.name
+        choices = {getattr(choice, "value", choice) for choice in getattr(output.type, "choices", ())}
+        assert "json" in choices, command.name
+
+
 def test_json_error_mode_distinguishes_format_from_file_destination():
     from typer.main import get_command
 
@@ -429,6 +476,14 @@ def test_json_error_mode_distinguishes_format_from_file_destination():
     assert _uses_json_output(root, ("agent", "show", "reviewer", "-ojson")) is True
     assert _uses_json_output(root, ("doctor", "support", "bundle", "--output", "json")) is True
     assert _uses_json_output(root, ("doctor", "support", "bundle", "--file", "json")) is False
+
+
+def test_machine_output_mode_includes_raw_json_commands_only():
+    from typer.main import get_command
+
+    root = get_command(app)
+    assert _uses_machine_output(root, ("registry", "mcp", "install", "item", "--harness", "pi", "--raw"))
+    assert not _uses_machine_output(root, ("registry", "mcp", "show", "--raw"))
 
 
 def test_json_error_mode_supports_typer_choice_without_click_inheritance():
@@ -454,6 +509,117 @@ def test_root_boundary_emits_json_usage_error_to_stderr():
     payload = json.loads(result.stderr)
     assert payload["error"]["category"] == "usage"
     assert payload["error"]["operation"] == "Run observal agent show"
+
+
+def test_package_conflict_uses_structured_json_error_boundary(monkeypatch):
+    import observal_cli.main as main
+
+    monkeypatch.setattr(importlib.metadata, "metadata", lambda _name: {"Name": "observal"})
+    monkeypatch.setattr(main, "_migrate_legacy_mcp_configs", lambda: None)
+    monkeypatch.setattr(main, "_try_lockfile_migration", lambda: None)
+
+    result = CliRunner().invoke(app, ["config", "path", "--output", "json"])
+
+    assert result.exit_code == ExitCode.CONFLICT
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    assert error["category"] == "conflict"
+    assert error["operation"] == "Start Observal CLI"
+
+
+def test_startup_migration_notice_never_contaminates_json_stdout(monkeypatch):
+    import observal_cli.main as main
+
+    monkeypatch.setattr(client.config, "migrate_shimmed_mcp_configs", lambda: [Path("/tmp/legacy.json")])
+    monkeypatch.setattr(main, "_try_lockfile_migration", lambda: None)
+
+    result = CliRunner().invoke(app, ["config", "path", "--output", "json"])
+
+    assert result.exit_code == 0, result.stderr
+    assert json.loads(result.stdout)["path"]
+    assert "Migrated" not in result.stdout
+    assert result.stderr == ""
+
+
+def test_startup_migration_failure_is_a_structured_json_error(monkeypatch):
+    import observal_cli.main as main
+
+    def fail_migration():
+        raise RuntimeError("private migration detail")
+
+    monkeypatch.setattr(client.config, "migrate_shimmed_mcp_configs", fail_migration)
+    monkeypatch.setattr(main, "_try_lockfile_migration", lambda: None)
+
+    result = CliRunner().invoke(app, ["config", "path", "--output", "json"])
+
+    assert result.exit_code == ExitCode.UNAVAILABLE
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    assert error["operation"] == "Migrate legacy MCP configuration"
+    assert "private migration detail" not in result.stderr
+
+
+def test_lockfile_migration_failure_emits_structured_warning_without_corrupting_stdout(tmp_path, monkeypatch):
+    import observal_cli.lockfile as lockfile
+    import observal_cli.main as main
+
+    config_dir = tmp_path / ".observal"
+    config_dir.mkdir()
+    monkeypatch.setattr(main, "_migrate_legacy_mcp_configs", lambda: None)
+    monkeypatch.setattr(main, "_sync_bundled_skills", lambda: None)
+    monkeypatch.setattr(lockfile, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(lockfile, "LOCKFILE_PATH", config_dir / "lockfile.json")
+    monkeypatch.setattr(lockfile, "migrate_agent_markers", MagicMock(side_effect=OSError("private path")))
+
+    result = CliRunner().invoke(app, ["config", "path", "--output", "json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["path"]
+    warning = json.loads(result.stderr)["warning"]
+    assert warning["category"] == "local_state_migration"
+    assert "private path" not in result.stderr
+
+
+def test_raw_json_validation_uses_machine_error_contract(monkeypatch):
+    import observal_cli.main as main
+
+    monkeypatch.setattr(main, "_migrate_legacy_mcp_configs", lambda: None)
+    monkeypatch.setattr(main, "_try_lockfile_migration", lambda: None)
+
+    result = CliRunner().invoke(
+        app,
+        ["registry", "mcp", "install", "alice/search", "--harness", "unknown", "--raw"],
+    )
+
+    assert result.exit_code == ExitCode.VALIDATION
+    assert result.stdout == ""
+    assert json.loads(result.stderr)["error"]["category"] == "validation"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["observal", "agent", "list", "--output", "json"],
+        ["observal", "registry", "mcp", "install", "item", "--harness", "pi", "--raw"],
+    ],
+)
+def test_update_banner_is_suppressed_for_tty_machine_output(monkeypatch, argv):
+    import observal_cli.main as main
+
+    class TTY(StringIO):
+        def isatty(self):
+            return True
+
+    stdout = TTY()
+    stderr = TTY()
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    main._show_update_banner()
+
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == ""
 
 
 def test_missing_authentication_uses_stable_json_contract(monkeypatch):

--- a/tests/test_cmd_agent_coverage.py
+++ b/tests/test_cmd_agent_coverage.py
@@ -349,11 +349,85 @@ def test_bulk_create_rejects_missing_file(tmp_path):
     assert "JSON file not found" in result.output
 
 
+def test_bulk_create_rejects_server_limit_and_canonical_duplicates_before_http(tmp_path, monkeypatch):
+    post = Mock()
+    monkeypatch.setattr(agent.client, "post", post)
+
+    too_many = tmp_path / "too-many.json"
+    too_many.write_text(json.dumps([{"name": f"agent-{index}"} for index in range(51)]), encoding="utf-8")
+    oversized = _invoke("bulk-create", "--from-file", str(too_many), "--dry-run")
+
+    duplicates = tmp_path / "duplicates.json"
+    duplicates.write_text(json.dumps([{"name": "Review Agent"}, {"name": "review-agent"}]), encoding="utf-8")
+    repeated = _invoke("bulk-create", "--from-file", str(duplicates), "--dry-run")
+
+    assert oversized.exit_code == 7
+    assert "at most 50" in oversized.output
+    assert repeated.exit_code == 7
+    assert "resolve to the same name" in repeated.output
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "agent_payload",
+    [
+        {"name": "___"},
+        {"name": "install"},
+        {"name": "valid", "components": "not-a-list"},
+        {"name": "valid", "components": ["not-an-object"]},
+        {"name": "valid", "components": [{"component_type": "skill"}]},
+        {"name": "valid", "version": 1},
+        {"name": "valid", "model_config_json": []},
+        {"name": "valid", "supported_harnesses": {}},
+        {"name": "valid", "supported_harnesses": [1]},
+        {"name": "valid", "external_mcps": {}},
+        {"name": "valid", "external_mcps": [1]},
+    ],
+)
+def test_bulk_create_rejects_invalid_agent_shapes_before_http(tmp_path, monkeypatch, agent_payload):
+    source = tmp_path / "invalid-agent.json"
+    source.write_text(json.dumps([agent_payload]), encoding="utf-8")
+    post = Mock()
+    monkeypatch.setattr(agent.client, "post", post)
+
+    result = _invoke("bulk-create", "--from-file", str(source), "--dry-run")
+
+    assert result.exit_code == 7
+    post.assert_not_called()
+
+
+def test_bulk_create_does_not_collapse_distinct_valid_hyphenated_names(tmp_path, monkeypatch):
+    agents = [{"name": "agent--one"}, {"name": "agent-one"}]
+    source = tmp_path / "distinct.json"
+    source.write_text(json.dumps(agents), encoding="utf-8")
+    post = Mock(return_value={"created": 2, "skipped": 0, "errors": 0, "results": []})
+    monkeypatch.setattr(agent.client, "post", post)
+
+    result = _invoke("bulk-create", "--from-file", str(source), "--dry-run", "--output", "json")
+
+    assert result.exit_code == 0
+    post.assert_called_once()
+
+
+def test_bulk_create_accepts_exactly_fifty_unique_agents(tmp_path, monkeypatch):
+    agents = [{"name": f"agent-{index}"} for index in range(50)]
+    source = tmp_path / "agents.json"
+    source.write_text(json.dumps(agents), encoding="utf-8")
+    post = Mock(return_value={"created": 50, "skipped": 0, "errors": 0, "results": []})
+    monkeypatch.setattr(agent.client, "post", post)
+
+    result = _invoke("bulk-create", "--from-file", str(source), "--dry-run", "--output", "json")
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["partial"] is False
+    post.assert_called_once_with("/api/v1/bulk/agents", {"agents": agents, "dry_run": True})
+
+
 def test_bulk_create_dry_run_renders_each_status_and_exact_payload(tmp_path, monkeypatch):
     agents = [
         {"name": "one", "version": "1.0.0", "model_name": "gpt-4o", "components": []},
         {"name": "two"},
-        {"name": "three", "components": [{"component_type": "skill"}]},
+        {"name": "three", "components": [{"component_type": "skill", "component_id": "bad-id"}]},
     ]
     source = tmp_path / "agents.json"
     source.write_text(json.dumps({"agents": agents}), encoding="utf-8")
@@ -372,7 +446,7 @@ def test_bulk_create_dry_run_renders_each_status_and_exact_payload(tmp_path, mon
 
     result = _invoke("bulk-create", "--from-file", str(source), "--dry-run")
 
-    assert result.exit_code == 0, result.output
+    assert result.exit_code == 11, result.output
     assert "Dry-run results" in result.output
     assert "created" in result.output
     assert "skipped" in result.output
@@ -407,10 +481,46 @@ def test_bulk_create_cancellation_and_creation_results(tmp_path, monkeypatch):
     }
     created = _invoke("bulk-create", "--from-file", str(source), "--yes")
 
-    assert created.exit_code == 0, created.output
+    assert created.exit_code == 11, created.output
     assert "Bulk create complete" in created.output
     assert "12345678" in created.output
     post.assert_called_once_with("/api/v1/bulk/agents", {"agents": agents, "dry_run": False})
+
+
+def test_bulk_create_partial_json_result_survives_nonzero_root_exit(tmp_path, monkeypatch):
+    import observal_cli.main as main
+
+    source = tmp_path / "agents.json"
+    source.write_text(json.dumps([{"name": "one"}, {"name": "two"}]), encoding="utf-8")
+    monkeypatch.setattr(main, "_migrate_legacy_mcp_configs", lambda: None)
+    monkeypatch.setattr(main, "_try_lockfile_migration", lambda: None)
+    monkeypatch.setattr(
+        agent.client,
+        "post",
+        Mock(
+            return_value={
+                "created": 1,
+                "skipped": 0,
+                "errors": 1,
+                "results": [
+                    {"name": "one", "status": "created", "agent_id": "agent-1"},
+                    {"name": "two", "status": "error", "error": "invalid"},
+                ],
+            }
+        ),
+    )
+
+    result = runner.invoke(
+        cli_app,
+        ["agent", "bulk-create", "--from-file", str(source), "--yes", "--output", "json"],
+    )
+
+    assert result.exit_code == 11
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["partial"] is True
+    assert payload["errors"] == 1
+    assert len(payload["results"]) == 2
 
 
 def test_agent_list_table_filters_ids_and_pagination(monkeypatch, _isolated_boundaries):
@@ -1282,6 +1392,35 @@ def test_local_init_add_and_build_json_contracts(tmp_path, monkeypatch):
     assert json.loads(initialized.output)["agent"]["name"] == "reviewer"
     assert json.loads(added.output)["component"]["component_id"] == "22222222-2222-2222-2222-222222222222"
     assert json.loads(built.output)["valid"] is True
+
+
+def test_build_json_error_contains_structured_repair_result(tmp_path, monkeypatch):
+    import observal_cli.main as main
+    from observal_cli.errors import CliError, ErrorCategory
+
+    _write_agent_yaml(
+        tmp_path,
+        components=[{"component_type": "skill", "component_id": "missing-skill"}],
+    )
+    monkeypatch.setattr(main, "_migrate_legacy_mcp_configs", lambda: None)
+    monkeypatch.setattr(main, "_try_lockfile_migration", lambda: None)
+    monkeypatch.setattr(
+        agent.client,
+        "get",
+        Mock(side_effect=CliError(ErrorCategory.NOT_FOUND, "Missing.", operation="Validate agent")),
+    )
+    monkeypatch.setattr(agent.client, "post", Mock(return_value={"valid": True, "issues": []}))
+    monkeypatch.setattr(agent.client, "add_publish_target", Mock(side_effect=_publish_target))
+
+    result = runner.invoke(cli_app, ["agent", "build", "--dir", str(tmp_path), "--output", "json"])
+
+    assert result.exit_code == 7
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    assert error["result"]["valid"] is False
+    assert error["result"]["components"] == [
+        {"type": "skill", "id": "missing-skill", "valid": False, "error": "not found"}
+    ]
 
 
 def test_publish_and_release_json_return_server_results(tmp_path, monkeypatch):

--- a/tests/test_cmd_api.py
+++ b/tests/test_cmd_api.py
@@ -42,11 +42,23 @@ def test_get_preserves_raw_api_array_json(api_call):
     api_call.assert_called_once_with(
         "GET",
         "/api/v1/teams",
-        params={"limit": "10"},
+        params=[("limit", "10")],
         json_data=None,
         operation="Call Observal API",
         resource="Observal API endpoint",
     )
+
+
+def test_repeated_query_parameters_preserve_order_and_values(api_call):
+    _allow(api_call, {"ok": True})
+
+    result = runner.invoke(
+        api_app,
+        ["GET", "/api/v1/items", "--param", "tag=a", "--param", "tag=b", "--output", "json"],
+    )
+
+    assert result.exit_code == 0
+    assert api_call.call_args.kwargs["params"] == [("tag", "a"), ("tag", "b")]
 
 
 def test_post_reads_json_file_and_returns_direct_object(tmp_path, api_call):
@@ -66,6 +78,43 @@ def test_post_reads_json_file_and_returns_direct_object(tmp_path, api_call):
         "/api/v1/teams",
         params=None,
         json_data={"name": "Platform"},
+        operation="Call Observal API",
+        resource="Observal API endpoint",
+    )
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ('[{"name":"one"}]', [{"name": "one"}]),
+        ('"plain"', "plain"),
+        ("42", 42),
+        ("true", True),
+    ],
+)
+def test_post_accepts_any_non_null_json_file_value(tmp_path, api_call, content, expected):
+    body = tmp_path / "body.json"
+    body.write_text(content, encoding="utf-8")
+    _allow(api_call, {"ok": True})
+
+    result = runner.invoke(api_app, ["POST", "/api/v1/items", "--from-file", str(body), "--output", "json"])
+
+    assert result.exit_code == 0
+    assert api_call.call_args.kwargs["json_data"] == expected
+
+
+def test_post_can_send_explicit_json_null(api_call):
+    _allow(api_call, {"ok": True})
+
+    result = runner.invoke(api_app, ["POST", "/api/v1/items", "--output", "json"], input="null")
+
+    assert result.exit_code == 0
+    api_call.assert_called_once_with(
+        "POST",
+        "/api/v1/items",
+        params=None,
+        json_data=None,
+        send_json=True,
         operation="Call Observal API",
         resource="Observal API endpoint",
     )
@@ -111,6 +160,8 @@ def test_default_output_renders_generic_table(api_call, monkeypatch: pytest.Monk
         ["TRACE", "/api/v1/teams"],
         ["GET", "https://evil.example/api/v1/teams"],
         ["GET", "/api/v1/../health"],
+        ["GET", "/api/v1/%252e%252e/health"],
+        ["GET", "/api/v1/teams%253Fadmin=true"],
         ["GET", "/api/v1/teams", "--param", "broken"],
     ],
 )
@@ -140,6 +191,13 @@ def test_get_rejects_request_body(tmp_path, api_call):
     body.write_text("{}", encoding="utf-8")
 
     result = runner.invoke(api_app, ["GET", "/api/v1/teams", "--from-file", str(body)])
+
+    assert result.exit_code == 7
+    api_call.assert_not_called()
+
+
+def test_get_rejects_explicit_null_body(api_call):
+    result = runner.invoke(api_app, ["GET", "/api/v1/teams"], input="null")
 
     assert result.exit_code == 7
     api_call.assert_not_called()

--- a/tests/test_cmd_api.py
+++ b/tests/test_cmd_api.py
@@ -103,6 +103,30 @@ def test_post_accepts_any_non_null_json_file_value(tmp_path, api_call, content, 
     assert api_call.call_args.kwargs["json_data"] == expected
 
 
+def test_client_retry_layer_preserves_explicit_json_null(monkeypatch):
+    response = Mock(status_code=200, headers={})
+    post = Mock(return_value=response)
+    monkeypatch.setattr(api.client.httpx, "post", post)
+    monkeypatch.setattr(api.client.config, "get_timeout", lambda: 17)
+
+    assert (
+        api.client._request_with_retry(
+            "post",
+            "https://registry.example.test/api/v1/items",
+            {},
+            json=None,
+            send_json=True,
+        )
+        is response
+    )
+    post.assert_called_once_with(
+        "https://registry.example.test/api/v1/items",
+        headers={"Content-Type": "application/json"},
+        timeout=17,
+        content=b"null",
+    )
+
+
 def test_post_can_send_explicit_json_null(api_call):
     _allow(api_call, {"ok": True})
 

--- a/tests/test_cmd_bulk.py
+++ b/tests/test_cmd_bulk.py
@@ -55,6 +55,7 @@ def test_dry_run_emits_parseable_json_without_http(tmp_path, boundaries):
         "submitted": 0,
         "skipped": 0,
         "errors": 0,
+        "partial": False,
         "dry_run": True,
         "results": [
             {"type": "skill", "name": "review", "status": "planned"},
@@ -101,11 +102,12 @@ def test_execute_submits_mixed_entries_and_reports_conflicts(tmp_path, boundarie
 
     assert result.exit_code == 0, result.output
     payload = json.loads(result.stdout)
-    assert {key: payload[key] for key in ("total", "submitted", "skipped", "errors", "dry_run")} == {
+    assert {key: payload[key] for key in ("total", "submitted", "skipped", "errors", "partial", "dry_run")} == {
         "total": 3,
         "submitted": 2,
         "skipped": 1,
         "errors": 0,
+        "partial": False,
         "dry_run": False,
     }
     assert payload["results"][1]["error"] == {
@@ -153,6 +155,38 @@ def test_execute_submits_mixed_entries_and_reports_conflicts(tmp_path, boundarie
             resource="sandbox submission",
         ),
     ]
+
+
+def test_partial_json_batch_preserves_result_and_exits_nonzero(tmp_path, boundaries, monkeypatch):
+    import observal_cli.main as main
+
+    post, _get, _load = boundaries
+    path = _write_components(
+        tmp_path,
+        [
+            {"type": "skill", "name": "review", "description": "Review"},
+            {"type": "hook", "name": "guard", "description": "Guard"},
+        ],
+    )
+    post.side_effect = [
+        {"id": "skill-1", "qualified_name": "alice/review", "status": "pending"},
+        CliError(ErrorCategory.VALIDATION, "Invalid hook.", operation="Bulk submit components"),
+    ]
+    monkeypatch.setattr(main, "_migrate_legacy_mcp_configs", lambda: None)
+    monkeypatch.setattr(main, "_try_lockfile_migration", lambda: None)
+
+    result = runner.invoke(
+        main.app,
+        ["registry", "bulk", "submit", "--from-file", str(path), "--yes", "--output", "json"],
+    )
+
+    assert result.exit_code == 11
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["partial"] is True
+    assert payload["submitted"] == 1
+    assert payload["errors"] == 1
+    assert [item["status"] for item in payload["results"]] == ["submitted", "error"]
 
 
 def test_default_output_renders_preview_and_results(tmp_path, boundaries, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cmd_mcp_coverage.py
+++ b/tests/test_cmd_mcp_coverage.py
@@ -1128,11 +1128,23 @@ def test_submit_json_is_clean_and_returns_server_result(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "requirements",
-    ["not-a-list", ["not-an-object"], [{}], [{"name": ""}]],
+    ("field", "kind", "requirements"),
+    [
+        ("environment_variables", "environment_variable", {}),
+        ("environment_variables", "environment_variable", ""),
+        ("environment_variables", "environment_variable", False),
+        ("environment_variables", "environment_variable", 0),
+        ("environment_variables", "environment_variable", ["not-an-object"]),
+        ("environment_variables", "environment_variable", [{}]),
+        ("environment_variables", "environment_variable", [{"name": ""}]),
+        ("headers", "header", {}),
+        ("headers", "header", ""),
+        ("headers", "header", False),
+        ("headers", "header", 0),
+    ],
 )
-def test_install_json_rejects_malformed_server_requirements(monkeypatch, requirements):
-    listing = _registry_item(environment_variables=requirements)
+def test_install_json_rejects_malformed_server_requirements(monkeypatch, field, kind, requirements):
+    listing = _registry_item(**{field: requirements})
     monkeypatch.setattr(mcp.client, "resolve_registry_reference", Mock(return_value="resolved"))
     monkeypatch.setattr(mcp.client, "get", Mock(return_value=listing))
     post = Mock()
@@ -1155,7 +1167,7 @@ def test_install_json_rejects_malformed_server_requirements(monkeypatch, require
 
     assert result.exit_code == 9
     assert result.stdout == ""
-    assert json.loads(result.stderr)["error"]["result"]["invalid_input_kind"] == "environment_variable"
+    assert json.loads(result.stderr)["error"]["result"]["invalid_input_kind"] == kind
     post.assert_not_called()
 
 
@@ -1234,6 +1246,33 @@ def test_install_json_accepts_all_required_values_without_echoing_them(monkeypat
     assert "fake-secret-value" not in result.stdout
     assert post.call_args.args[1]["env_values"] == {"API_KEY": "fake-secret-value"}
     assert post.call_args.args[1]["header_values"] == {"Authorization": "Bearer fake-secret-value"}
+
+
+def test_install_json_treats_null_requirement_fields_as_empty(monkeypatch):
+    listing = _registry_item(environment_variables=None, headers=None)
+    response = {"config_snippet": {"mcpServers": {"search": {}}}}
+    monkeypatch.setattr(mcp.client, "resolve_registry_reference", Mock(return_value="resolved"))
+    monkeypatch.setattr(mcp.client, "get", Mock(return_value=listing))
+    monkeypatch.setattr(mcp.client, "post", Mock(return_value=response))
+    monkeypatch.setattr(lockfile, "local_registry_name", Mock(return_value="search"))
+
+    result = runner.invoke(
+        app,
+        [
+            "registry",
+            "mcp",
+            "install",
+            "alice/search",
+            "--harness",
+            "cursor",
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == response
 
 
 def test_install_json_allows_missing_optional_values(monkeypatch):

--- a/tests/test_cmd_mcp_coverage.py
+++ b/tests/test_cmd_mcp_coverage.py
@@ -1127,6 +1127,145 @@ def test_submit_json_is_clean_and_returns_server_result(monkeypatch):
     assert json.loads(result.stdout) == {"id": "mcp-1", "name": "search", "status": "pending"}
 
 
+@pytest.mark.parametrize(
+    "requirements",
+    ["not-a-list", ["not-an-object"], [{}], [{"name": ""}]],
+)
+def test_install_json_rejects_malformed_server_requirements(monkeypatch, requirements):
+    listing = _registry_item(environment_variables=requirements)
+    monkeypatch.setattr(mcp.client, "resolve_registry_reference", Mock(return_value="resolved"))
+    monkeypatch.setattr(mcp.client, "get", Mock(return_value=listing))
+    post = Mock()
+    monkeypatch.setattr(mcp.client, "post", post)
+
+    result = runner.invoke(
+        app,
+        [
+            "registry",
+            "mcp",
+            "install",
+            "alice/search",
+            "--harness",
+            "cursor",
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    assert json.loads(result.stderr)["error"]["result"]["invalid_input_kind"] == "environment_variable"
+    post.assert_not_called()
+
+
+def test_install_json_missing_required_values_returns_needs_input_without_mutation(monkeypatch):
+    listing = _registry_item(
+        environment_variables=[{"name": "API_KEY", "required": True}],
+        headers=[{"name": "Authorization", "required": True}],
+    )
+    monkeypatch.setattr(mcp.client, "resolve_registry_reference", Mock(return_value="resolved"))
+    monkeypatch.setattr(mcp.client, "get", Mock(return_value=listing))
+    post = Mock()
+    monkeypatch.setattr(mcp.client, "post", post)
+
+    result = runner.invoke(
+        app,
+        [
+            "registry",
+            "mcp",
+            "install",
+            "alice/search",
+            "--harness",
+            "cursor",
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 7
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    assert error["result"] == {
+        "needs_input": True,
+        "inputs": [
+            {"kind": "environment_variable", "name": "API_KEY"},
+            {"kind": "header", "name": "Authorization"},
+        ],
+    }
+    assert "fake-secret-value" not in result.stderr
+    post.assert_not_called()
+
+
+def test_install_json_accepts_all_required_values_without_echoing_them(monkeypatch):
+    listing = _registry_item(
+        environment_variables=[{"name": "API_KEY", "required": True}],
+        headers=[{"name": "Authorization", "required": True}],
+    )
+    response = {"config_snippet": {"mcpServers": {"search": {"command": "npx"}}}}
+    monkeypatch.setattr(mcp.client, "resolve_registry_reference", Mock(return_value="resolved"))
+    monkeypatch.setattr(mcp.client, "get", Mock(return_value=listing))
+    post = Mock(return_value=response)
+    monkeypatch.setattr(mcp.client, "post", post)
+    monkeypatch.setattr(lockfile, "local_registry_name", Mock(return_value="search"))
+
+    result = runner.invoke(
+        app,
+        [
+            "registry",
+            "mcp",
+            "install",
+            "alice/search",
+            "--harness",
+            "cursor",
+            "--env",
+            "API_KEY=fake-secret-value",
+            "--header",
+            "Authorization=Bearer fake-secret-value",
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == response
+    assert "fake-secret-value" not in result.stdout
+    assert post.call_args.args[1]["env_values"] == {"API_KEY": "fake-secret-value"}
+    assert post.call_args.args[1]["header_values"] == {"Authorization": "Bearer fake-secret-value"}
+
+
+def test_install_json_allows_missing_optional_values(monkeypatch):
+    listing = _registry_item(
+        environment_variables=[{"name": "OPTIONAL", "required": False}],
+        headers=[{"name": "X-Optional", "required": False}],
+    )
+    response = {"config_snippet": {"mcpServers": {"search": {}}}}
+    monkeypatch.setattr(mcp.client, "resolve_registry_reference", Mock(return_value="resolved"))
+    monkeypatch.setattr(mcp.client, "get", Mock(return_value=listing))
+    monkeypatch.setattr(mcp.client, "post", Mock(return_value=response))
+    monkeypatch.setattr(lockfile, "local_registry_name", Mock(return_value="search"))
+
+    result = runner.invoke(
+        app,
+        [
+            "registry",
+            "mcp",
+            "install",
+            "alice/search",
+            "--harness",
+            "cursor",
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == response
+
+
 def test_install_json_returns_operation_result_without_lockfile_write(monkeypatch):
     listing = _registry_item()
     response = {"config_snippet": {"mcpServers": {"search": {"command": "npx"}}}, "warnings": []}
@@ -1139,7 +1278,17 @@ def test_install_json_returns_operation_result_without_lockfile_write(monkeypatc
 
     result = runner.invoke(
         app,
-        ["registry", "mcp", "install", "alice/search", "--harness", "cursor", "--output", "json"],
+        [
+            "registry",
+            "mcp",
+            "install",
+            "alice/search",
+            "--harness",
+            "cursor",
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
     )
 
     assert result.exit_code == 0, result.stderr
@@ -1170,6 +1319,7 @@ def test_edit_json_is_noninteractive_and_returns_server_result(monkeypatch):
         ["install", "alice/search", "--harness", "unknown"],
         ["install", "alice/search", "--harness", "cursor", "--env", "MISSING_SEPARATOR"],
         ["install", "alice/search", "--harness", "cursor", "--raw", "--output", "json"],
+        ["install", "alice/search", "--harness", "cursor", "--output", "json"],
     ],
 )
 def test_mcp_validation_uses_stable_exit_code(arguments, monkeypatch):

--- a/tests/test_cmd_pull_coverage.py
+++ b/tests/test_cmd_pull_coverage.py
@@ -22,6 +22,7 @@ import yaml
 from typer.testing import CliRunner
 
 import observal_cli.cmd_pull as cmd_pull
+from observal_cli.errors import ErrorHandlingGroup
 
 RUNNER = CliRunner()
 
@@ -942,9 +943,9 @@ def test_pull_full_project_flow_writes_every_shape_and_exact_side_effects(
         sensitivity="high",
     )
     assert run.call_args_list == [
-        call(["good", "mcp", "add", "new"], capture_output=True, text=True),
-        call(["missing", "mcp", "add", "manual"], capture_output=True, text=True),
-        call(["bad", "mcp", "add", "broken"], capture_output=True, text=True),
+        call(["good", "mcp", "add", "new"], capture_output=True, text=True, timeout=60),
+        call(["missing", "mcp", "add", "manual"], capture_output=True, text=True, timeout=60),
+        call(["bad", "mcp", "add", "broken"], capture_output=True, text=True, timeout=60),
     ]
     for visible in (
         "Pulled claude-code config (10 files)",
@@ -1053,6 +1054,105 @@ def test_pull_user_scope_expands_home_for_string_hook_and_agent_files(
     boundaries.upsert.assert_called_once()
 
 
+def test_pull_json_rejects_malformed_server_input_requirements(
+    boundaries: SimpleNamespace,
+    tmp_path: Path,
+) -> None:
+    root = typer.Typer(cls=ErrorHandlingGroup)
+    agent = typer.Typer()
+    cmd_pull.register_pull(agent)
+    root.add_typer(agent, name="agent")
+    detail = _agent_detail(mcp_links=[{"mcp_listing_id": "mcp-1", "mcp_name": "GitHub"}])
+
+    def get(path: str):
+        if path == "/api/v1/agents/agent-uuid":
+            return detail
+        if path == "/api/v1/mcps/mcp-1":
+            return {"environment_variables": [{"name": ""}], "headers": []}
+        raise AssertionError(path)
+
+    boundaries.get.side_effect = get
+    result = RUNNER.invoke(
+        root,
+        [
+            "agent",
+            "pull",
+            "acme/reviewer",
+            "--harness",
+            "claude-code",
+            "--dir",
+            str(tmp_path / "project"),
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    assert json.loads(result.stderr)["error"]["result"] == {
+        "invalid_input_kind": "environment_variable",
+        "component": "GitHub",
+    }
+    boundaries.post.assert_not_called()
+
+
+def test_pull_json_missing_required_inputs_returns_needs_input_before_install(
+    boundaries: SimpleNamespace,
+    tmp_path: Path,
+) -> None:
+    root = typer.Typer(cls=ErrorHandlingGroup)
+    agent = typer.Typer()
+    cmd_pull.register_pull(agent)
+    root.add_typer(agent, name="agent")
+    detail = _agent_detail(mcp_links=[{"mcp_listing_id": "mcp-1", "mcp_name": "GitHub"}])
+
+    def get(path: str):
+        if path == "/api/v1/agents/agent-uuid":
+            return detail
+        if path == "/api/v1/mcps/mcp-1":
+            return {
+                "environment_variables": [
+                    {"name": "API_KEY", "required": True},
+                    {"name": "REGION", "required": False},
+                ],
+                "headers": [{"name": "Authorization", "required": True}],
+            }
+        raise AssertionError(path)
+
+    boundaries.get.side_effect = get
+    target = tmp_path / "project"
+    result = RUNNER.invoke(
+        root,
+        [
+            "agent",
+            "pull",
+            "acme/reviewer",
+            "--harness",
+            "claude-code",
+            "--dir",
+            str(target),
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 7
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    assert error["result"] == {
+        "needs_input": True,
+        "inputs": [
+            {"kind": "environment_variable", "name": "API_KEY", "component": "GitHub"},
+            {"kind": "header", "name": "Authorization", "component": "GitHub"},
+        ],
+    }
+    boundaries.post.assert_not_called()
+    boundaries.local_name.assert_not_called()
+    assert not target.exists()
+
+
 def test_pull_partial_skill_failure_stops_metadata_updates_without_rolling_back_files(
     pull_app: typer.Typer,
     boundaries: SimpleNamespace,
@@ -1084,6 +1184,144 @@ def test_pull_partial_skill_failure_stops_metadata_updates_without_rolling_back_
     boundaries.emit.assert_not_called()
 
 
+def test_pull_json_dry_run_invalid_setup_has_no_partial_side_effects(
+    boundaries: SimpleNamespace,
+    tmp_path: Path,
+) -> None:
+    root = typer.Typer(cls=ErrorHandlingGroup)
+    agent = typer.Typer()
+    cmd_pull.register_pull(agent)
+    root.add_typer(agent, name="agent")
+    target = tmp_path / "project"
+    boundaries.post.return_value = {
+        "config_snippet": {
+            "agent_profile": {"path": "agent.md", "content": "agent\n"},
+            "mcp_setup_commands": [{}],
+        }
+    }
+
+    result = RUNNER.invoke(
+        root,
+        [
+            "agent",
+            "pull",
+            "acme/reviewer",
+            "--harness",
+            "claude-code",
+            "--dir",
+            str(target),
+            "--dry-run",
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    state = json.loads(result.stderr)["error"]["result"]
+    assert state["partial"] is False
+    assert state["dry_run"] is True
+    assert state["files"] == [{"path": str(target / "agent.md"), "status": "would write"}]
+    assert not target.exists()
+    boundaries.upsert.assert_not_called()
+
+
+def test_pull_json_skill_exception_reports_partial_state(
+    boundaries: SimpleNamespace,
+    tmp_path: Path,
+) -> None:
+    root = typer.Typer(cls=ErrorHandlingGroup)
+    agent = typer.Typer()
+    cmd_pull.register_pull(agent)
+    root.add_typer(agent, name="agent")
+    target = tmp_path / "project"
+    boundaries.direct_install.side_effect = OSError("private filesystem detail")
+    boundaries.post.return_value = {
+        "config_snippet": {
+            "agent_profile": {"path": "agent.md", "content": "agent\n"},
+            "skill_components": [{"name": "broken-skill", "skill_md_content": "content"}],
+        }
+    }
+
+    result = RUNNER.invoke(
+        root,
+        [
+            "agent",
+            "pull",
+            "acme/reviewer",
+            "--harness",
+            "claude-code",
+            "--dir",
+            str(target),
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    assert error["result"]["stage"] == "install_skills"
+    assert error["result"]["failed_skills"] == ["broken-skill"]
+    assert error["result"]["partial"] is True
+    assert "private filesystem detail" not in result.stderr
+    assert (target / "agent.md").is_file()
+    boundaries.upsert.assert_not_called()
+
+
+def test_pull_json_setup_failure_reports_secret_free_partial_state(
+    boundaries: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = typer.Typer(cls=ErrorHandlingGroup)
+    agent = typer.Typer()
+    cmd_pull.register_pull(agent)
+    root.add_typer(agent, name="agent")
+    target = tmp_path / "project"
+    boundaries.post.return_value = {
+        "config_snippet": {
+            "agent_profile": {"path": "agent.md", "content": "agent\n"},
+            "mcp_setup_commands": [["broken", "--token", "secret-value"]],
+        }
+    }
+    monkeypatch.setattr(
+        cmd_pull.subprocess,
+        "run",
+        MagicMock(return_value=subprocess.CompletedProcess(["broken"], 2, "", "private stderr")),
+    )
+
+    result = RUNNER.invoke(
+        root,
+        [
+            "agent",
+            "pull",
+            "acme/reviewer",
+            "--harness",
+            "claude-code",
+            "--dir",
+            str(target),
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    partial = error["result"]
+    assert partial["partial"] is True
+    assert partial["stage"] == "run_setup_commands"
+    assert partial["files"] == [{"path": str(target / "agent.md"), "status": "created"}]
+    assert partial["setup_commands"] == [{"executable": "broken", "status": "failed", "return_code": 2}]
+    assert "secret-value" not in result.stderr
+    assert "private stderr" not in result.stderr
+    boundaries.upsert.assert_not_called()
+
+
 def test_pull_lockfile_failure_is_not_reported_as_success(
     pull_app: typer.Typer,
     boundaries: SimpleNamespace,
@@ -1111,6 +1349,44 @@ def test_pull_lockfile_failure_is_not_reported_as_success(
     boundaries.snapshot.assert_not_called()
     boundaries.adapter.persist_active_agent.assert_not_called()
     boundaries.emit.assert_not_called()
+
+
+def test_pull_json_lockfile_failure_reports_tracking_state(
+    boundaries: SimpleNamespace,
+    tmp_path: Path,
+) -> None:
+    root = typer.Typer(cls=ErrorHandlingGroup)
+    agent = typer.Typer()
+    cmd_pull.register_pull(agent)
+    root.add_typer(agent, name="agent")
+    target = tmp_path / "project"
+    boundaries.upsert.side_effect = OSError("private lock detail")
+
+    result = RUNNER.invoke(
+        root,
+        [
+            "agent",
+            "pull",
+            "acme/reviewer",
+            "--harness",
+            "claude-code",
+            "--dir",
+            str(target),
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    partial = json.loads(result.stderr)["error"]["result"]
+    assert partial["stage"] == "update_lockfile"
+    assert partial["installation_tracked"] is False
+    assert partial["active_agent_persisted"] is False
+    assert partial["partial"] is True
+    assert "private lock detail" not in result.stderr
+    boundaries.adapter.persist_active_agent.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cmd_pull_coverage.py
+++ b/tests/test_cmd_pull_coverage.py
@@ -60,6 +60,15 @@ def pull_app() -> typer.Typer:
 
 
 @pytest.fixture
+def pull_app_boundary() -> typer.Typer:
+    root = typer.Typer(cls=ErrorHandlingGroup)
+    agent = typer.Typer()
+    cmd_pull.register_pull(agent)
+    root.add_typer(agent, name="agent")
+    return root
+
+
+@pytest.fixture
 def boundaries(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> SimpleNamespace:
     import observal_cli.audit as audit
     import observal_cli.cmd_skill as cmd_skill
@@ -1055,13 +1064,10 @@ def test_pull_user_scope_expands_home_for_string_hook_and_agent_files(
 
 
 def test_pull_json_rejects_malformed_server_input_requirements(
+    pull_app_boundary: typer.Typer,
     boundaries: SimpleNamespace,
     tmp_path: Path,
 ) -> None:
-    root = typer.Typer(cls=ErrorHandlingGroup)
-    agent = typer.Typer()
-    cmd_pull.register_pull(agent)
-    root.add_typer(agent, name="agent")
     detail = _agent_detail(mcp_links=[{"mcp_listing_id": "mcp-1", "mcp_name": "GitHub"}])
 
     def get(path: str):
@@ -1073,7 +1079,7 @@ def test_pull_json_rejects_malformed_server_input_requirements(
 
     boundaries.get.side_effect = get
     result = RUNNER.invoke(
-        root,
+        pull_app_boundary,
         [
             "agent",
             "pull",
@@ -1098,13 +1104,10 @@ def test_pull_json_rejects_malformed_server_input_requirements(
 
 
 def test_pull_json_missing_required_inputs_returns_needs_input_before_install(
+    pull_app_boundary: typer.Typer,
     boundaries: SimpleNamespace,
     tmp_path: Path,
 ) -> None:
-    root = typer.Typer(cls=ErrorHandlingGroup)
-    agent = typer.Typer()
-    cmd_pull.register_pull(agent)
-    root.add_typer(agent, name="agent")
     detail = _agent_detail(mcp_links=[{"mcp_listing_id": "mcp-1", "mcp_name": "GitHub"}])
 
     def get(path: str):
@@ -1123,7 +1126,7 @@ def test_pull_json_missing_required_inputs_returns_needs_input_before_install(
     boundaries.get.side_effect = get
     target = tmp_path / "project"
     result = RUNNER.invoke(
-        root,
+        pull_app_boundary,
         [
             "agent",
             "pull",
@@ -1185,13 +1188,10 @@ def test_pull_partial_skill_failure_stops_metadata_updates_without_rolling_back_
 
 
 def test_pull_json_dry_run_invalid_setup_has_no_partial_side_effects(
+    pull_app_boundary: typer.Typer,
     boundaries: SimpleNamespace,
     tmp_path: Path,
 ) -> None:
-    root = typer.Typer(cls=ErrorHandlingGroup)
-    agent = typer.Typer()
-    cmd_pull.register_pull(agent)
-    root.add_typer(agent, name="agent")
     target = tmp_path / "project"
     boundaries.post.return_value = {
         "config_snippet": {
@@ -1201,7 +1201,7 @@ def test_pull_json_dry_run_invalid_setup_has_no_partial_side_effects(
     }
 
     result = RUNNER.invoke(
-        root,
+        pull_app_boundary,
         [
             "agent",
             "pull",
@@ -1228,13 +1228,10 @@ def test_pull_json_dry_run_invalid_setup_has_no_partial_side_effects(
 
 
 def test_pull_json_skill_exception_reports_partial_state(
+    pull_app_boundary: typer.Typer,
     boundaries: SimpleNamespace,
     tmp_path: Path,
 ) -> None:
-    root = typer.Typer(cls=ErrorHandlingGroup)
-    agent = typer.Typer()
-    cmd_pull.register_pull(agent)
-    root.add_typer(agent, name="agent")
     target = tmp_path / "project"
     boundaries.direct_install.side_effect = OSError("private filesystem detail")
     boundaries.post.return_value = {
@@ -1245,7 +1242,7 @@ def test_pull_json_skill_exception_reports_partial_state(
     }
 
     result = RUNNER.invoke(
-        root,
+        pull_app_boundary,
         [
             "agent",
             "pull",
@@ -1272,14 +1269,11 @@ def test_pull_json_skill_exception_reports_partial_state(
 
 
 def test_pull_json_setup_failure_reports_secret_free_partial_state(
+    pull_app_boundary: typer.Typer,
     boundaries: SimpleNamespace,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    root = typer.Typer(cls=ErrorHandlingGroup)
-    agent = typer.Typer()
-    cmd_pull.register_pull(agent)
-    root.add_typer(agent, name="agent")
     target = tmp_path / "project"
     boundaries.post.return_value = {
         "config_snippet": {
@@ -1294,7 +1288,7 @@ def test_pull_json_setup_failure_reports_secret_free_partial_state(
     )
 
     result = RUNNER.invoke(
-        root,
+        pull_app_boundary,
         [
             "agent",
             "pull",
@@ -1352,18 +1346,15 @@ def test_pull_lockfile_failure_is_not_reported_as_success(
 
 
 def test_pull_json_lockfile_failure_reports_tracking_state(
+    pull_app_boundary: typer.Typer,
     boundaries: SimpleNamespace,
     tmp_path: Path,
 ) -> None:
-    root = typer.Typer(cls=ErrorHandlingGroup)
-    agent = typer.Typer()
-    cmd_pull.register_pull(agent)
-    root.add_typer(agent, name="agent")
     target = tmp_path / "project"
     boundaries.upsert.side_effect = OSError("private lock detail")
 
     result = RUNNER.invoke(
-        root,
+        pull_app_boundary,
         [
             "agent",
             "pull",
@@ -1621,6 +1612,45 @@ def test_pull_rejects_malformed_existing_config_without_overwrite(
     result = _invoke(pull_app, target)
 
     assert result.exit_code == 6
+    assert path.read_text() == "not-json"
+    boundaries.upsert.assert_not_called()
+
+
+def test_pull_json_write_failure_reports_failed_path(
+    pull_app_boundary: typer.Typer,
+    boundaries: SimpleNamespace,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "project"
+    path = target / "mcp.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("not-json")
+    boundaries.post.return_value = {
+        "config_snippet": {"mcp_config": {"path": "mcp.json", "content": {"mcpServers": {"new": {}}}}}
+    }
+
+    result = RUNNER.invoke(
+        pull_app_boundary,
+        [
+            "agent",
+            "pull",
+            "acme/reviewer",
+            "--harness",
+            "claude-code",
+            "--dir",
+            str(target),
+            "--no-prompt",
+            "--output",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 6
+    assert result.stdout == ""
+    state = json.loads(result.stderr)["error"]["result"]
+    assert state["stage"] == "write_files"
+    assert state["failed_path"] == str(path)
+    assert state["partial"] is False
     assert path.read_text() == "not-json"
     boundaries.upsert.assert_not_called()
 

--- a/tests/test_observal_skill.py
+++ b/tests/test_observal_skill.py
@@ -403,7 +403,8 @@ class TestAgentBehaviorContracts:
 
     def test_local_fallback_requires_an_explicit_failure(self):
         text = (SKILLS_DIR / "observal-advanced/references/recovery-workflows.md").read_text(encoding="utf-8")
-        assert "`Connection failed` or `Not configured`" in text
+        assert "`error.category: unavailable` with exit code `9`" in text
+        assert "`Load authenticated CLI configuration` and exit code `3`" in text
         assert "user confirms" in text
         assert '"tools":["read"]' in text
         assert 'tools` to `["*"]` only after separate confirmation' in text

--- a/tests/test_server_upgrade.py
+++ b/tests/test_server_upgrade.py
@@ -247,7 +247,12 @@ def test_lifecycle_rejects_incomplete_status_response(isolated, monkeypatch: pyt
 
     assert result.exit_code == 9
     assert result.stdout == ""
-    assert "incomplete" in json.loads(result.stderr)["error"]["message"]
+    error = json.loads(result.stderr)["error"]
+    assert "incomplete" in error["message"]
+    assert error["result"] == {
+        "expected": "stopped",
+        "services": [{"service": "api", "status": "running"}],
+    }
 
 
 def test_status_json_can_report_unhealthy(isolated, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_server_upgrade.py
+++ b/tests/test_server_upgrade.py
@@ -126,6 +126,12 @@ def test_start_json_is_finite_and_suppresses_nested_output(isolated, monkeypatch
     monkeypatch.setattr(isolated.updater, "check_for_update", MagicMock())
     service = MagicMock()
     service.is_running.return_value = False
+    service.status.return_value = {
+        "postgres": "running",
+        "clickhouse": "running",
+        "redis": "running",
+        "api": "running",
+    }
     service.start_all.side_effect = lambda **_kwargs: print("nested human progress")
     factory = MagicMock(return_value=service)
     monkeypatch.setattr(isolated.orchestrator, "Orchestrator", factory)
@@ -141,6 +147,12 @@ def test_start_json_is_finite_and_suppresses_nested_output(isolated, monkeypatch
         "port": 8000,
         "background": True,
         "used_fallback_port": False,
+        "services": [
+            {"service": "postgres", "status": "running"},
+            {"service": "clickhouse", "status": "running"},
+            {"service": "redis", "status": "running"},
+            {"service": "api", "status": "running"},
+        ],
     }
     assert "nested human progress" not in result.stdout
     service.start_all.assert_called_once_with(foreground=False)
@@ -171,6 +183,10 @@ def test_start_reports_explicit_port_conflict(monkeypatch: pytest.MonkeyPatch) -
 def test_restart_and_stop_json(isolated, monkeypatch: pytest.MonkeyPatch) -> None:
     service = MagicMock()
     service.is_running.return_value = True
+    service.status.side_effect = [
+        {"postgres": "running", "clickhouse": "running", "redis": "running", "api": "running"},
+        {"postgres": "stopped", "clickhouse": "stopped", "redis": "stopped", "api": "stopped"},
+    ]
     monkeypatch.setattr(isolated.orchestrator, "Orchestrator", MagicMock(return_value=service))
 
     restarted = runner.invoke(app, ["server", "restart", "--background", "--output", "json"])
@@ -180,6 +196,58 @@ def test_restart_and_stop_json(isolated, monkeypatch: pytest.MonkeyPatch) -> Non
     assert json.loads(stopped.stdout)["status"] == "stopped"
     service.stop_all.assert_called()
     service.start_all.assert_called_once_with(foreground=False)
+
+
+def test_lifecycle_commands_fail_when_final_state_is_not_verified(isolated, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = MagicMock()
+    service.is_running.return_value = False
+    service.status.return_value = {
+        "postgres": "running",
+        "clickhouse": "running",
+        "redis": "running",
+        "api": "stopped",
+    }
+    monkeypatch.setattr(socket, "socket", SocketFactory([True]))
+    monkeypatch.setattr(isolated.deps, "all_installed", MagicMock(return_value=True))
+    monkeypatch.setattr(isolated.updater, "check_for_update", MagicMock())
+    monkeypatch.setattr(isolated.orchestrator, "Orchestrator", MagicMock(return_value=service))
+
+    result = runner.invoke(app, ["server", "start", "--background", "--output", "json"])
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    error = json.loads(result.stderr)["error"]
+    assert error["result"]["expected"] == "running"
+    assert error["result"]["services"][-1] == {"service": "api", "status": "stopped"}
+
+
+def test_stop_fails_when_any_service_remains_running(isolated, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = MagicMock()
+    service.status.return_value = {
+        "postgres": "stopped",
+        "clickhouse": "stopped",
+        "redis": "running",
+        "api": "stopped",
+    }
+    monkeypatch.setattr(isolated.orchestrator, "Orchestrator", MagicMock(return_value=service))
+
+    result = runner.invoke(app, ["server", "stop", "--output", "json"])
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    assert json.loads(result.stderr)["error"]["result"]["expected"] == "stopped"
+
+
+def test_lifecycle_rejects_incomplete_status_response(isolated, monkeypatch: pytest.MonkeyPatch) -> None:
+    service = MagicMock()
+    service.status.return_value = {"api": "running"}
+    monkeypatch.setattr(isolated.orchestrator, "Orchestrator", MagicMock(return_value=service))
+
+    result = runner.invoke(app, ["server", "stop", "--output", "json"])
+
+    assert result.exit_code == 9
+    assert result.stdout == ""
+    assert "incomplete" in json.loads(result.stderr)["error"]["message"]
 
 
 def test_status_json_can_report_unhealthy(isolated, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/web/src/lib/types/registry.ts
+++ b/web/src/lib/types/registry.ts
@@ -215,6 +215,7 @@ export interface BulkResult {
 	created: number;
 	skipped: number;
 	errors: number;
+	partial: boolean;
 	dry_run: boolean;
 	results: BulkResultItem[];
 }


### PR DESCRIPTION
   <!-- SPDX-FileCopyrightText: 2026 Hari Srinivasan <harisrini21@gmail.com> -->
   <!-- SPDX-FileCopyrightText: 2026 Shaan Narendran <shaannaren06@gmail.com> -->
   <!-- SPDX-FileCopyrightText: 2026 Piyush <pranyasharma55555@gmail.com> -->
   <!-- SPDX-FileCopyrightText: 2026 Lokesh Selvam <lokeshselvam7025@gmail.com> -->
   <!-- SPDX-License-Identifier: Apache-2.0 -->

   ## Purpose / Description

   Harden the CLI for reliable agent-driven and machine-readable workflows.

   ## Fixes

   * Fixes JSON output contamination, partial batch exit handling, bulk validation gaps, hidden structured errors, incomplete API  request support, missing install input handling, and optimistic server lifecycle responses.


   ## Approach

   * Keep JSON and raw stdout machine-readable.
   * Add structured error results and partial batch exit code 11.
   * Validate bulk limits, fields, and duplicate names before mutation.
   * Support arbitrary JSON API bodies and repeated query parameters.
   * Detect missing required MCP and Agent installation inputs.
   * Report partial pull state without exposing secrets.
   * Verify embedded server state after lifecycle operations.
   * Update CLI documentation, skills, tests, and frontend API types.

   ## How Has This Been Tested?

   * `make lint`
   * Focused CLI and server tests: 464 passed
   * Main test suite: 8568 passed, 21 skipped
   * Excluded CLI suite: 102 passed
   * Frontend typecheck, lint, and production build
   * Pre-commit checks on all changed files
   * Local finite JSON and raw JSON error smoke tests
   * Verified JSON support for all 192 leaf commands

   The full parallel suite also exposed one local `.env` ordering issue and two Hypothesis deadline flakes. Each affected test
 passes independently.

   ## Learning (optional, can help others)

   The main issue was not missing JSON support, but inconsistent process-level behavior around startup output, partial success,
 validation, and post-mutation failures.

   ## Checklist

   - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
   - [x] You have commented your code, particularly in hard-to-understand areas
   - [x] You have performed a self-review of your own code
   - [x] UI changes: not applicable, no visual UI changes

   ## AI Assistance

   _Was generative AI tooling used to co-author this PR?_

   - [x] Yes (Pi coding agent)
   - [x] Was the generated code manually reviewed and tested?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk operations now report partial results and use exit code 11 for item-level errors.
  * JSON output preserves successful and failed item details while remaining machine-readable.
  * API requests support any JSON value, repeated query parameters, and stricter path validation.
  * Service lifecycle commands verify final states and report status details.
  * MCP installation and agent pull workflows provide structured missing-input and partial-state errors.

* **Bug Fixes**
  * Improved validation, duplicate detection, secret redaction, and failure reporting.

* **Documentation**
  * Updated CLI and workflow guidance for validation, JSON behavior, partial results, and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->